### PR TITLE
fix: include human-readable label alongside [NODE_ID] in action prompts (closes #38)

### DIFF
--- a/.claude/commands/wh/CLAUDE.md
+++ b/.claude/commands/wh/CLAUDE.md
@@ -73,3 +73,9 @@ Tool access is the primary enforcement mechanism:
 - Write mode validates citations before creating Document nodes
 - All modes can call `graph_context` for research context
 - Never use em dashes. Use colons, commas, periods, parentheses.
+
+### Action-prompt labeling rule (titles alongside [NODE_ID])
+
+When a command presents a graph node to the scientist for a decision (approve/edit/skip, close out, sign off, mark as), or in a status/summary/progress listing where the scientist scans many nodes at once, include a short label alongside each `[NODE_ID]`. The label is the first 80-120 chars of the node's `description`, `statement`, `question`, or `title` field, coalesced. Format: `[NODE_ID] "label"` or `[NODE_ID] label`.
+
+This avoids forcing a separate `show_node` lookup before the scientist can decide. Bare `[NODE_ID]` remains the right style for factual claims in synthesis prose (compile, write), where the citation is a reference inside flowing text and the label would clutter the sentence. Confirm-style messages right after creation ("Added: [F-xxxx] ...", "Noted: [N-xxxx] ...") already include the title and don't need restating.

--- a/.claude/commands/wh/close.md
+++ b/.claude/commands/wh/close.md
@@ -104,15 +104,17 @@ For each orphan or cluster of related orphans, propose an Execution node:
   - Dataset from ingestion → kind="ingest"
 - **Identify likely inputs** — papers referenced, datasets used, prior findings discussed. Use `show_node` to check existing relationships for clues.
 
-Present the batch to the scientist:
+Present the batch to the scientist.
+
+**Action-prompt labeling rule (applies to user-facing approval prompts, not in-prose citations).** When asking the scientist to approve, edit, or skip a graph node, include a short label (the first 80-120 chars of the node's `description`, `statement`, `question`, or `title` field, coalesced) alongside each `[NODE_ID]`. Bare `[NODE_ID]` remains the right style for factual claims in synthesis prose, but action prompts need labels so the scientist can decide without a separate `show_node` lookup.
 
 ```
 ## Proposed Provenance Links
 
 ### Group 1: Discussion about calcium dynamics
 - **Execution**: kind="discuss", description="Discussion of calcium oscillation patterns"
-- **Inputs (USED)**: [P-a4f2] Bhatt & Bhalla 2024, [D-5678] cell_042 recordings
-- **Outputs (WAS_GENERATED_BY)**: [F-3a2b] frequency scaling finding, [H-7c8d] channel gating hypothesis
+- **Inputs (USED)**: [P-a4f2] "Bhatt & Bhalla 2024: Fast and slow oscillations", [D-5678] "cell_042 recordings (patch clamp, pH 7.4)"
+- **Outputs (WAS_GENERATED_BY)**: [F-3a2b] "frequency scaling: 2-5 Hz baseline, 8-12 Hz with agonist", [H-7c8d] "calcium-activated K+ channels mediate frequency shift"
 
 ### Group 2: ...
 

--- a/.claude/commands/wh/dream.md
+++ b/.claude/commands/wh/dream.md
@@ -136,6 +136,8 @@ Look for consolidation opportunities:
 
 Act on what you found. For each action, log it for the report.
 
+**Action-prompt labeling rule.** OpenQuestions created here are shown to the scientist as user-facing prompts (they will be answered from the morning brief or `/wh:status`). Include a short quoted label (first 80-120 chars of the referenced node's `description`, `statement`, `question`, or `title`, coalesced) alongside each `[NODE_ID]` so the scientist can act without a separate lookup. Bare `[NODE_ID]` remains correct for factual claims in synthesis prose; the rule applies to OpenQuestion text and any other approval-style content.
+
 ### Tier Promotions
 For each generated finding with:
 - Full provenance chain (Finding → WAS_GENERATED_BY → Execution)
@@ -149,21 +151,21 @@ For each orphaned paper (no relationships):
 - Search finding descriptions for keywords from the paper title
 - Search execution descriptions for methodology matches
 - If a reasonable match exists, call `link_nodes(execution_id, paper_id, "USED")`
-- If uncertain, create an OpenQuestion: "Should [P-xxx] be linked to [X-yyy]?"
+- If uncertain, create an OpenQuestion: `Should [P-xxx] "<paper title>" be linked to [X-yyy] "<execution description>"?`
 
 ### Duplicate Flagging
 For each pair of findings with >70% word overlap:
-- Create an OpenQuestion: "Potential duplicate findings: [F-xxx] and [F-yyy]:should these be merged?"
+- Create an OpenQuestion: `Potential duplicate findings: [F-xxx] "<F-xxx description, ~100 chars>" and [F-yyy] "<F-yyy description, ~100 chars>": should these be merged?`
 - Set priority 5 (medium)
 
 ### Hypothesis Review
 For each open hypothesis with 3+ supporting findings:
-- Create an OpenQuestion: "[H-xxx] has N supporting findings and 0 contradictions:should this be marked as supported?"
+- Create an OpenQuestion: `[H-xxx] "<hypothesis statement, ~100 chars>" has N supporting findings and 0 contradictions: should this be marked as supported?`
 - Set priority 6
 
 ### Staleness Handling
 For each stale script from `detect_stale`:
-- Create an OpenQuestion: "[S-xxx] is stale (script modified since last execution):re-run needed?"
+- Create an OpenQuestion: `[S-xxx] "<script title or path>" is stale (script modified since last execution): re-run needed?`
 - Set priority 7
 
 ## Phase 3.5: Generate Synthesis Index Files

--- a/.claude/commands/wh/execute.md
+++ b/.claude/commands/wh/execute.md
@@ -169,7 +169,7 @@ After all WHEELER tasks complete, verify against the plan's success criteria:
 
 ## Execution Summary Template
 
-After execution, write `.plans/<name>-SUMMARY.md`:
+After execution, write `.plans/<name>-SUMMARY.md`. The summary is the scientist's scannable review of what changed, so follow the **action-prompt labeling rule** from `CLAUDE.md`: every `[NODE_ID]` in the lists below carries a short label (first 80-120 chars of `description`/`statement`/`question`/`title`) so the scientist can review without separate `show_node` lookups.
 
 ```markdown
 ---
@@ -184,22 +184,22 @@ checkpoints_hit: <N>
 # Execution Summary: <name>
 
 ## Tasks Completed
-<numbered list — task name, result, [NODE_ID] citations for any graph nodes created>
+<numbered list. Task name, result, [NODE_ID] "label" citations for any graph nodes created>
 
 ## Tasks Skipped (SCIENTIST/PAIR)
-<numbered list with assignee tags — these still need the scientist>
+<numbered list with assignee tags. These still need the scientist>
 
 ## Graph Nodes Created
-<list of [NODE_ID] with one-line descriptions>
+<list of [NODE_ID] "label" with one-line descriptions. Example: [F-3a2b] "frequency scaling: 2-5 Hz baseline, 8-12 Hz with agonist">
 
 ## Deviations from Plan
-<what changed from the plan and why, or "None — plan executed as written">
+<what changed from the plan and why, or "None: plan executed as written">
 
 ## Checkpoints Flagged
-<[Q-xxxx] nodes created at decision points, or "None">
+<[Q-xxxx] "question text" nodes created at decision points, or "None">
 
 ## Success Criteria Status
-<MET/PARTIAL/UNMET per criterion with [NODE_ID] evidence>
+<MET/PARTIAL/UNMET per criterion with [NODE_ID] "label" evidence>
 
 ## Next Steps
 <prioritized, tagged by assignee (SCIENTIST/WHEELER/PAIR)>
@@ -234,7 +234,7 @@ Evidence: <[NODE_ID] citations, or description of gap>
 <run validate_citations on all investigation files — report total, valid, invalid, stale>
 
 ## Open Questions Remaining
-<[Q-xxxx] nodes still open, with priority>
+<[Q-xxxx] "question text" nodes still open, with priority>
 
 ## Gaps Identified
 <missing coverage, stale analyses, unlinked findings>

--- a/.claude/commands/wh/graph-link.md
+++ b/.claude/commands/wh/graph-link.md
@@ -97,22 +97,26 @@ Outputs that defy clustering go into a final "Needs Review" group with no auto-E
 
 ## Phase 3: Propose
 
-Present the entire batch in one message. Use this exact format:
+Present the entire batch in one message.
+
+**Action-prompt labeling rule (applies to user-facing approval prompts, not in-prose citations).** Every `[NODE_ID]` listed in the batch must be followed by a short quoted label (the first 80-120 chars of the node's `description`, `statement`, `question`, or `title`, coalesced) so the scientist can decide per group without a separate `show_node` lookup. The `Needs Review` entries also need labels. Bare `[NODE_ID]` remains correct for factual claims in synthesis prose elsewhere; the rule here applies to this approval batch and the per-group reason text.
+
+Use this exact format:
 
 ```
 ## Proposed Provenance Groups
 
 ### Group 1: <inferred topic>
 - **Execution**: kind="<inferred>", description="<one line>"
-- **Inputs (USED)**: [P-...] <title>, [D-...] <title>  (or "none inferred")
-- **Outputs (WAS_GENERATED_BY)**: [F-...] <title>, [H-...] <title>, ...
+- **Inputs (USED)**: [P-a4f2] "Bhatt & Bhalla 2024: Fast and slow oscillations", [D-5678] "cell_042 recordings (patch clamp, pH 7.4)"  (or "none inferred")
+- **Outputs (WAS_GENERATED_BY)**: [F-3a2b] "frequency scaling: 2-5 Hz baseline, 8-12 Hz with agonist", [H-7c8d] "calcium-activated K+ channels mediate frequency shift", ...
 - **Confidence**: high / medium / low (with reason if low)
 
 ### Group 2: <inferred topic>
 ...
 
 ### Needs Review (no Execution proposed)
-- [N-...] <title> — reason: cannot infer kind from context
+- [N-91cd] "ad-hoc note on agonist concentration calibration" (reason: cannot infer kind from context)
 
 ---
 

--- a/.claude/commands/wh/graph-review.md
+++ b/.claude/commands/wh/graph-review.md
@@ -121,6 +121,8 @@ Apply the analogous check for Hypotheses referencing Findings.
 
 Group findings by category. For each category list the issues with **a concrete fix command**. Suppress empty categories.
 
+This is an action prompt: the scientist reads each row and decides which fix to run. Follow the **action-prompt labeling rule** from `CLAUDE.md`: every `[NODE_ID]` in the issue list carries a short label (first 80-120 chars of `description`/`statement`/`question`/`title`) alongside any `path` field, so the scientist can decide without a separate `show_node` lookup. For duplicate groups, include the label on each member.
+
 ```
 ## Graph Review: <date>
 Scope: <args summary>
@@ -133,25 +135,25 @@ Total issues found: <N> (across <K> categories)
 **Suggested fix**: `graph_consistency_check(repair=True)` (review the diff first)
 
 ### B. Wrong node types (<N> issues)
-- [W-abcd1234] /path/to/script.m -> should be Script
+- [W-abcd1234] "fit_model SRM analysis" (/path/to/script.m) -> should be Script
   **Suggested fix**: `delete_node("W-abcd1234")` then `add_script(path="/path/to/script.m", title="...")`. Re-link any existing edges manually.
 - ...
 
 ### C. Plans registered as Documents (<N> issues)
-- [W-...] /.plans/foo.md -> should be Plan
+- [W-...] "investigation plan title" (/.plans/foo.md) -> should be Plan
   **Suggested fix**: `delete_node(...)` then `add_plan(...)`. (Or, if links are not yet attached, just `update_node` if a re-label tool exists.)
 
 ### D. Broken file paths (<N> issues; showing first 20)
-- [F-...] /path/to/missing.csv MISSING
+- [F-...] "finding description" (/path/to/missing.csv) MISSING
   **Suggested fix**: investigate (file may have been moved); `update_node(id, path="/new/path")` or `delete_node(id)` if obsolete.
 - ...
 
 ### E. Duplicate nodes by path (<N> groups)
-- /shared/path: [F-aaa, F-bbb]
+- /shared/path: [F-aaa] "finding A description", [F-bbb] "finding B description"
   **Suggested fix**: `propose_merge("F-aaa", "F-bbb")` -> review -> `execute_merge(...)`.
 
 ### F. Missing semantic relationships (<N> heuristic hits)
-- [F-abcd] mentions H-efgh in description but no SUPPORTS/CONTRADICTS edge
+- [F-abcd] "finding description" mentions [H-efgh] "hypothesis statement" in description but no SUPPORTS/CONTRADICTS edge
   **Suggested fix**: confirm intent, then `link_nodes("F-abcd", "H-efgh", "SUPPORTS")` (or CONTRADICTS).
 
 ### G. Stale nodes (<N> by label)

--- a/.claude/commands/wh/reconvene.md
+++ b/.claude/commands/wh/reconvene.md
@@ -71,19 +71,21 @@ Use wheeler MCP tools to query for recently added/modified nodes:
 
 ### Step 3: Present the Synthesis
 
+This is the scientist's first read of what happened while they were away, so follow the **action-prompt labeling rule** from `CLAUDE.md`: every `[NODE_ID]` carries a short label (first 80-120 chars of `description`/`statement`/`question`/`title`). Bare IDs in this listing force a `show_node` lookup before the scientist can decide what to act on.
+
 ```
 ## COMPLETED
-- [F-xxxx] Finding description (confidence: 0.X) <- [A-xxxx] Analysis
-- [D-xxxx] Dataset registered, linked to [E-xxxx]
+- [F-xxxx] "finding description text" (confidence: 0.X) <- [A-xxxx] "analysis title"
+- [D-xxxx] "dataset description" registered, linked to [E-xxxx] "execution kind: description"
 - Literature search: N papers found, M linked to hypotheses
 
 ## FLAGGED (needs your judgment)
-- Checkpoint: [description] — Wheeler took conservative path [details]
-- [Q-xxxx] "Decision needed: [question]" (priority: N)
+- Checkpoint: [description]. Wheeler took conservative path [details]
+- [Q-xxxx] "Decision needed: <question>" (priority: N)
 
 ## SURPRISES
-- [F-xxxx] contradicts [F-yyyy] — possible [explanation]
-- Unexpected pattern in [D-xxxx]: [description]
+- [F-xxxx] "finding A description" contradicts [F-yyyy] "finding B description". Possible [explanation]
+- Unexpected pattern in [D-xxxx] "dataset description": [details]
 
 ## NEXT
 - Prioritized by what would close the most gaps
@@ -97,12 +99,12 @@ If an investigation plan exists with status `in-progress`:
    - **MET**: Finding/dataset/hypothesis exists that satisfies it — cite [NODE_ID]
    - **PARTIAL**: Some evidence but gaps remain
    - **UNMET**: No evidence found
-3. Include verification summary in the synthesis:
+3. Include verification summary in the synthesis (apply the same labeling rule: every cited node gets a short label):
    ```
    ## VERIFICATION (against plan: <name>)
-   - [MET] Criterion 1 — satisfied by [F-xxxx]
-   - [PARTIAL] Criterion 2 — data loaded but analysis not complete
-   - [UNMET] Criterion 3 — no findings yet
+   - [MET] Criterion 1: satisfied by [F-xxxx] "finding description"
+   - [PARTIAL] Criterion 2: data loaded but analysis not complete
+   - [UNMET] Criterion 3: no findings yet
    ```
 4. If all MET → update plan frontmatter `status` to `completed` and `updated` timestamp
 5. If gaps → include in NEXT section with specific tasks to close them

--- a/.claude/commands/wh/status.md
+++ b/.claude/commands/wh/status.md
@@ -70,18 +70,20 @@ Use wheeler MCP tools:
 
 ## Step 4: Present and Route
 
+This is a scannable status board, so follow the **action-prompt labeling rule** from `CLAUDE.md`: when listing findings, questions, plans, or any other graph nodes, include a short label (first 80-120 chars of `description`/`statement`/`question`/`title`) alongside each `[NODE_ID]`. Example: `[F-3a2b] "frequency scaling: 2-5 Hz baseline"`, not bare `[F-3a2b]`.
+
 ```
 ## Active Work
-<investigations in progress, paused work, pending contexts>
+<investigations in progress, paused work, pending contexts. Cite plans as [PL-xxxx] "plan title">
 
 ## Recent Results
-<team tasks or unreviewed logs, recent findings, flagged checkpoints>
+<team tasks or unreviewed logs, recent findings as [F-xxxx] "description", flagged checkpoints as [Q-xxxx] "question">
 
 ## Graph Summary
-<node counts, recent findings, open questions, gaps>
+<node counts, recent findings, open questions, gaps. Each listed node gets a label>
 
 ## Suggested Next Action
-/wh:<command> — <reasoning>
+/wh:<command>: <reasoning>
 ```
 
 ### Routing Logic

--- a/wheeler/_data/commands/CLAUDE.md
+++ b/wheeler/_data/commands/CLAUDE.md
@@ -73,3 +73,9 @@ Tool access is the primary enforcement mechanism:
 - Write mode validates citations before creating Document nodes
 - All modes can call `graph_context` for research context
 - Never use em dashes. Use colons, commas, periods, parentheses.
+
+### Action-prompt labeling rule (titles alongside [NODE_ID])
+
+When a command presents a graph node to the scientist for a decision (approve/edit/skip, close out, sign off, mark as), or in a status/summary/progress listing where the scientist scans many nodes at once, include a short label alongside each `[NODE_ID]`. The label is the first 80-120 chars of the node's `description`, `statement`, `question`, or `title` field, coalesced. Format: `[NODE_ID] "label"` or `[NODE_ID] label`.
+
+This avoids forcing a separate `show_node` lookup before the scientist can decide. Bare `[NODE_ID]` remains the right style for factual claims in synthesis prose (compile, write), where the citation is a reference inside flowing text and the label would clutter the sentence. Confirm-style messages right after creation ("Added: [F-xxxx] ...", "Noted: [N-xxxx] ...") already include the title and don't need restating.

--- a/wheeler/_data/commands/close.md
+++ b/wheeler/_data/commands/close.md
@@ -104,15 +104,17 @@ For each orphan or cluster of related orphans, propose an Execution node:
   - Dataset from ingestion → kind="ingest"
 - **Identify likely inputs** — papers referenced, datasets used, prior findings discussed. Use `show_node` to check existing relationships for clues.
 
-Present the batch to the scientist:
+Present the batch to the scientist.
+
+**Action-prompt labeling rule (applies to user-facing approval prompts, not in-prose citations).** When asking the scientist to approve, edit, or skip a graph node, include a short label (the first 80-120 chars of the node's `description`, `statement`, `question`, or `title` field, coalesced) alongside each `[NODE_ID]`. Bare `[NODE_ID]` remains the right style for factual claims in synthesis prose, but action prompts need labels so the scientist can decide without a separate `show_node` lookup.
 
 ```
 ## Proposed Provenance Links
 
 ### Group 1: Discussion about calcium dynamics
 - **Execution**: kind="discuss", description="Discussion of calcium oscillation patterns"
-- **Inputs (USED)**: [P-a4f2] Bhatt & Bhalla 2024, [D-5678] cell_042 recordings
-- **Outputs (WAS_GENERATED_BY)**: [F-3a2b] frequency scaling finding, [H-7c8d] channel gating hypothesis
+- **Inputs (USED)**: [P-a4f2] "Bhatt & Bhalla 2024: Fast and slow oscillations", [D-5678] "cell_042 recordings (patch clamp, pH 7.4)"
+- **Outputs (WAS_GENERATED_BY)**: [F-3a2b] "frequency scaling: 2-5 Hz baseline, 8-12 Hz with agonist", [H-7c8d] "calcium-activated K+ channels mediate frequency shift"
 
 ### Group 2: ...
 

--- a/wheeler/_data/commands/dream.md
+++ b/wheeler/_data/commands/dream.md
@@ -136,6 +136,8 @@ Look for consolidation opportunities:
 
 Act on what you found. For each action, log it for the report.
 
+**Action-prompt labeling rule.** OpenQuestions created here are shown to the scientist as user-facing prompts (they will be answered from the morning brief or `/wh:status`). Include a short quoted label (first 80-120 chars of the referenced node's `description`, `statement`, `question`, or `title`, coalesced) alongside each `[NODE_ID]` so the scientist can act without a separate lookup. Bare `[NODE_ID]` remains correct for factual claims in synthesis prose; the rule applies to OpenQuestion text and any other approval-style content.
+
 ### Tier Promotions
 For each generated finding with:
 - Full provenance chain (Finding → WAS_GENERATED_BY → Execution)
@@ -149,21 +151,21 @@ For each orphaned paper (no relationships):
 - Search finding descriptions for keywords from the paper title
 - Search execution descriptions for methodology matches
 - If a reasonable match exists, call `link_nodes(execution_id, paper_id, "USED")`
-- If uncertain, create an OpenQuestion: "Should [P-xxx] be linked to [X-yyy]?"
+- If uncertain, create an OpenQuestion: `Should [P-xxx] "<paper title>" be linked to [X-yyy] "<execution description>"?`
 
 ### Duplicate Flagging
 For each pair of findings with >70% word overlap:
-- Create an OpenQuestion: "Potential duplicate findings: [F-xxx] and [F-yyy]:should these be merged?"
+- Create an OpenQuestion: `Potential duplicate findings: [F-xxx] "<F-xxx description, ~100 chars>" and [F-yyy] "<F-yyy description, ~100 chars>": should these be merged?`
 - Set priority 5 (medium)
 
 ### Hypothesis Review
 For each open hypothesis with 3+ supporting findings:
-- Create an OpenQuestion: "[H-xxx] has N supporting findings and 0 contradictions:should this be marked as supported?"
+- Create an OpenQuestion: `[H-xxx] "<hypothesis statement, ~100 chars>" has N supporting findings and 0 contradictions: should this be marked as supported?`
 - Set priority 6
 
 ### Staleness Handling
 For each stale script from `detect_stale`:
-- Create an OpenQuestion: "[S-xxx] is stale (script modified since last execution):re-run needed?"
+- Create an OpenQuestion: `[S-xxx] "<script title or path>" is stale (script modified since last execution): re-run needed?`
 - Set priority 7
 
 ## Phase 3.5: Generate Synthesis Index Files

--- a/wheeler/_data/commands/execute.md
+++ b/wheeler/_data/commands/execute.md
@@ -169,7 +169,7 @@ After all WHEELER tasks complete, verify against the plan's success criteria:
 
 ## Execution Summary Template
 
-After execution, write `.plans/<name>-SUMMARY.md`:
+After execution, write `.plans/<name>-SUMMARY.md`. The summary is the scientist's scannable review of what changed, so follow the **action-prompt labeling rule** from `CLAUDE.md`: every `[NODE_ID]` in the lists below carries a short label (first 80-120 chars of `description`/`statement`/`question`/`title`) so the scientist can review without separate `show_node` lookups.
 
 ```markdown
 ---
@@ -184,22 +184,22 @@ checkpoints_hit: <N>
 # Execution Summary: <name>
 
 ## Tasks Completed
-<numbered list — task name, result, [NODE_ID] citations for any graph nodes created>
+<numbered list. Task name, result, [NODE_ID] "label" citations for any graph nodes created>
 
 ## Tasks Skipped (SCIENTIST/PAIR)
-<numbered list with assignee tags — these still need the scientist>
+<numbered list with assignee tags. These still need the scientist>
 
 ## Graph Nodes Created
-<list of [NODE_ID] with one-line descriptions>
+<list of [NODE_ID] "label" with one-line descriptions. Example: [F-3a2b] "frequency scaling: 2-5 Hz baseline, 8-12 Hz with agonist">
 
 ## Deviations from Plan
-<what changed from the plan and why, or "None — plan executed as written">
+<what changed from the plan and why, or "None: plan executed as written">
 
 ## Checkpoints Flagged
-<[Q-xxxx] nodes created at decision points, or "None">
+<[Q-xxxx] "question text" nodes created at decision points, or "None">
 
 ## Success Criteria Status
-<MET/PARTIAL/UNMET per criterion with [NODE_ID] evidence>
+<MET/PARTIAL/UNMET per criterion with [NODE_ID] "label" evidence>
 
 ## Next Steps
 <prioritized, tagged by assignee (SCIENTIST/WHEELER/PAIR)>
@@ -234,7 +234,7 @@ Evidence: <[NODE_ID] citations, or description of gap>
 <run validate_citations on all investigation files — report total, valid, invalid, stale>
 
 ## Open Questions Remaining
-<[Q-xxxx] nodes still open, with priority>
+<[Q-xxxx] "question text" nodes still open, with priority>
 
 ## Gaps Identified
 <missing coverage, stale analyses, unlinked findings>

--- a/wheeler/_data/commands/graph-link.md
+++ b/wheeler/_data/commands/graph-link.md
@@ -97,22 +97,26 @@ Outputs that defy clustering go into a final "Needs Review" group with no auto-E
 
 ## Phase 3: Propose
 
-Present the entire batch in one message. Use this exact format:
+Present the entire batch in one message.
+
+**Action-prompt labeling rule (applies to user-facing approval prompts, not in-prose citations).** Every `[NODE_ID]` listed in the batch must be followed by a short quoted label (the first 80-120 chars of the node's `description`, `statement`, `question`, or `title`, coalesced) so the scientist can decide per group without a separate `show_node` lookup. The `Needs Review` entries also need labels. Bare `[NODE_ID]` remains correct for factual claims in synthesis prose elsewhere; the rule here applies to this approval batch and the per-group reason text.
+
+Use this exact format:
 
 ```
 ## Proposed Provenance Groups
 
 ### Group 1: <inferred topic>
 - **Execution**: kind="<inferred>", description="<one line>"
-- **Inputs (USED)**: [P-...] <title>, [D-...] <title>  (or "none inferred")
-- **Outputs (WAS_GENERATED_BY)**: [F-...] <title>, [H-...] <title>, ...
+- **Inputs (USED)**: [P-a4f2] "Bhatt & Bhalla 2024: Fast and slow oscillations", [D-5678] "cell_042 recordings (patch clamp, pH 7.4)"  (or "none inferred")
+- **Outputs (WAS_GENERATED_BY)**: [F-3a2b] "frequency scaling: 2-5 Hz baseline, 8-12 Hz with agonist", [H-7c8d] "calcium-activated K+ channels mediate frequency shift", ...
 - **Confidence**: high / medium / low (with reason if low)
 
 ### Group 2: <inferred topic>
 ...
 
 ### Needs Review (no Execution proposed)
-- [N-...] <title> — reason: cannot infer kind from context
+- [N-91cd] "ad-hoc note on agonist concentration calibration" (reason: cannot infer kind from context)
 
 ---
 

--- a/wheeler/_data/commands/graph-review.md
+++ b/wheeler/_data/commands/graph-review.md
@@ -121,6 +121,8 @@ Apply the analogous check for Hypotheses referencing Findings.
 
 Group findings by category. For each category list the issues with **a concrete fix command**. Suppress empty categories.
 
+This is an action prompt: the scientist reads each row and decides which fix to run. Follow the **action-prompt labeling rule** from `CLAUDE.md`: every `[NODE_ID]` in the issue list carries a short label (first 80-120 chars of `description`/`statement`/`question`/`title`) alongside any `path` field, so the scientist can decide without a separate `show_node` lookup. For duplicate groups, include the label on each member.
+
 ```
 ## Graph Review: <date>
 Scope: <args summary>
@@ -133,25 +135,25 @@ Total issues found: <N> (across <K> categories)
 **Suggested fix**: `graph_consistency_check(repair=True)` (review the diff first)
 
 ### B. Wrong node types (<N> issues)
-- [W-abcd1234] /path/to/script.m -> should be Script
+- [W-abcd1234] "fit_model SRM analysis" (/path/to/script.m) -> should be Script
   **Suggested fix**: `delete_node("W-abcd1234")` then `add_script(path="/path/to/script.m", title="...")`. Re-link any existing edges manually.
 - ...
 
 ### C. Plans registered as Documents (<N> issues)
-- [W-...] /.plans/foo.md -> should be Plan
+- [W-...] "investigation plan title" (/.plans/foo.md) -> should be Plan
   **Suggested fix**: `delete_node(...)` then `add_plan(...)`. (Or, if links are not yet attached, just `update_node` if a re-label tool exists.)
 
 ### D. Broken file paths (<N> issues; showing first 20)
-- [F-...] /path/to/missing.csv MISSING
+- [F-...] "finding description" (/path/to/missing.csv) MISSING
   **Suggested fix**: investigate (file may have been moved); `update_node(id, path="/new/path")` or `delete_node(id)` if obsolete.
 - ...
 
 ### E. Duplicate nodes by path (<N> groups)
-- /shared/path: [F-aaa, F-bbb]
+- /shared/path: [F-aaa] "finding A description", [F-bbb] "finding B description"
   **Suggested fix**: `propose_merge("F-aaa", "F-bbb")` -> review -> `execute_merge(...)`.
 
 ### F. Missing semantic relationships (<N> heuristic hits)
-- [F-abcd] mentions H-efgh in description but no SUPPORTS/CONTRADICTS edge
+- [F-abcd] "finding description" mentions [H-efgh] "hypothesis statement" in description but no SUPPORTS/CONTRADICTS edge
   **Suggested fix**: confirm intent, then `link_nodes("F-abcd", "H-efgh", "SUPPORTS")` (or CONTRADICTS).
 
 ### G. Stale nodes (<N> by label)

--- a/wheeler/_data/commands/reconvene.md
+++ b/wheeler/_data/commands/reconvene.md
@@ -71,19 +71,21 @@ Use wheeler MCP tools to query for recently added/modified nodes:
 
 ### Step 3: Present the Synthesis
 
+This is the scientist's first read of what happened while they were away, so follow the **action-prompt labeling rule** from `CLAUDE.md`: every `[NODE_ID]` carries a short label (first 80-120 chars of `description`/`statement`/`question`/`title`). Bare IDs in this listing force a `show_node` lookup before the scientist can decide what to act on.
+
 ```
 ## COMPLETED
-- [F-xxxx] Finding description (confidence: 0.X) <- [A-xxxx] Analysis
-- [D-xxxx] Dataset registered, linked to [E-xxxx]
+- [F-xxxx] "finding description text" (confidence: 0.X) <- [A-xxxx] "analysis title"
+- [D-xxxx] "dataset description" registered, linked to [E-xxxx] "execution kind: description"
 - Literature search: N papers found, M linked to hypotheses
 
 ## FLAGGED (needs your judgment)
-- Checkpoint: [description] — Wheeler took conservative path [details]
-- [Q-xxxx] "Decision needed: [question]" (priority: N)
+- Checkpoint: [description]. Wheeler took conservative path [details]
+- [Q-xxxx] "Decision needed: <question>" (priority: N)
 
 ## SURPRISES
-- [F-xxxx] contradicts [F-yyyy] — possible [explanation]
-- Unexpected pattern in [D-xxxx]: [description]
+- [F-xxxx] "finding A description" contradicts [F-yyyy] "finding B description". Possible [explanation]
+- Unexpected pattern in [D-xxxx] "dataset description": [details]
 
 ## NEXT
 - Prioritized by what would close the most gaps
@@ -97,12 +99,12 @@ If an investigation plan exists with status `in-progress`:
    - **MET**: Finding/dataset/hypothesis exists that satisfies it — cite [NODE_ID]
    - **PARTIAL**: Some evidence but gaps remain
    - **UNMET**: No evidence found
-3. Include verification summary in the synthesis:
+3. Include verification summary in the synthesis (apply the same labeling rule: every cited node gets a short label):
    ```
    ## VERIFICATION (against plan: <name>)
-   - [MET] Criterion 1 — satisfied by [F-xxxx]
-   - [PARTIAL] Criterion 2 — data loaded but analysis not complete
-   - [UNMET] Criterion 3 — no findings yet
+   - [MET] Criterion 1: satisfied by [F-xxxx] "finding description"
+   - [PARTIAL] Criterion 2: data loaded but analysis not complete
+   - [UNMET] Criterion 3: no findings yet
    ```
 4. If all MET → update plan frontmatter `status` to `completed` and `updated` timestamp
 5. If gaps → include in NEXT section with specific tasks to close them

--- a/wheeler/_data/commands/status.md
+++ b/wheeler/_data/commands/status.md
@@ -70,18 +70,20 @@ Use wheeler MCP tools:
 
 ## Step 4: Present and Route
 
+This is a scannable status board, so follow the **action-prompt labeling rule** from `CLAUDE.md`: when listing findings, questions, plans, or any other graph nodes, include a short label (first 80-120 chars of `description`/`statement`/`question`/`title`) alongside each `[NODE_ID]`. Example: `[F-3a2b] "frequency scaling: 2-5 Hz baseline"`, not bare `[F-3a2b]`.
+
 ```
 ## Active Work
-<investigations in progress, paused work, pending contexts>
+<investigations in progress, paused work, pending contexts. Cite plans as [PL-xxxx] "plan title">
 
 ## Recent Results
-<team tasks or unreviewed logs, recent findings, flagged checkpoints>
+<team tasks or unreviewed logs, recent findings as [F-xxxx] "description", flagged checkpoints as [Q-xxxx] "question">
 
 ## Graph Summary
-<node counts, recent findings, open questions, gaps>
+<node counts, recent findings, open questions, gaps. Each listed node gets a label>
 
 ## Suggested Next Action
-/wh:<command> — <reasoning>
+/wh:<command>: <reasoning>
 ```
 
 ### Routing Logic


### PR DESCRIPTION
## Summary
Wheeler skill prompts cited graph nodes by bare `[NODE_ID]` in user-facing action prompts (close-out, sign-off, batch approval), forcing users to look up node titles separately. Added a shared "Action-prompt labeling rule" to `.claude/commands/wh/CLAUDE.md` and applied it to every wh:* skill that surfaces node IDs in user-facing prompts. The in-prose `[NODE_ID]` citation rule for factual claims (write.md, compile.md) is preserved verbatim.

## Acceptance criteria (verified, all PASS)
- [x] **PASS** — Skill prompts explicitly instruct title-alongside-`[NODE_ID]` for user actions. Shared rule at `.claude/commands/wh/CLAUDE.md:77-81`; per-skill references in close.md, dream.md, graph-link.md, execute.md, reconvene.md, status.md, graph-review.md.
- [x] **PASS** — In-prose `[NODE_ID]` citation rule preserved. write.md and compile.md unchanged.
- [x] **PASS** — Every affected skill has at least one example block demonstrating the new format.
- [x] **PASS** — Existing tests pass. 1558 passed, 2 skipped.

## E2E behavioral gate: n/a (documentation-only change)

Skill prompts are markdown system prompts loaded by Claude Code at runtime; there is no Python behavior to round-trip. Verifier confirmed the instruction text is correct, applied to all relevant skills, and the mirror trees (`.claude/commands/wh/` and `wheeler/_data/commands/`) stay in sync.

## Files changed (16 files, mirror-paired)
- `.claude/commands/wh/CLAUDE.md` + mirror: new shared rule
- close.md, dream.md, graph-link.md, execute.md, reconvene.md, status.md, graph-review.md (each + mirror)

## Verified by
wheeler-issue-cycle, independent Verifier on 2026-05-19.

Closes #38