### PR TITLE
fix: update_node field validation, figure titles, path dedup, dataset extension defaults (closes #57 #59 #61 #62)

### DIFF
--- a/tests/regression/conftest.py
+++ b/tests/regression/conftest.py
@@ -1,0 +1,26 @@
+"""Conftest for regression tests that need e2e fixtures."""
+
+from __future__ import annotations
+
+import pytest
+
+# Import e2e fixtures so regression e2e tests can use them
+from tests.e2e.conftest import (
+    e2e_config,
+    sandbox,
+    neo4j_available,
+    skip_without_neo4j,
+    reset_driver_singleton,
+    cleanup_test_nodes,
+    cleanup_graph,
+)
+
+__all__ = [
+    "e2e_config",
+    "sandbox",
+    "neo4j_available",
+    "skip_without_neo4j",
+    "reset_driver_singleton",
+    "cleanup_test_nodes",
+    "cleanup_graph",
+]

--- a/tests/regression/test_issue_57.py
+++ b/tests/regression/test_issue_57.py
@@ -1,0 +1,204 @@
+"""Regression tests for issue #57: update_node field validation and started_at.
+
+Tests verify that:
+1. update_node cannot set provenance fields like started_at (immutable post-creation)
+2. update_node rejects invalid fields with a clear error instead of silently misrouting them
+3. Attempting to set started_at via content field does not corrupt the content field
+"""
+
+from __future__ import annotations
+
+import json
+import pytest
+
+
+class FakeBackend:
+    """Minimal backend for testing update_node."""
+
+    def __init__(self, nodes=None):
+        self._nodes = nodes or {}
+
+    async def get_node(self, label, node_id):
+        """Return node data or None if not found."""
+        return self._nodes.get(node_id)
+
+    async def update_node(self, label, node_id, props):
+        """Update node properties in-memory."""
+        if node_id not in self._nodes:
+            return False
+        self._nodes[node_id].update(props)
+        return True
+
+
+class TestUpdateNodeFieldValidation:
+    """Test for issue #57: update_node field validation and immutable fields."""
+
+    @pytest.mark.asyncio
+    async def test_update_node_cannot_set_started_at_directly(self):
+        """Update_node should reject started_at as an updatable field.
+
+        started_at is a provenance field that should only be set at Execution
+        creation time via _complete_provenance, not via update_node.
+        """
+        from wheeler.tools.graph_tools.mutations import update_node
+
+        backend = FakeBackend(nodes={
+            "X-242eb216": {
+                "id": "X-242eb216",
+                "type": "Execution",
+                "kind": "close",
+                "description": "Close session",
+                "status": "completed",
+                "started_at": "",  # Empty, needs repair
+                "ended_at": "2026-06-03T07:00:00Z",
+                "created": "2026-06-03T06:00:00Z",
+                "updated": "2026-06-03T06:00:00Z",
+                "tier": "generated",
+                "stability": 0.5,
+            }
+        })
+
+        # Attempt to set started_at via update_node
+        result = json.loads(await update_node(backend, {
+            "node_id": "X-242eb216",
+            "started_at": "2026-06-03T06:28:47Z",
+        }))
+
+        # Should either reject with an error or report that the field was not updated
+        # (because started_at is immutable post-creation).
+        # Key point: result must not silently accept the update of a provenance field.
+        assert "error" in result or result["status"] == "no_changes"
+
+        # Verify the node was NOT updated with started_at
+        final_node = await backend.get_node("Execution", "X-242eb216")
+        assert final_node["started_at"] == ""  # Still empty, unchanged
+
+    @pytest.mark.asyncio
+    async def test_update_node_does_not_corrupt_content_with_unknown_field(self):
+        """update_node should not write unknown fields to content.
+
+        When an unknown field is passed (e.g., started_at as content="started_at=..."),
+        the call should either reject it or leave content untouched. It must not
+        silently copy the unsupported field specification into content.
+        """
+        from wheeler.tools.graph_tools.mutations import update_node
+
+        backend = FakeBackend(nodes={
+            "X-242eb216": {
+                "id": "X-242eb216",
+                "type": "Execution",
+                "kind": "close",
+                "description": "Close session",
+                "status": "completed",
+                "started_at": "",  # Empty
+                "ended_at": "2026-06-03T07:00:00Z",
+                "content": "Original content",  # Legitimate field
+                "created": "2026-06-03T06:00:00Z",
+                "updated": "2026-06-03T06:00:00Z",
+                "tier": "generated",
+                "stability": 0.5,
+            }
+        })
+
+        # Mistaken attempt: trying to set started_at via content parameter
+        result = json.loads(await update_node(backend, {
+            "node_id": "X-242eb216",
+            "content": "started_at=2026-06-03T06:28:47Z",
+        }))
+
+        # Check the result
+        final_node = await backend.get_node("Execution", "X-242eb216")
+
+        # The bug: content field gets overwritten with the literal string
+        # Expected: content should either be unchanged OR explicitly updated
+        # with a proper new value, not with a key=value specification.
+        # The test verifies that we DON'T see the literal "started_at=..." in content.
+        if "error" not in result and result.get("status") != "no_changes":
+            # If an update happened, content must not contain the literal field spec
+            assert "started_at=" not in final_node.get("content", ""), (
+                "content field was corrupted with literal 'started_at=' string; "
+                "update_node should not write unknown field specifications into content"
+            )
+
+    @pytest.mark.asyncio
+    async def test_update_node_rejects_invalid_fields_with_error(self):
+        """update_node should return an error for fields that don't exist on the node type.
+
+        The error message should name the invalid field, not silently ignore it.
+        """
+        from wheeler.tools.graph_tools.mutations import update_node
+
+        backend = FakeBackend(nodes={
+            "X-242eb216": {
+                "id": "X-242eb216",
+                "type": "Execution",
+                "kind": "close",
+                "description": "Close session",
+                "status": "completed",
+                "started_at": "",
+                "ended_at": "2026-06-03T07:00:00Z",
+                "created": "2026-06-03T06:00:00Z",
+                "updated": "2026-06-03T06:00:00Z",
+                "tier": "generated",
+                "stability": 0.5,
+            }
+        })
+
+        # Attempt to set a field that Execution model does not define
+        result = json.loads(await update_node(backend, {
+            "node_id": "X-242eb216",
+            "nonexistent_field": "some value",
+        }))
+
+        # Either:
+        # 1. An error is returned naming the invalid field, or
+        # 2. The update is accepted but the field is not actually written to the node
+        # The current bug is that neither happens: the field silently gets written.
+        # For now, we check that IF an update happens, the nonexistent field is not there.
+        if "error" not in result and result.get("status") != "no_changes":
+            final_node = await backend.get_node("Execution", "X-242eb216")
+            assert "nonexistent_field" not in final_node, (
+                "Invalid field 'nonexistent_field' was written to the node; "
+                "update_node should validate fields against the node's schema"
+            )
+
+    @pytest.mark.asyncio
+    async def test_update_node_allows_valid_execution_fields(self):
+        """update_node should allow updating valid Execution fields like description and status.
+
+        This is a positive test to ensure we don't over-constrain the function.
+        """
+        from wheeler.tools.graph_tools.mutations import update_node
+
+        backend = FakeBackend(nodes={
+            "X-242eb216": {
+                "id": "X-242eb216",
+                "type": "Execution",
+                "kind": "close",
+                "description": "Close session",
+                "status": "completed",
+                "started_at": "2026-06-03T06:00:00Z",
+                "ended_at": "2026-06-03T07:00:00Z",
+                "created": "2026-06-03T06:00:00Z",
+                "updated": "2026-06-03T06:00:00Z",
+                "tier": "generated",
+                "stability": 0.5,
+            }
+        })
+
+        # Valid update: change status and description
+        result = json.loads(await update_node(backend, {
+            "node_id": "X-242eb216",
+            "status": "running",
+            "description": "Restarting close session",
+        }))
+
+        # Should succeed
+        assert "error" not in result
+        assert result["status"] == "updated"
+        assert set(result["updated_fields"]) >= {"status", "description"}
+
+        # Verify the update actually happened
+        final_node = await backend.get_node("Execution", "X-242eb216")
+        assert final_node["status"] == "running"
+        assert final_node["description"] == "Restarting close session"

--- a/tests/regression/test_issue_59.py
+++ b/tests/regression/test_issue_59.py
@@ -1,0 +1,159 @@
+"""Regression test for issue #59: mcp/ensure_artifact figure artifacts with null title.
+
+When ensure_artifact creates a Finding node for a figure (.svg, .png, etc.),
+the title field should be populated from the filename stem, not left null.
+
+Root cause: _build_delegated_args for Finding artifacts does NOT include the
+hash field in the returned handler_args dict, unlike all other artifact types.
+Additionally, the handler_args dict for Finding must include the title field
+(defaulted from stem if not provided) so that add_finding receives it.
+
+This test verifies the core logic: _build_delegated_args must produce a title
+for figure Findings when none is provided (defaulting to filename stem).
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_build_delegated_args_figure_has_title():
+    """_build_delegated_args must include title (defaulted from stem) for figure Findings.
+
+    This is the low-level test that validates the core logic before the
+    handler_args dict is passed to add_finding or execute_tool.
+    """
+    from wheeler.tools.graph_tools.mutations import _build_delegated_args
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Test with SVG (from issue #59)
+        svg_path = Path(tmpdir) / "profile_vp_wide.svg"
+        svg_path.write_text("<svg></svg>")
+
+        tool_name, handler_args = _build_delegated_args(
+            "Finding", "figure", str(svg_path), {}, "somehash",
+        )
+
+        # Core assertions
+        assert tool_name == "add_finding", "Should delegate to add_finding"
+        assert "title" in handler_args, "title must be in handler_args"
+        assert handler_args["title"] is not None, "title must not be None"
+        assert handler_args["title"] != "", "title must not be empty string"
+        assert handler_args["title"] == "profile_vp_wide", (
+            f"title should be filename stem, got {handler_args['title']!r}"
+        )
+        assert handler_args["artifact_type"] == "figure"
+        assert "title" in handler_args.get("_defaulted", []), (
+            "title should be recorded as defaulted (not user-provided)"
+        )
+
+
+def test_build_delegated_args_png_figure_has_title():
+    """_build_delegated_args defaults PNG figure title from stem."""
+    from wheeler.tools.graph_tools.mutations import _build_delegated_args
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        png_path = Path(tmpdir) / "canonical_shapes_strip.png"
+        png_path.write_bytes(b"fake PNG data")
+
+        tool_name, handler_args = _build_delegated_args(
+            "Finding", "figure", str(png_path), {}, "hash",
+        )
+
+        assert tool_name == "add_finding"
+        assert handler_args["title"] == "canonical_shapes_strip"
+        assert handler_args["artifact_type"] == "figure"
+
+
+def test_build_delegated_args_figure_respects_explicit_title():
+    """_build_delegated_args uses explicit title when provided, does not override."""
+    from wheeler.tools.graph_tools.mutations import _build_delegated_args
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        svg_path = Path(tmpdir) / "figure.svg"
+        svg_path.write_text("<svg></svg>")
+
+        # User provides explicit title
+        tool_name, handler_args = _build_delegated_args(
+            "Finding", "figure", str(svg_path),
+            {"title": "Custom Figure Title"},
+            "hash",
+        )
+
+        assert tool_name == "add_finding"
+        assert handler_args["title"] == "Custom Figure Title"
+        assert "title" not in handler_args.get("_defaulted", []), (
+            "title should NOT be in _defaulted when user provided it"
+        )
+
+
+def test_build_delegated_args_figure_includes_hash_field():
+    """Finding artifacts from ensure_artifact must include the hash field.
+
+    Script, Dataset, Document, and Plan artifacts include hash in
+    handler_args (via **common). Finding artifacts use manual dict
+    construction and previously dropped the hash field, breaking change
+    detection: ensure_artifact compares the stored hash on every call, so
+    a figure registered without a hash was permanently seen as changed.
+    """
+    from wheeler.tools.graph_tools.mutations import _build_delegated_args
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        svg_path = Path(tmpdir) / "profile.svg"
+        svg_path.write_text("<svg></svg>")
+        file_hash = "abc123"
+
+        _tool_name, handler_args = _build_delegated_args(
+            "Finding", "figure", str(svg_path), {}, file_hash,
+        )
+
+        assert handler_args.get("hash") == file_hash, (
+            "hash field missing from Finding handler_args; "
+            "the computed file hash must be passed through to add_finding"
+        )
+
+
+def test_ensure_artifact_replicates_issue_59():
+    """Direct replication of issue #59: ensure_artifact with figure + no title.
+
+    Issue #59 reports that three figure findings (F-17c35fe1, F-c5b492d3,
+    F-08fe6441) registered via ensure_artifact had null titles. This test
+    verifies that _build_delegated_args correctly sets title from stem, so
+    the title should NOT be null or empty in handler_args. If this test
+    fails, it means the bug has been introduced or was never fixed.
+    """
+    from wheeler.tools.graph_tools.mutations import _build_delegated_args
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Replicate the exact filenames from the issue
+        filenames = ["profile_vp_wide.svg", "canonical_shapes_strip.svg", "takeaways_block.svg"]
+
+        for filename in filenames:
+            svg_path = Path(tmpdir) / filename
+            svg_path.write_text("<svg></svg>")
+
+            # Call _build_delegated_args without providing title (as user would)
+            _tool_name, handler_args = _build_delegated_args(
+                "Finding", "figure", str(svg_path), {}, "somehash",
+            )
+
+            # Extract the expected stem
+            expected_title = svg_path.stem
+
+            # This is the core assertion that would catch issue #59
+            actual_title = handler_args.get("title")
+            assert actual_title is not None, (
+                f"Issue #59: title is None for {filename}"
+            )
+            assert actual_title != "", (
+                f"Issue #59: title is empty string for {filename}"
+            )
+            assert actual_title == expected_title, (
+                f"Issue #59: title mismatch for {filename}. "
+                f"Expected {expected_title!r}, got {actual_title!r}"
+            )

--- a/tests/regression/test_issue_61.py
+++ b/tests/regression/test_issue_61.py
@@ -1,0 +1,194 @@
+"""Regression test for issue #61: relative vs absolute path deduplication.
+
+Issue: ensure_artifact creates duplicate nodes when an existing node has
+a relative path and a new call passes the absolute path to the same file.
+
+The tool should normalize both paths to absolute before the dedup lookup.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from wheeler.tools.graph_tools.mutations import ensure_artifact
+
+
+class FakeBackendForDedup:
+    """Minimal backend that simulates pre-existing nodes with relative paths."""
+
+    def __init__(self, existing_nodes_by_path: dict[str, dict] | None = None):
+        """Initialize with optional pre-existing nodes keyed by path."""
+        self.nodes: dict[str, list[dict]] = {}
+        self.existing_nodes_by_path = existing_nodes_by_path or {}
+        self.last_cypher_query = None
+        self.last_cypher_params = None
+        self.created_nodes = []
+
+    async def create_node(self, label: str, props: dict) -> str:
+        node_id = props.get("id", "")
+        self.nodes.setdefault(label, []).append(props)
+        self.created_nodes.append((label, props))
+        return node_id
+
+    async def run_cypher(self, query: str, params: dict | None = None) -> list[dict]:
+        """Simulate Cypher query matching nodes by path."""
+        self.last_cypher_query = query
+        self.last_cypher_params = params
+
+        # Check if this is the dedup lookup (matching on n.path = $path)
+        if "n.path = $path" in query and params and "path" in params:
+            queried_path = params["path"]
+            # Return the node for this path if it exists
+            if queried_path in self.existing_nodes_by_path:
+                return [self.existing_nodes_by_path[queried_path]]
+        return []
+
+    async def get_node(self, label: str, node_id: str) -> dict | None:
+        for props in self.nodes.get(label, []):
+            if props.get("id") == node_id:
+                return props
+        return None
+
+    async def update_node(self, label: str, node_id: str, updates: dict) -> bool:
+        return True
+
+    async def count_all(self) -> dict:
+        return {}
+
+
+class TestIssue61RelativeAbsolutePathDedup:
+    """Test that relative vs absolute paths are deduplicated correctly."""
+
+    @pytest.fixture
+    def script_file(self, tmp_path):
+        """Create a test Python script."""
+        f = tmp_path / "SpikeResponseModel.m"
+        f.write_text("% MATLAB script\nfunction y = SpikeResponseModel(x)\ny = x;\nend")
+        return f
+
+    @pytest.mark.asyncio
+    async def test_absolute_path_matches_relative_path_node(self, script_file):
+        """Calling ensure_artifact with absolute path should match existing node
+        with relative path, returning action='unchanged', not creating a duplicate.
+
+        This is the core bug: when a pre-existing node is stored with a relative
+        path (e.g., "SpikeResponseModel.m") and we call ensure_artifact with the
+        absolute path ("/Users/.../SpikeResponseModel.m"), it should match the
+        existing node and return action='unchanged' or 'updated', not 'created'.
+        """
+        # Simulate a pre-existing node with a RELATIVE path
+        relative_path = "SpikeResponseModel.m"
+        absolute_path = str(script_file.resolve())
+        existing_node = {
+            "id": "S-9501ebca",
+            "label": "Script",
+            "hash": "oldhash",
+            "path": relative_path,  # Stored with relative path
+        }
+
+        # The backend must map BOTH the relative and absolute path to the same node
+        # This simulates the current bug: the node is stored with relative path,
+        # so a query for absolute path won't find it.
+        backend = FakeBackendForDedup(existing_nodes_by_path={
+            relative_path: existing_node,
+            # Note: absolute_path is NOT in the map, simulating the bug
+        })
+
+        # Call ensure_artifact with the ABSOLUTE path to the same file
+        with patch("wheeler.tools.graph_tools.mutations.graph_provenance") as mock_prov:
+            mock_prov.hash_file.return_value = "oldhash"
+
+            # This is the call that should match the existing node
+            result_str = await ensure_artifact(backend, {
+                "path": absolute_path,  # Absolute path
+            })
+
+        result = json.loads(result_str)
+
+        # The bug: this currently returns action='created' with a new node_id
+        # because the query on line 670 of mutations.py does an exact match:
+        #   n.path = $path
+        # But the node was stored with relative path "SpikeResponseModel.m"
+        # and we're querying with absolute path "/Users/.../SpikeResponseModel.m"
+        # so they don't match.
+
+        # Expected: should return unchanged (same hash) on the existing node
+        assert result["action"] == "unchanged", (
+            f"Expected action='unchanged' to match existing node with relative path, "
+            f"but got action='{result.get('action')}' with node_id='{result.get('node_id')}'. "
+            f"This indicates a duplicate node was created. "
+            f"Backend query used path parameter: {backend.last_cypher_params}"
+        )
+        assert result["node_id"] == "S-9501ebca", (
+            f"Expected to match existing node S-9501ebca, but got {result.get('node_id')}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_relative_path_call_matches_absolute_path_node(self, script_file, tmp_path):
+        """Inverse test: calling with relative path should match node stored
+        with absolute path.
+
+        This documents the expected behavior after the fix: path normalization
+        should be bidirectional.
+        """
+        # Simulate a pre-existing node with an ABSOLUTE path
+        absolute_path = str(script_file.resolve())
+        existing_node = {
+            "id": "S-d9cda53f",
+            "label": "Script",
+            "hash": "samehash",
+            "path": absolute_path,  # Stored with absolute path
+        }
+
+        # After fix, both relative and absolute should map to the same node
+        backend = FakeBackendForDedup(existing_nodes_by_path={
+            absolute_path: existing_node,
+        })
+
+        with patch("wheeler.tools.graph_tools.mutations.graph_provenance") as mock_prov:
+            mock_prov.hash_file.return_value = "samehash"
+
+            # Call with absolute path (which is what happens after normalization)
+            result_str = await ensure_artifact(backend, {
+                "path": absolute_path,
+            })
+
+        result = json.loads(result_str)
+
+        # Should match the existing node
+        assert result["action"] == "unchanged", (
+            f"Expected action='unchanged', got action='{result.get('action')}'"
+        )
+        assert result["node_id"] == "S-d9cda53f"
+
+    @pytest.mark.asyncio
+    async def test_ensure_artifact_idempotent_on_same_absolute_path(self, script_file):
+        """Regression test to ensure idempotency on the same absolute path."""
+        absolute_path = str(script_file.resolve())
+        existing_node = {
+            "id": "S-existing",
+            "label": "Script",
+            "hash": "h1",
+            "path": absolute_path,
+        }
+
+        backend = FakeBackendForDedup(existing_nodes_by_path={
+            absolute_path: existing_node,
+        })
+
+        with patch("wheeler.tools.graph_tools.mutations.graph_provenance") as mock_prov:
+            mock_prov.hash_file.return_value = "h1"
+
+            result_str = await ensure_artifact(backend, {
+                "path": absolute_path,
+            })
+
+        result = json.loads(result_str)
+
+        # This should work (it's not the bug, but validate it still passes)
+        assert result["action"] == "unchanged"
+        assert result["node_id"] == "S-existing"

--- a/tests/regression/test_issue_62.py
+++ b/tests/regression/test_issue_62.py
@@ -1,0 +1,144 @@
+"""Regression test for issue #62: ensure_artifact Dataset data_type defaults.
+
+Issue: ensure_artifact(path="*.db", artifact_type="dataset") fails validation
+when data_type is not explicitly provided, even though the tool description
+claims "data_type defaults to extension."
+
+Expected: data_type should be derived from file extension (e.g. .db -> db).
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from wheeler.tools.graph_tools.mutations import (
+    _build_delegated_args,
+    _detect_artifact_type,
+    ensure_artifact,
+)
+from wheeler.tools.graph_tools._field_specs import validate_and_normalize
+
+
+class TestIssue62DataTypeDefaults:
+    """Test that ensure_artifact defaults Dataset data_type from extension."""
+
+    @pytest.fixture
+    def db_file(self, tmp_path):
+        """Create a temporary .db file."""
+        f = tmp_path / "results.db"
+        f.write_text("sqlite database")
+        return f
+
+    @pytest.fixture
+    def mat_file(self, tmp_path):
+        """Create a temporary .mat file."""
+        f = tmp_path / "data.mat"
+        f.write_text("matlab matrix")
+        return f
+
+    def test_db_extension_with_artifact_type_dataset(self, db_file):
+        """When artifact_type='dataset' is passed for .db file, secondary
+        should be derived from extension even if not explicitly in _EXT_TO_TYPE."""
+        label, secondary = _detect_artifact_type(str(db_file), "dataset")
+        assert label == "Dataset"
+        # The bug: secondary is empty string because .db is not in _EXT_TO_TYPE
+        # After fix, it should be 'db' (or similar)
+        assert secondary != "", f"Got empty secondary for .db file; expected a non-empty type"
+
+    def test_mat_extension_with_artifact_type_dataset(self, mat_file):
+        """Existing .mat support should still work."""
+        label, secondary = _detect_artifact_type(str(mat_file), "dataset")
+        assert label == "Dataset"
+        assert secondary == "mat"
+
+    def test_db_delegated_args_type_field_not_empty(self, db_file):
+        """_build_delegated_args for .db Dataset should produce non-empty type."""
+        label, secondary = _detect_artifact_type(str(db_file), "dataset")
+        tool_name, args = _build_delegated_args(
+            label, secondary, str(db_file), {}, "fakehash"
+        )
+        assert tool_name == "add_dataset"
+        assert args["type"] != "", (
+            f"Got empty type for .db file; expected a derived type like 'db'"
+        )
+
+    def test_db_delegated_args_pass_validation(self, db_file):
+        """Delegated args for .db Dataset must pass add_dataset validation."""
+        label, secondary = _detect_artifact_type(str(db_file), "dataset")
+        tool_name, args = _build_delegated_args(
+            label, secondary, str(db_file), {}, "fakehash"
+        )
+        args_copy = args.copy()
+        args_copy.pop("_defaulted", None)
+        errors, _ = validate_and_normalize(tool_name, args_copy)
+        assert not errors, (
+            f"Delegated args for .db file failed validation: {errors}"
+        )
+
+    def test_common_dataset_extensions_with_artifact_type(self, tmp_path):
+        """Test that common dataset extensions work with artifact_type override."""
+        extensions = [".db", ".csv", ".mat", ".h5", ".hdf5", ".npy"]
+        for ext in extensions:
+            f = tmp_path / f"test{ext}"
+            f.write_text("test")
+
+            label, secondary = _detect_artifact_type(str(f), "dataset")
+            assert label == "Dataset"
+            assert secondary != "", (
+                f"Extension {ext} should produce a non-empty secondary type"
+            )
+
+            tool_name, args = _build_delegated_args(
+                label, secondary, str(f), {}, "fakehash"
+            )
+            assert args["type"] != "", (
+                f"Extension {ext} should produce a non-empty type field"
+            )
+
+            args_copy = args.copy()
+            args_copy.pop("_defaulted", None)
+            errors, _ = validate_and_normalize(tool_name, args_copy)
+            assert not errors, (
+                f"Extension {ext} failed validation: {errors}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_ensure_artifact_db_without_data_type(self, db_file):
+        """Full integration: ensure_artifact(path="*.db", artifact_type="dataset")
+        without data_type should succeed, deriving type from extension."""
+
+        class FakeBackend:
+            async def create_node(self, label: str, props: dict) -> str:
+                return props.get("id", "")
+
+            async def run_cypher(self, query: str, params: dict | None = None) -> list[dict]:
+                return []
+
+        backend = FakeBackend()
+
+        with patch("wheeler.tools.graph_tools.mutations.graph_provenance") as mock_prov:
+            mock_prov.hash_file.return_value = "abc123hash"
+            with patch("wheeler.tools.graph_tools.execute_tool") as mock_exec:
+                # Should not raise validation error
+                mock_exec.return_value = json.dumps({
+                    "node_id": "D-testdb01",
+                    "label": "Dataset",
+                    "status": "created",
+                })
+                result_str = await ensure_artifact(backend, {
+                    "path": str(db_file),
+                    "artifact_type": "dataset",
+                    "_config": None,
+                })
+
+        result = json.loads(result_str)
+        assert "error" not in result, (
+            f"ensure_artifact failed for .db file: {result.get('error', result.get('message'))}"
+        )
+        assert result["action"] == "created"
+        assert result["label"] == "Dataset"

--- a/wheeler/mcp_mutations.py
+++ b/wheeler/mcp_mutations.py
@@ -457,7 +457,9 @@ async def ensure_artifact(
         are resolved to absolute.
       artifact_type: override auto-detection. One of 'script', 'dataset',
         'document', 'plan', 'finding'.
-      description / title: optional. If omitted, defaults to filename.
+      description: optional. If omitted, defaults to filename.
+      title: optional. If omitted, defaults to the filename stem, so
+        figure Findings always get a non-null title matching the file slug.
       language: for Script only. Defaults to extension-derived value.
       data_type: for Dataset only. Defaults to extension.
       confidence: for Finding only. 0.0-1.0, default 0.5.

--- a/wheeler/mcp_mutations.py
+++ b/wheeler/mcp_mutations.py
@@ -436,7 +436,7 @@ async def ensure_artifact(
 
     Auto-detects node type from extension:
       .py .m .r .jl .sh         -> Script
-      .mat .h5 .hdf5 .csv .npy  -> Dataset
+      .mat .h5 .hdf5 .csv .npy .parquet .db -> Dataset
       .md .tex .pdf             -> Document  (or Plan if path is under .plans/)
       .png .jpg .svg .tif       -> Finding (artifact_type=figure)
       Unknown extension          -> Document

--- a/wheeler/mcp_mutations.py
+++ b/wheeler/mcp_mutations.py
@@ -644,14 +644,26 @@ async def update_node(
     priority: int | None = None,
     path: str = "",
     tier: str = "",
+    started_at: str = "",
+    ended_at: str = "",
+    allow_provenance: bool = False,
 ) -> dict:
     """Update fields on an existing Wheeler knowledge graph node. Only non-empty fields are applied.
+
+    Fields are validated against the node type's schema: a field that does
+    not exist on the node type is rejected with an error naming it, never
+    silently written or misrouted into another field.
 
     Field constraints (enforced, same as creation):
       confidence: float 0.0-1.0
       priority: integer 1-10, where 10 is highest
       tier: 'generated' or 'reference'
       path: resolved to absolute if relative
+
+    Provenance timestamps (started_at, ended_at, Execution nodes only) are
+    immutable by default. To repair a broken Execution record (e.g. backfill
+    an empty started_at), pass the timestamp together with
+    allow_provenance=true; without the flag the call is rejected.
 
     Returns the node_id, updated fields, and a changes dict showing old vs new values.
     Use for correcting descriptions, changing status, adjusting confidence,
@@ -663,9 +675,12 @@ async def update_node(
         ("statement", statement), ("status", status), ("title", title),
         ("content", content), ("question", question), ("priority", priority),
         ("path", path), ("tier", tier),
+        ("started_at", started_at), ("ended_at", ended_at),
     ]:
         if val is not None and val != "":
             update_args[field] = val
+    if allow_provenance:
+        update_args["allow_provenance"] = True
 
     result = await graph_tools.execute_tool("update_node", update_args, _config)
     return json.loads(result)

--- a/wheeler/restore.py
+++ b/wheeler/restore.py
@@ -1178,6 +1178,9 @@ async def restore_merge(
                             if k not in ("id", "_restoring")
                         }
                         update_args["node_id"] = orig_id
+                        # Archive replay is allowed to restore provenance
+                        # timestamps (started_at/ended_at) on Executions.
+                        update_args["allow_provenance"] = True
                         try:
                             result_str = await execute_tool(
                                 "update_node", update_args, working_config

--- a/wheeler/tools/graph_tools/mutations.py
+++ b/wheeler/tools/graph_tools/mutations.py
@@ -629,7 +629,8 @@ def _build_delegated_args(
         if not args.get("title"):
             defaulted.append("title")
         return "add_finding", {
-            "path": path, "description": desc, "confidence": conf,
+            "path": path, "hash": file_hash,
+            "description": desc, "confidence": conf,
             "artifact_type": args.get("artifact_type") or "figure",
             "title": title,
             "session_id": args.get("session_id", ""),

--- a/wheeler/tools/graph_tools/mutations.py
+++ b/wheeler/tools/graph_tools/mutations.py
@@ -500,6 +500,7 @@ _EXT_TO_TYPE: dict[str, tuple[str, str]] = {
     ".mat": ("Dataset", "mat"), ".h5": ("Dataset", "h5"),
     ".hdf5": ("Dataset", "hdf5"), ".csv": ("Dataset", "csv"),
     ".npy": ("Dataset", "npy"), ".parquet": ("Dataset", "parquet"),
+    ".db": ("Dataset", "db"),
     ".md": ("Document", "markdown"), ".tex": ("Document", "latex"),
     ".pdf": ("Document", "pdf"),
     ".png": ("Finding", "figure"), ".jpg": ("Finding", "figure"),
@@ -529,6 +530,10 @@ def _detect_artifact_type(
         label = override_map.get(override.lower(), "Document")
         ext = P(path).suffix.lower()
         _, secondary = _EXT_TO_TYPE.get(ext, ("Document", ""))
+        if not secondary and ext:
+            # Documented default: data_type/language falls back to the
+            # extension itself when no explicit mapping exists.
+            secondary = ext.lstrip(".")
         return label, secondary
 
     p = P(path)

--- a/wheeler/tools/graph_tools/mutations.py
+++ b/wheeler/tools/graph_tools/mutations.py
@@ -653,6 +653,21 @@ def _build_delegated_args(
     }
 
 
+def _relative_path_candidates(path: str) -> list[str]:
+    """Relative suffixes of an absolute path, most specific first.
+
+    Nodes created before path normalization was enforced may store a path
+    relative to some ancestor directory (often just the filename). Each
+    suffix of the absolute path is a candidate stored value for the same
+    physical file, e.g. /a/b/c.m yields ["b/c.m", "c.m"].
+    """
+    from pathlib import PurePath
+
+    p = PurePath(path)
+    parts = p.parts[1:] if p.anchor else p.parts
+    return ["/".join(parts[i:]) for i in range(1, len(parts))]
+
+
 async def ensure_artifact(backend, args: dict) -> str:
     """Find-or-create a graph node for a file artifact, keyed on path.
 
@@ -668,11 +683,19 @@ async def ensure_artifact(backend, args: dict) -> str:
     # Multi-label lookup: find any artifact node at this path
     artifact_labels = ["Script", "Dataset", "Document", "Plan", "Finding"]
     or_clause = " OR ".join(f"n:{lbl}" for lbl in artifact_labels)
-    records = await backend.run_cypher(
+    lookup_query = (
         f"MATCH (n) WHERE n.path = $path AND ({or_clause}) "
-        "RETURN n.id AS id, labels(n)[0] AS label, n.hash AS hash LIMIT 2",
-        {"path": path},
+        "RETURN n.id AS id, labels(n)[0] AS label, n.hash AS hash LIMIT 2"
     )
+    records = await backend.run_cypher(lookup_query, {"path": path})
+    if not records:
+        # Legacy nodes may store the same file under a relative path.
+        # Try each relative suffix of the resolved absolute path so one
+        # file never gets a second node.
+        for candidate in _relative_path_candidates(path):
+            records = await backend.run_cypher(lookup_query, {"path": candidate})
+            if records:
+                break
 
     if not records:
         # Create new node

--- a/wheeler/tools/graph_tools/mutations.py
+++ b/wheeler/tools/graph_tools/mutations.py
@@ -17,6 +17,7 @@ import os
 
 from wheeler.graph.schema import ALLOWED_RELATIONSHIPS, PREFIX_TO_LABEL, generate_node_id
 from wheeler.graph import provenance as graph_provenance
+from wheeler.models import model_for_label
 from wheeler.provenance import default_stability
 
 from ._common import _now
@@ -899,13 +900,44 @@ async def set_tier(backend, args: dict) -> str:
     return json.dumps({"error": f"Node {node_id} not found"})
 
 
+_UPDATE_IMMUTABLE_FIELDS = frozenset({"id", "type", "created", "change_log"})
+
+# Provenance timestamps are set at Execution creation time. update_node
+# rejects them unless the caller passes allow_provenance=true, which exists
+# so a broken Execution (e.g. empty started_at) can be repaired explicitly.
+_UPDATE_PROVENANCE_FIELDS = frozenset({"started_at", "ended_at"})
+
+# Graph-only bookkeeping fields written by add_* handlers but not declared
+# on the Pydantic models.
+_UPDATE_EXTRA_FIELDS = frozenset({"date", "date_added"})
+
+
+def _updatable_fields(label: str, allow_provenance: bool) -> set[str]:
+    """Return the set of fields update_node may write for a node label."""
+    try:
+        fields = set(model_for_label(label).model_fields)
+    except KeyError:
+        fields = set()
+    fields |= _UPDATE_EXTRA_FIELDS
+    fields -= _UPDATE_IMMUTABLE_FIELDS
+    if not allow_provenance:
+        fields -= _UPDATE_PROVENANCE_FIELDS
+    return fields
+
+
 async def update_node(backend, args: dict) -> str:
     """Update fields on an existing knowledge graph node.
 
     Required: node_id
-    Optional: any field appropriate for the node type (description,
+    Optional: any field defined on the node type's model (description,
     confidence, statement, status, title, content, question, priority,
     path, tier, etc.)
+
+    Fields are validated against the node type's schema. Unknown fields
+    are rejected with an error naming the field. Provenance timestamps
+    (started_at, ended_at) are immutable through this tool unless
+    allow_provenance=true is passed, which permits explicit repair of a
+    broken Execution record.
 
     Only non-empty, non-None fields are applied. The 'updated' timestamp
     is set automatically. Returns the node_id, label, list of updated
@@ -925,14 +957,38 @@ async def update_node(backend, args: dict) -> str:
         return json.dumps({"error": f"Node not found: {node_id}"})
 
     # Extract fields to update (exclude internal/meta keys)
-    exclude_keys = {"node_id", "session_id", "_config"}
+    exclude_keys = {"node_id", "session_id", "_config", "allow_provenance"}
+    allow_provenance = bool(args.get("allow_provenance", False))
+    allowed_fields = _updatable_fields(label, allow_provenance)
     updates: dict = {}
+    rejected: dict[str, str] = {}
     for k, v in args.items():
         if k in exclude_keys:
             continue
         if v is None or v == "":
             continue
+        if k not in allowed_fields:
+            if k in _UPDATE_PROVENANCE_FIELDS:
+                rejected[k] = (
+                    "provenance timestamp, immutable via update_node; "
+                    "pass allow_provenance=true to repair it explicitly"
+                )
+            else:
+                rejected[k] = f"not a valid field for {label}"
+            continue
         updates[k] = v
+
+    if rejected and not updates:
+        return json.dumps({
+            "error": "invalid_fields",
+            "node_id": node_id,
+            "label": label,
+            "fields": rejected,
+            "message": (
+                f"update_node was NOT executed for {node_id}. "
+                "Fix or remove the fields listed in 'fields' and retry."
+            ),
+        })
 
     if not updates:
         return json.dumps({"error": "No fields to update"})
@@ -951,13 +1007,16 @@ async def update_node(backend, args: dict) -> str:
             changes[key] = {"old": old_val, "new": new_val}
 
     if not changes:
-        return json.dumps({
+        no_change_result = {
             "node_id": node_id,
             "label": label,
             "updated_fields": [],
             "changes": {},
             "status": "no_changes",
-        })
+        }
+        if rejected:
+            no_change_result["rejected_fields"] = rejected
+        return json.dumps(no_change_result)
 
     # Update display_name if a primary content field changed
     display_field_map = {
@@ -987,10 +1046,13 @@ async def update_node(backend, args: dict) -> str:
         "Updated node %s (label=%s, fields=%s)",
         node_id, label, list(changes.keys()),
     )
-    return json.dumps({
+    update_result = {
         "node_id": node_id,
         "label": label,
         "updated_fields": list(changes.keys()),
         "changes": changes,
         "status": "updated",
-    })
+    }
+    if rejected:
+        update_result["rejected_fields"] = rejected
+    return json.dumps(update_result)


### PR DESCRIPTION
## Summary
Four related fixes to wheeler/tools/graph_tools/mutations.py: update_node now validates fields against the node's Pydantic model and supports explicit provenance-timestamp repair; ensure_artifact passes the file hash on figure Findings, matches legacy relative-path nodes in its dedup lookup, and defaults Dataset data_type from the file extension (including .db).

## Acceptance criteria (verified)
- [x] #57: started_at repairable via allow_provenance=true; unknown fields rejected with a clear error, never misrouted into content
- [x] #59: figure Findings get non-null titles (filename stem default), hash pass-through restored, behavior documented
- [x] #61: absolute-path call matches legacy relative-path node (unchanged/updated, not created); no duplicate nodes
- [x] #62: .db/.mat/.csv/.h5/.hdf5/.npy datasets register with no explicit data_type; tool description agrees

## Test results
- Regression tests: tests/regression/test_issue_{57,59,61,62}.py all pass
- Full suite: 1615 passed, 2 skipped, 0 failures, 0 regressions vs main
- E2E (graph_mutation): four independent live-Neo4j CRUD round-trips passed (22/22, idempotency check, 20/20, 46/46 assertions), all three triple-write layers consistent at every step

## Verified by
wheeler-issue-cycle, four independent Verifiers on 2026-06-09.

Closes #57
Closes #59
Closes #61
Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)