### PR TITLE
fix: detect framing divergence between linked Findings in /wh:dream (closes #45)

### DIFF
--- a/.claude/commands/wh/dream.md
+++ b/.claude/commands/wh/dream.md
@@ -130,7 +130,24 @@ Look for consolidation opportunities:
 
 5. **Stale scripts**:call `detect_stale`.
 
-6. Read `.plans/STATE.md` and any recent `*-SUMMARY.md` for context on what happened recently.
+6. **Framing divergence between linked Findings**:scan recent Findings (last 30 days) that are linked via `RELEVANT_TO` or `AROSE_FROM` from an even-newer Finding. The newer Finding's description may have reframed the older one (a follow-up trace subsumed or contradicted the original framing), leaving the older Finding's description stale. Flag these pairs for human review; do not auto-revise.
+
+   ```cypher
+   MATCH (newer:Finding)-[r:RELEVANT_TO|AROSE_FROM]->(older:Finding)
+   WHERE newer.date IS NOT NULL AND older.date IS NOT NULL
+     AND newer.date > older.date
+     AND duration.between(date(older.date), date()).days <= 30
+     AND newer.description IS NOT NULL AND older.description IS NOT NULL
+     AND size(newer.description) > 40 AND size(older.description) > 40
+   RETURN older.id AS older_id, older.description AS older_desc, older.date AS older_date,
+          newer.id AS newer_id, newer.description AS newer_desc, newer.date AS newer_date,
+          type(r) AS rel
+   ORDER BY newer.date DESC LIMIT 20
+   ```
+
+   For each returned pair, compare framings. Cheap heuristics: low keyword overlap (under 30% shared content words) combined with the newer description introducing a relationship word the older one lacks ("inversely", "single", "continuous", "same line", "subsumes", "consequence of") suggests the newer trace reframed rather than merely added evidence. When uncertain, treat as a candidate. The bar is "is this worth a human look", not "definitely reframed".
+
+7. Read `.plans/STATE.md` and any recent `*-SUMMARY.md` for context on what happened recently.
 
 ## Phase 3: Consolidate
 
@@ -167,6 +184,14 @@ For each open hypothesis with 3+ supporting findings:
 For each stale script from `detect_stale`:
 - Create an OpenQuestion: `[S-xxx] "<script title or path>" is stale (script modified since last execution): re-run needed?`
 - Set priority 7
+
+### Framing-Divergence Review
+For each candidate pair from Phase 2 step 6 (an older Finding that a newer RELEVANT_TO Finding appears to have reframed):
+- Create an OpenQuestion citing both Findings and quoting the description-diff in compact form. Template:
+  `Framing divergence: [F-older] "<first 80-120 chars of older.description>" may have been reframed by [F-newer] "<first 80-120 chars of newer.description>" (linked RELEVANT_TO). Revise [F-older]'s description to cite [F-newer], or accept the divergence?`
+- Set priority 6 (medium: chronic, not acute, per issue context).
+- Do not call `update_node` on the older Finding automatically. The flag is the deliverable; the scientist edits the description (typically via `update_node`) if they agree.
+- If the same older Finding is reframed by multiple newer Findings, consolidate into a single OpenQuestion listing each newer Finding rather than spawning one question per pair.
 
 ## Phase 3.5: Generate Synthesis Index Files
 
@@ -439,6 +464,7 @@ Consolidated: <timestamp>
 - [Q-cccc] Potential duplicate: [F-dddd] and [F-eeee]
 - [Q-ffff] Hypothesis [H-gggg] ready for review (4 supporting findings)
 - [Q-hhhh] Stale script [S-iiii] needs re-run
+- [Q-jjjj] Framing divergence: [F-older] may have been reframed by [F-newer]
 
 ## Synthesis Files Generated
 - synthesis/INDEX.md: N nodes indexed

--- a/tests/regression/test_issue_45.py
+++ b/tests/regression/test_issue_45.py
@@ -1,0 +1,150 @@
+"""Regression test for issue #45: workflow to flag Findings reframed by follow-up traces.
+
+Issue: When a newer Finding reframes an older Finding (e.g., Finding B RELEVANT_TO
+Finding A where B contains new framing), there is no automated workflow to flag or
+handle the older Finding's stale description. This test verifies that EITHER:
+  (a) /wh:dream includes framing-divergence detection, OR
+  (b) a new skill /wh:revise-finding exists, OR
+  (c) appropriate graph schema (REFRAMED_BY/SUPERSEDED_BY) and tools are available.
+"""
+
+import pytest
+from pathlib import Path
+import re
+
+
+def test_wh_dream_has_framing_divergence_detection():
+    """Verify /wh:dream includes framing divergence detection step.
+
+    Specifically looking for detection that when Finding B is RELEVANT_TO
+    Finding A, and B's description reframes A's description, A is flagged
+    for revision. This should appear in Phase 2 or Phase 3.
+    """
+    dream_cmd = Path(__file__).parent.parent.parent / ".claude" / "commands" / "wh" / "dream.md"
+    assert dream_cmd.exists(), f"Dream command not found at {dream_cmd}"
+
+    content = dream_cmd.read_text()
+
+    # Look for specific mentions of:
+    # - "framing divergence" or "framing-divergence"
+    # - "divergence between linked Findings"
+    # - "reframed" in context of Findings
+    # - "semantic divergence" of descriptions
+    # - "RELEVANT_TO" paired with description analysis
+    # - Explicit mention of handling reframed Findings
+    has_framing_detection = any([
+        "framing divergence" in content.lower() or "framing-divergence" in content.lower(),
+        "reframed" in content.lower() and "finding" in content.lower(),
+        "divergence" in content.lower() and "linked" in content.lower() and "finding" in content.lower(),
+        ("semantic" in content.lower() and "divergence" in content.lower()),
+        ("new finding" in content.lower() and "reframe" in content.lower()),
+        ("RELEVANT_TO" in content and "description" in content and ("divergence" in content.lower() or "reframe" in content.lower())),
+    ])
+
+    assert has_framing_detection, (
+        "Dream command does not implement framing divergence detection. "
+        "No phase exists to flag or handle Findings reframed by newer RELEVANT_TO traces. "
+        "Issue #45 requires: When Finding B is RELEVANT_TO Finding A and B's description "
+        "contains different framing than A, flag A for revision."
+    )
+
+
+def test_wh_revise_finding_skill_exists():
+    """Verify /wh:revise-finding skill exists as alternative to dream detection."""
+    revise_finding_cmd = Path(__file__).parent.parent.parent / ".claude" / "commands" / "wh" / "revise-finding.md"
+
+    # This is OK to not exist IF dream detection is present
+    # But if neither exists, the test should fail
+    dream_cmd = Path(__file__).parent.parent.parent / ".claude" / "commands" / "wh" / "dream.md"
+    dream_content = dream_cmd.read_text()
+
+    has_dream_detection = any([
+        "framing divergence" in dream_content.lower() or "framing-divergence" in dream_content.lower(),
+        "reframed" in dream_content.lower() and "finding" in dream_content.lower(),
+        "divergence" in dream_content.lower() and "linked" in dream_content.lower() and "finding" in dream_content.lower(),
+    ])
+
+    # At least one of these must be true:
+    # (a) /wh:dream has framing detection, OR
+    # (b) /wh:revise-finding skill exists
+    assert has_dream_detection or revise_finding_cmd.exists(), (
+        "Neither /wh:dream framing detection nor /wh:revise-finding skill exists. "
+        "Issue #45 requires at least one workflow to handle reframed Findings."
+    )
+
+
+def test_graph_schema_has_reframing_relationships():
+    """Verify graph schema supports reframing relationships if needed."""
+    schema_file = Path(__file__).parent.parent.parent / "wheeler" / "graph" / "schema.py"
+    assert schema_file.exists(), f"Schema file not found at {schema_file}"
+
+    content = schema_file.read_text()
+
+    # Look for relationship type definitions
+    # Should have either REFRAMED_BY, SUPERSEDED_BY, or rely on RELEVANT_TO
+    allowed_rels = [
+        "REFRAMED_BY",
+        "SUPERSEDED_BY",
+        "RELEVANT_TO",  # existing fallback
+    ]
+
+    # At minimum, RELEVANT_TO should be defined (it already is)
+    has_relevant_to = "RELEVANT_TO" in content
+
+    assert has_relevant_to, (
+        "Graph schema missing RELEVANT_TO relationship. "
+        "Cannot link reframed Findings without this."
+    )
+
+    # Check if extended relationships for clarity exist
+    has_reframing_rel = any(rel in content for rel in ["REFRAMED_BY", "SUPERSEDED_BY"])
+
+    # The test doesn't fail if these are missing, but notes for improvement
+    if not has_reframing_rel:
+        # This is informational; it's acceptable to use RELEVANT_TO
+        # as long as the workflow properly detects and handles it
+        pass
+
+
+def test_dream_file_format_matches_data_dir():
+    """Verify dream command file parity between repo and data dir."""
+    repo_dream = Path(__file__).parent.parent.parent / ".claude" / "commands" / "wh" / "dream.md"
+    data_dream = Path(__file__).parent.parent.parent / "wheeler" / "_data" / "commands" / "dream.md"
+
+    assert repo_dream.exists(), f"Repo dream command not found at {repo_dream}"
+    assert data_dream.exists(), f"Data dream command not found at {data_dream}"
+
+    repo_content = repo_dream.read_text()
+    data_content = data_dream.read_text()
+
+    assert repo_content == data_content, (
+        "Dream command files are out of sync. "
+        f"{repo_dream} and {data_dream} must be identical."
+    )
+
+
+def test_issue_45_workflow_exists():
+    """Integration test: verify at least ONE workflow exists to handle reframed Findings."""
+    dream_cmd = Path(__file__).parent.parent.parent / ".claude" / "commands" / "wh" / "dream.md"
+    revise_finding_cmd = Path(__file__).parent.parent.parent / ".claude" / "commands" / "wh" / "revise-finding.md"
+
+    dream_content = dream_cmd.read_text()
+
+    # Check for framing detection in /wh:dream (specific to reframed Findings)
+    has_dream_framing_detection = any([
+        "framing divergence" in dream_content.lower() or "framing-divergence" in dream_content.lower(),
+        "reframed" in dream_content.lower() and "finding" in dream_content.lower(),
+        ("RELEVANT_TO" in dream_content and "divergence" in dream_content.lower() and "description" in dream_content.lower()),
+    ])
+
+    # Check if /wh:revise-finding exists
+    has_revise_skill = revise_finding_cmd.exists()
+
+    # At least ONE must be present
+    assert has_dream_framing_detection or has_revise_skill, (
+        "Issue #45: No workflow exists to flag earlier Findings reframed by follow-up traces. "
+        "Neither /wh:dream framing-divergence detection nor /wh:revise-finding skill is available. "
+        "Expected: (a) /wh:dream adds phase to detect when Finding B RELEVANT_TO A "
+        "with different framing, and surfaces A for revision, OR "
+        "(b) new skill /wh:revise-finding guides manual revision workflow."
+    )

--- a/wheeler/_data/commands/dream.md
+++ b/wheeler/_data/commands/dream.md
@@ -130,7 +130,24 @@ Look for consolidation opportunities:
 
 5. **Stale scripts**:call `detect_stale`.
 
-6. Read `.plans/STATE.md` and any recent `*-SUMMARY.md` for context on what happened recently.
+6. **Framing divergence between linked Findings**:scan recent Findings (last 30 days) that are linked via `RELEVANT_TO` or `AROSE_FROM` from an even-newer Finding. The newer Finding's description may have reframed the older one (a follow-up trace subsumed or contradicted the original framing), leaving the older Finding's description stale. Flag these pairs for human review; do not auto-revise.
+
+   ```cypher
+   MATCH (newer:Finding)-[r:RELEVANT_TO|AROSE_FROM]->(older:Finding)
+   WHERE newer.date IS NOT NULL AND older.date IS NOT NULL
+     AND newer.date > older.date
+     AND duration.between(date(older.date), date()).days <= 30
+     AND newer.description IS NOT NULL AND older.description IS NOT NULL
+     AND size(newer.description) > 40 AND size(older.description) > 40
+   RETURN older.id AS older_id, older.description AS older_desc, older.date AS older_date,
+          newer.id AS newer_id, newer.description AS newer_desc, newer.date AS newer_date,
+          type(r) AS rel
+   ORDER BY newer.date DESC LIMIT 20
+   ```
+
+   For each returned pair, compare framings. Cheap heuristics: low keyword overlap (under 30% shared content words) combined with the newer description introducing a relationship word the older one lacks ("inversely", "single", "continuous", "same line", "subsumes", "consequence of") suggests the newer trace reframed rather than merely added evidence. When uncertain, treat as a candidate. The bar is "is this worth a human look", not "definitely reframed".
+
+7. Read `.plans/STATE.md` and any recent `*-SUMMARY.md` for context on what happened recently.
 
 ## Phase 3: Consolidate
 
@@ -167,6 +184,14 @@ For each open hypothesis with 3+ supporting findings:
 For each stale script from `detect_stale`:
 - Create an OpenQuestion: `[S-xxx] "<script title or path>" is stale (script modified since last execution): re-run needed?`
 - Set priority 7
+
+### Framing-Divergence Review
+For each candidate pair from Phase 2 step 6 (an older Finding that a newer RELEVANT_TO Finding appears to have reframed):
+- Create an OpenQuestion citing both Findings and quoting the description-diff in compact form. Template:
+  `Framing divergence: [F-older] "<first 80-120 chars of older.description>" may have been reframed by [F-newer] "<first 80-120 chars of newer.description>" (linked RELEVANT_TO). Revise [F-older]'s description to cite [F-newer], or accept the divergence?`
+- Set priority 6 (medium: chronic, not acute, per issue context).
+- Do not call `update_node` on the older Finding automatically. The flag is the deliverable; the scientist edits the description (typically via `update_node`) if they agree.
+- If the same older Finding is reframed by multiple newer Findings, consolidate into a single OpenQuestion listing each newer Finding rather than spawning one question per pair.
 
 ## Phase 3.5: Generate Synthesis Index Files
 
@@ -439,6 +464,7 @@ Consolidated: <timestamp>
 - [Q-cccc] Potential duplicate: [F-dddd] and [F-eeee]
 - [Q-ffff] Hypothesis [H-gggg] ready for review (4 supporting findings)
 - [Q-hhhh] Stale script [S-iiii] needs re-run
+- [Q-jjjj] Framing divergence: [F-older] may have been reframed by [F-newer]
 
 ## Synthesis Files Generated
 - synthesis/INDEX.md: N nodes indexed


### PR DESCRIPTION
## Summary

Added a new phase to `/wh:dream` that scans recent Findings for framing divergence with linked older Findings (via RELEVANT_TO / AROSE_FROM), and surfaces candidates as proposed revisions via OpenQuestion nodes. No new graph relationship types added; reuses existing edges.

This satisfies the acceptance criteria's EITHER path (a): extend `/wh:dream`. The alternative path (b) of creating a new `/wh:revise-finding` skill was rejected as heavier-touch.

## Acceptance criteria (verified)

- [x] /wh:dream adds step "detect framing-divergence between linked Findings"
- [x] Heuristics include keyword patterns ("single", "continuous", "same line", "consequence of")
- [x] OpenQuestion created when divergence detected, citing both Findings
- [x] Existing tests still pass (1566 passed, 2 skipped)
- [~] PL-36a2d0a7 fixture exercise: prose validates conceptually but no live graph fixture to literally run; verifier marked PARTIAL on this criterion only

## Test results

- Regression test: `tests/regression/test_issue_45.py` (5 tests) passes
- Full suite: 1566 passed, 0 failed, 0 regressions vs main
- E2E: pure_logic (act-prompt markdown change)

## Verified by

wheeler-issue-cycle independent Verifier, 2026-05-20.

Closes #45