### PR TITLE
fix: add Write/Edit tools to wheeler-researcher profile (closes #43)

### DIFF
--- a/.claude/agents/wheeler-researcher.md
+++ b/.claude/agents/wheeler-researcher.md
@@ -3,6 +3,8 @@ name: wheeler-researcher
 description: Literature and web search agent for Wheeler research tasks
 allowed-tools:
   - Read
+  - Write
+  - Edit
   - Glob
   - Grep
   - WebSearch
@@ -19,7 +21,8 @@ allowed-tools:
 ---
 
 You are a Wheeler researcher agent. You search the web, read docs, and return
-concise answers. You have NO file writing, editing, or bash access.
+concise answers. You can write your own research-note files (Write, Edit) so
+the parent does not have to copy-paste content, but you have no bash access.
 
 ## SPEED IS CRITICAL
 
@@ -91,5 +94,6 @@ After flagging a checkpoint, STOP that line of work.
 - NEVER pad answers with tangential information
 - In Mode 2: record ALL findings to graph, validate citations before completing
 - Flag conflicting evidence rather than choosing a side
-- Never make scientific judgment calls — those are checkpoints
-- You cannot write files — flag as checkpoint if needed
+- Never make scientific judgment calls, those are checkpoints
+- When asked to save a note to a path, write the file yourself and then
+  register it via `ensure_artifact` so provenance stays linked to your run

--- a/tests/regression/test_issue_43.py
+++ b/tests/regression/test_issue_43.py
@@ -1,0 +1,104 @@
+"""Regression test for issue #43: wheeler-researcher profile missing Write tools.
+
+Issue: The wheeler-researcher subagent profile lacks Write and Edit tools,
+preventing it from saving research notes to disk. This forces the agent to
+return content inline and ask the parent to save it, breaking provenance
+and wasting tokens.
+
+Expected: wheeler-researcher should have Write and Edit in allowed-tools.
+"""
+
+import pytest
+import yaml
+from pathlib import Path
+
+
+def test_wheeler_researcher_profile_has_write_tools():
+    """Wheeler-researcher agent should be able to write files."""
+    agent_path = Path(__file__).parent.parent.parent / ".claude" / "agents" / "wheeler-researcher.md"
+    assert agent_path.exists(), f"Agent profile not found at {agent_path}"
+
+    content = agent_path.read_text()
+
+    # Extract YAML frontmatter
+    lines = content.split("\n")
+    assert lines[0] == "---", "Agent profile should start with YAML frontmatter"
+
+    # Find the closing ---
+    yaml_end = None
+    for i in range(1, len(lines)):
+        if lines[i] == "---":
+            yaml_end = i
+            break
+
+    assert yaml_end is not None, "Agent profile should have closing --- for YAML"
+
+    yaml_content = "\n".join(lines[1:yaml_end])
+    frontmatter = yaml.safe_load(yaml_content)
+
+    assert frontmatter is not None, "Failed to parse YAML frontmatter"
+    assert "allowed-tools" in frontmatter, "Agent profile missing 'allowed-tools' key"
+
+    allowed_tools = frontmatter["allowed-tools"]
+    assert isinstance(allowed_tools, list), "allowed-tools should be a list"
+
+    # Check that Write tool is available
+    has_write = "Write" in allowed_tools
+    assert has_write, (
+        f"wheeler-researcher missing 'Write' tool. "
+        f"Current allowed-tools: {allowed_tools}"
+    )
+
+    # Check that Edit tool is available
+    has_edit = "Edit" in allowed_tools
+    assert has_edit, (
+        f"wheeler-researcher missing 'Edit' tool. "
+        f"Current allowed-tools: {allowed_tools}"
+    )
+
+
+def test_wheeler_researcher_system_prompt_reflects_write_capability():
+    """If agent has Write tools, system prompt should acknowledge it."""
+    agent_path = Path(__file__).parent.parent.parent / ".claude" / "agents" / "wheeler-researcher.md"
+    content = agent_path.read_text()
+
+    # Extract the markdown body (after the closing ---)
+    lines = content.split("\n")
+    yaml_end = None
+    for i in range(1, len(lines)):
+        if lines[i] == "---":
+            yaml_end = i
+            break
+
+    markdown_body = "\n".join(lines[yaml_end + 1 :])
+
+    # Extract frontmatter to check for Write tool
+    yaml_content = "\n".join(lines[1:yaml_end])
+    frontmatter = yaml.safe_load(yaml_content)
+    allowed_tools = frontmatter.get("allowed-tools", [])
+    has_write = "Write" in allowed_tools
+
+    # If Write is in allowed-tools, the system prompt should NOT say "cannot write"
+    if has_write:
+        assert "NO file writing" not in markdown_body and "cannot write" not in markdown_body.lower(), (
+            "System prompt claims agent cannot write files, but Write tool is in allowed-tools. "
+            "Update the system prompt to reflect write capability."
+        )
+
+
+def test_agent_profile_mirrored_in_data_dir():
+    """Agent profile should be mirrored in wheeler/_data/agents/."""
+    agent_path = Path(__file__).parent.parent.parent / ".claude" / "agents" / "wheeler-researcher.md"
+    data_path = Path(__file__).parent.parent.parent / "wheeler" / "_data" / "agents" / "wheeler-researcher.md"
+
+    assert agent_path.exists(), f"Agent profile not found at {agent_path}"
+    assert data_path.exists(), f"Agent data file not found at {data_path}"
+
+    # Both should be identical (per CLAUDE.md requirement)
+    agent_content = agent_path.read_text()
+    data_content = data_path.read_text()
+
+    assert agent_content == data_content, (
+        "wheeler-researcher agent files are out of sync. "
+        f"{agent_path} and {data_path} must be identical."
+    )

--- a/wheeler/_data/agents/wheeler-researcher.md
+++ b/wheeler/_data/agents/wheeler-researcher.md
@@ -3,6 +3,8 @@ name: wheeler-researcher
 description: Literature and web search agent for Wheeler research tasks
 allowed-tools:
   - Read
+  - Write
+  - Edit
   - Glob
   - Grep
   - WebSearch
@@ -19,7 +21,8 @@ allowed-tools:
 ---
 
 You are a Wheeler researcher agent. You search the web, read docs, and return
-concise answers. You have NO file writing, editing, or bash access.
+concise answers. You can write your own research-note files (Write, Edit) so
+the parent does not have to copy-paste content, but you have no bash access.
 
 ## SPEED IS CRITICAL
 
@@ -91,5 +94,6 @@ After flagging a checkpoint, STOP that line of work.
 - NEVER pad answers with tangential information
 - In Mode 2: record ALL findings to graph, validate citations before completing
 - Flag conflicting evidence rather than choosing a side
-- Never make scientific judgment calls — those are checkpoints
-- You cannot write files — flag as checkpoint if needed
+- Never make scientific judgment calls, those are checkpoints
+- When asked to save a note to a path, write the file yourself and then
+  register it via `ensure_artifact` so provenance stays linked to your run


### PR DESCRIPTION
## Summary

`wheeler-researcher` agent profile lacked `Write` / `Edit` tools, forcing the parent agent to copy-paste research output back to disk. Add Write + Edit to allowed-tools in both profile copies; update the system prompt to reflect the new capability; instruct the researcher to register output via `ensure_artifact`.

## Acceptance criteria (verified)

- [x] Write + Edit available in allowed-tools
- [x] System prompt instructs researcher to write its own notes and call `ensure_artifact`
- [x] Both profile copies (`.claude/agents/` and `wheeler/_data/agents/`) byte-identical
- [x] Existing tests still pass (1564 passed, 2 skipped)

## Test results

- Regression test: `tests/regression/test_issue_43.py` (3 tests) passes
- Full suite: 1564 passed, 0 failed, 0 regressions vs main
- E2E behavioral check: YAML frontmatter contains Write+Edit, mcp_wheeler_mutations__* exposes ensure_artifact/add_note, system prompt no longer claims "no file writing", both profile mirrors byte-identical

## Verified by

wheeler-issue-cycle independent Verifier, 2026-05-20.

Closes #43