### PR TITLE
fix: display anchor figures inline in /wh:execute plan mode (closes #44)

### DIFF
--- a/.claude/commands/wh/execute.md
+++ b/.claude/commands/wh/execute.md
@@ -65,9 +65,10 @@ When running from a registered plan (PL-xxxx):
 4. **Create the canonical export directory** for archived figures, datasets, scripts, and verification docs: `mkdir -p analysis_exports/<investigation_slug>_<YYYY-MM-DD>/{figures,scripts}` where `<investigation_slug>` is the plan's `investigation:` frontmatter and `<YYYY-MM-DD>` is today's date (the execute date, not the plan-draft date). This is the archive root all figure / dataset / script paths should resolve under; see "Artifact organization" below.
 5. Execute WHEELER-assigned tasks in dependency order. **If `citation_mode: strict`**, every factual claim produced by a task must cite a `[NODE_ID]` already in the graph. Untraced claims are a contract violation; either ground them or remove them.
 6. Skip SCIENTIST and PAIR tasks: flag them as needing the scientist
-7. After each task, update the plan file (mark task done, note results)
-8. When all WHEELER tasks complete, run **Step 2.5: Honor the contract** if any contract field is set. Otherwise jump straight to checking success criteria.
-9. Call `update_node(node_id=PL-xxxx, status="completed")` (or leave as in-progress if gaps remain). Update plan file frontmatter to mirror.
+7. After each task that produced a figure (any artifact registered via `ensure_artifact(artifact_type="finding")` whose path ends in `.png`/`.jpg`/`.svg`/`.pdf`), display the anchor figure inline by calling `Read` on the PNG path. Do this per-task at the moment of registration, not just at end of execution, so the scientist sees the figure in the chat thread without having to ask.
+8. After each task, update the plan file (mark task done, note results)
+9. When all WHEELER tasks complete, run **Step 2.5: Honor the contract** if any contract field is set. Otherwise jump straight to checking success criteria.
+10. Call `update_node(node_id=PL-xxxx, status="completed")` (or leave as in-progress if gaps remain). Update plan file frontmatter to mirror.
 
 ### Artifact organization (canonical export directory)
 

--- a/tests/regression/test_issue_44.py
+++ b/tests/regression/test_issue_44.py
@@ -1,0 +1,123 @@
+"""
+Regression test for issue #44: plan-based mode does not instruct AI to display anchor figures inline.
+
+This test verifies that the /wh:execute skill includes instructions for displaying figures
+registered as findings during plan execution, particularly in the plan-based execution path.
+"""
+
+import pytest
+
+
+def test_execute_skill_plan_mode_includes_figure_display_instruction():
+    """
+    Verify that the /wh:execute skill's plan-based execution section includes
+    an explicit instruction to display figures inline after each task completes.
+
+    The issue reports that while planless-mode execution instructs the AI to
+    "Display anchor figures for any Dataset or Script referenced," the plan-based
+    mode (Step 2a) has no such instruction. This causes figures registered via
+    ensure_artifact(artifact_type=finding) to be written to disk and registered
+    in the graph but not displayed inline in chat.
+    """
+    from pathlib import Path
+
+    # Read the execute.md skill file
+    skill_path = Path(__file__).parent.parent.parent / ".claude" / "commands" / "wh" / "execute.md"
+    assert skill_path.exists(), f"Skill file not found at {skill_path}"
+
+    skill_content = skill_path.read_text()
+
+    # Check that Step 2 (plan-based execution) includes instruction to display figures
+    # The instruction should be in the context of running tasks that produce findings
+    assert "Step 2: Run the plan" in skill_content, "Step 2 title missing"
+
+    # Extract the Step 2 section (from "### Step 2:" to the next "###")
+    step2_start = skill_content.find("### Step 2:")
+    assert step2_start != -1, "Step 2 section not found"
+
+    step2_end = skill_content.find("\n### ", step2_start + 1)
+    if step2_end == -1:
+        step2_end = len(skill_content)
+
+    step2_content = skill_content[step2_start:step2_end]
+
+    # Verify the figure display instruction exists somewhere in Step 2
+    # Key phrases to check for:
+    # - "Display anchor figures" or "display...figures" (from reconvene.md)
+    # - "Read the PNG" (from issue body examples)
+    # - "inline" in context of figures
+    # - "artifact_type=finding" reference
+
+    figure_instruction_found = any([
+        "display" in step2_content.lower() and "figure" in step2_content.lower(),
+        "read the png" in step2_content.lower(),
+        "anchor figure" in step2_content.lower(),
+    ])
+
+    assert figure_instruction_found, (
+        "Step 2 (plan-based execution) does not include an instruction to display "
+        "figures inline. The issue reports that figures registered via ensure_artifact() "
+        "are created but not shown to the user unless explicitly Read or prompted for. "
+        "This test would pass if the skill includes language like 'Display anchor figures' "
+        "or 'Read the PNG' in the plan execution path."
+    )
+
+
+def test_execute_skill_both_copies_have_figure_display_instruction():
+    """
+    Verify that both copies of the execute.md skill (source and package) carry
+    the figure display instruction in their Step 2 section.
+
+    The CLAUDE.md mirror invariant requires `.claude/commands/wh/execute.md`
+    (source) and `wheeler/_data/commands/execute.md` (packaged) to stay in
+    sync. After fixing #44, both files must include the display instruction
+    in plan-based execution; if a future edit drops the instruction from
+    either copy, this test catches it.
+    """
+    from pathlib import Path
+
+    # Read both copies
+    source_skill_path = Path(__file__).parent.parent.parent / ".claude" / "commands" / "wh" / "execute.md"
+    packaged_skill_path = Path(__file__).parent.parent.parent / "wheeler" / "_data" / "commands" / "execute.md"
+
+    assert source_skill_path.exists(), f"Source skill file not found at {source_skill_path}"
+    assert packaged_skill_path.exists(), f"Packaged skill file not found at {packaged_skill_path}"
+
+    source_content = source_skill_path.read_text()
+    packaged_content = packaged_skill_path.read_text()
+
+    # Both should have the "Step 2: Run the plan" section
+    assert "Step 2: Run the plan" in source_content, "Source: Step 2 missing"
+    assert "Step 2: Run the plan" in packaged_content, "Packaged: Step 2 missing"
+
+    # Extract Step 2 sections from both
+    source_step2_start = source_content.find("### Step 2:")
+    packaged_step2_start = packaged_content.find("### Step 2:")
+
+    source_step2_end = source_content.find("\n### ", source_step2_start + 1)
+    if source_step2_end == -1:
+        source_step2_end = len(source_content)
+
+    packaged_step2_end = packaged_content.find("\n### ", packaged_step2_start + 1)
+    if packaged_step2_end == -1:
+        packaged_step2_end = len(packaged_content)
+
+    source_step2 = source_content[source_step2_start:source_step2_end]
+    packaged_step2 = packaged_content[packaged_step2_start:packaged_step2_end]
+
+    # Both must carry the figure display instruction
+    for name, text in [("Source", source_step2), ("Packaged", packaged_step2)]:
+        figure_instruction_found = any([
+            "display" in text.lower() and "figure" in text.lower(),
+            "read the png" in text.lower(),
+            "anchor figure" in text.lower(),
+        ])
+        assert figure_instruction_found, (
+            f"{name} copy of execute.md is missing the figure display "
+            f"instruction in Step 2 (plan-based execution). Both copies must "
+            f"stay in sync; see #44."
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/wheeler/_data/commands/execute.md
+++ b/wheeler/_data/commands/execute.md
@@ -65,9 +65,10 @@ When running from a registered plan (PL-xxxx):
 4. **Create the canonical export directory** for archived figures, datasets, scripts, and verification docs: `mkdir -p analysis_exports/<investigation_slug>_<YYYY-MM-DD>/{figures,scripts}` where `<investigation_slug>` is the plan's `investigation:` frontmatter and `<YYYY-MM-DD>` is today's date (the execute date, not the plan-draft date). This is the archive root all figure / dataset / script paths should resolve under; see "Artifact organization" below.
 5. Execute WHEELER-assigned tasks in dependency order. **If `citation_mode: strict`**, every factual claim produced by a task must cite a `[NODE_ID]` already in the graph. Untraced claims are a contract violation; either ground them or remove them.
 6. Skip SCIENTIST and PAIR tasks: flag them as needing the scientist
-7. After each task, update the plan file (mark task done, note results)
-8. When all WHEELER tasks complete, run **Step 2.5: Honor the contract** if any contract field is set. Otherwise jump straight to checking success criteria.
-9. Call `update_node(node_id=PL-xxxx, status="completed")` (or leave as in-progress if gaps remain). Update plan file frontmatter to mirror.
+7. After each task that produced a figure (any artifact registered via `ensure_artifact(artifact_type="finding")` whose path ends in `.png`/`.jpg`/`.svg`/`.pdf`), display the anchor figure inline by calling `Read` on the PNG path. Do this per-task at the moment of registration, not just at end of execution, so the scientist sees the figure in the chat thread without having to ask.
+8. After each task, update the plan file (mark task done, note results)
+9. When all WHEELER tasks complete, run **Step 2.5: Honor the contract** if any contract field is set. Otherwise jump straight to checking success criteria.
+10. Call `update_node(node_id=PL-xxxx, status="completed")` (or leave as in-progress if gaps remain). Update plan file frontmatter to mirror.
 
 ### Artifact organization (canonical export directory)
 


### PR DESCRIPTION
## Summary

Add per-task instruction to `/wh:execute` Step 2 (plan-based execution): when a task registers a finding artifact whose path ends in `.png/.jpg/.svg/.pdf`, call `Read` on that path so the figure renders inline in the chat. Parallel to `/wh:reconvene`'s existing "Display anchor figures" line. Mirror in `wheeler/_data/commands/execute.md` kept byte-identical.

This was deferred from Wave 1 because execute.md overlapped with Group A's worktree.

## Acceptance criteria (verified)

- [x] /wh:execute plan-based mode explicitly instructs display via Read on the PNG path
- [x] Instruction parallel to /wh:reconvene's "Display anchor figures"
- [x] Both copies of execute.md byte-identical
- [x] Existing tests still pass (1593 passed, 2 skipped, 0 regressions)

## Test results

- Regression test: `tests/regression/test_issue_44.py` (2 tests) passes
- Full suite: 1593 passed, 0 failures, 0 regressions vs main
- E2E: pure_logic (markdown-only act-prompt edit)

## Note on test rewrite

The Fixer rewrote the second assertion in `test_issue_44.py` because the Reproducer wrote it as `assert not figure_instruction_found` with a docstring acknowledging "if this fails, the bug may already be fixed". That is a self-deleting assertion (always fails post-fix, providing zero ongoing protection). The Fixer recast it as a forward-looking mirror-sync guard that catches future regressions in either copy. Verified by the independent Verifier as a structural-defect repair, not an assertion flip to mask failure.

## Verified by

wheeler-issue-cycle independent Verifier, 2026-05-20.

Closes #44