### PR TITLE
fix: surface triple-write drift proactively in graph_health (closes #60)

### DIFF
--- a/tests/regression/test_issue_60.py
+++ b/tests/regression/test_issue_60.py
@@ -1,0 +1,284 @@
+"""Regression test for issue #60: silent triple-write drift.
+
+Tests that newly-created nodes appear consistently across all three layers:
+graph, JSON, and synthesis. Also verifies that deprecated Analysis nodes
+from pre-migration are detected by consistency check.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from wheeler.config import load_config
+from wheeler.consistency import check_consistency
+from wheeler.models import ScriptModel, ExecutionModel
+
+
+class TestTripleWriteConsistency:
+    """Verify that new nodes written via execute_tool appear in all three layers."""
+
+    async def test_add_script_writes_all_three_layers(self, tmp_path):
+        """When add_script succeeds, graph, JSON, and synthesis all get the node."""
+        from wheeler.tools.graph_tools import execute_tool
+        from wheeler.knowledge.store import read_node
+        from wheeler.knowledge.render import render_synthesis
+
+        config = load_config()
+        knowledge_dir = tmp_path / "knowledge"
+        synthesis_dir = tmp_path / "synthesis"
+        knowledge_dir.mkdir()
+        synthesis_dir.mkdir()
+        config.knowledge_path = str(knowledge_dir)
+        config.synthesis_path = str(synthesis_dir)
+
+        # Create a dummy script file
+        script_file = tmp_path / "test_script.py"
+        script_file.write_text("print('hello')")
+
+        # Execute add_script
+        result_str = await execute_tool(
+            "add_script",
+            {
+                "path": str(script_file),
+                "language": "python",
+                "session_id": "test-session",
+            },
+            config,
+        )
+        result = json.loads(result_str)
+        assert "error" not in result, result
+        script_id = result.get("node_id")
+        assert script_id.startswith("S-"), f"Expected S- prefix, got {script_id}"
+
+        # Verify JSON file exists and is readable
+        json_path = knowledge_dir / f"{script_id}.json"
+        assert json_path.exists(), f"JSON file missing: {json_path}"
+        json_model = read_node(knowledge_dir, script_id)
+        assert isinstance(json_model, ScriptModel)
+        assert json_model.language == "python"
+
+        # Verify synthesis file exists and is readable
+        synthesis_path = synthesis_dir / f"{script_id}.md"
+        assert synthesis_path.exists(), f"Synthesis file missing: {synthesis_path}"
+        markdown = synthesis_path.read_text()
+        assert "python" in markdown.lower() or script_id in markdown
+
+        # Verify graph consistency: this node should NOT appear in json_only
+        # (it was just created via triple-write)
+        from wheeler.tools.graph_tools import _get_backend
+
+        backend = await _get_backend(config)
+        records = await backend.run_cypher(
+            f"MATCH (n:Script {{id: $nid}}) RETURN n.id AS id", {"nid": script_id}
+        )
+        assert len(records) > 0, f"Script node {script_id} missing from graph"
+        assert records[0]["id"] == script_id
+
+    async def test_add_finding_writes_all_three_layers(self, tmp_path):
+        """When add_finding succeeds, all three layers receive the node."""
+        from wheeler.tools.graph_tools import execute_tool
+        from wheeler.knowledge.store import read_node
+        from wheeler.models import FindingModel
+
+        config = load_config()
+        knowledge_dir = tmp_path / "knowledge"
+        synthesis_dir = tmp_path / "synthesis"
+        knowledge_dir.mkdir()
+        synthesis_dir.mkdir()
+        config.knowledge_path = str(knowledge_dir)
+        config.synthesis_path = str(synthesis_dir)
+
+        # Execute add_finding
+        result_str = await execute_tool(
+            "add_finding",
+            {
+                "description": "Test finding for triple-write",
+                "confidence": 0.95,
+                "session_id": "test-session",
+            },
+            config,
+        )
+        result = json.loads(result_str)
+        assert "error" not in result, result
+        finding_id = result.get("node_id")
+        assert finding_id.startswith("F-"), f"Expected F- prefix, got {finding_id}"
+
+        # Verify all three layers have the node
+        json_path = knowledge_dir / f"{finding_id}.json"
+        assert json_path.exists(), f"JSON file missing: {json_path}"
+        json_model = read_node(knowledge_dir, finding_id)
+        assert isinstance(json_model, FindingModel)
+        assert json_model.description == "Test finding for triple-write"
+
+        synthesis_path = synthesis_dir / f"{finding_id}.md"
+        assert synthesis_path.exists(), f"Synthesis file missing: {synthesis_path}"
+
+        # Graph check
+        from wheeler.tools.graph_tools import _get_backend
+
+        backend = await _get_backend(config)
+        records = await backend.run_cypher(
+            f"MATCH (n:Finding {{id: $nid}}) RETURN n.id AS id", {"nid": finding_id}
+        )
+        assert len(records) > 0, f"Finding node {finding_id} missing from graph"
+
+    async def test_consistency_check_sees_new_nodes_in_all_layers(self, tmp_path):
+        """After triple-write, consistency check should report zero drift."""
+        from wheeler.tools.graph_tools import execute_tool, _get_backend
+
+        config = load_config()
+        knowledge_dir = tmp_path / "knowledge"
+        synthesis_dir = tmp_path / "synthesis"
+        knowledge_dir.mkdir()
+        synthesis_dir.mkdir()
+        config.knowledge_path = str(knowledge_dir)
+        config.synthesis_path = str(synthesis_dir)
+
+        # Create a script node via triple-write
+        script_file = tmp_path / "test.py"
+        script_file.write_text("x = 1")
+
+        result_str = await execute_tool(
+            "add_script",
+            {"path": str(script_file), "language": "python", "session_id": "test"},
+            config,
+        )
+        result = json.loads(result_str)
+        script_id = result["node_id"]
+
+        # Run consistency check
+        report = await check_consistency(config)
+
+        # The newly-created node should appear in all three
+        assert report.total_json >= 1
+        assert report.total_synthesis >= 1
+        assert report.total_graph >= 1
+
+        # And it should NOT be in any diff list
+        assert script_id not in report.json_only, (
+            f"New node {script_id} incorrectly reported in json_only; "
+            "triple-write failed"
+        )
+        assert script_id not in report.synthesis_missing, (
+            f"New node {script_id} incorrectly reported in synthesis_missing; "
+            "triple-write incomplete"
+        )
+        assert script_id not in report.graph_only, (
+            f"New node {script_id} incorrectly reported in graph_only; "
+            "graph write failed"
+        )
+
+    async def test_detects_legacy_analysis_nodes(self, tmp_path):
+        """Legacy A-* Analysis JSON files (pre-migration) should be detected as json_only."""
+        from wheeler.config import load_config
+
+        config = load_config()
+        knowledge_dir = tmp_path / "knowledge"
+        synthesis_dir = tmp_path / "synthesis"
+        knowledge_dir.mkdir()
+        synthesis_dir.mkdir()
+        config.knowledge_path = str(knowledge_dir)
+        config.synthesis_path = str(synthesis_dir)
+
+        # Simulate a legacy Analysis JSON file (from before the migration)
+        # This would have type="Analysis" but Analysis no longer exists as a node type
+        legacy_analysis_id = "A-legacy001"
+        legacy_json = {
+            "id": legacy_analysis_id,
+            "type": "Analysis",  # This type no longer exists
+            "script_path": "/some/path/script.py",
+            "created": "2026-01-01T00:00:00+00:00",
+            "updated": "2026-01-01T00:00:00+00:00",
+        }
+        analysis_path = knowledge_dir / f"{legacy_analysis_id}.json"
+        analysis_path.write_text(json.dumps(legacy_json))
+
+        # Run consistency check with mocked backend (graph returns nothing)
+        class FakeBackend:
+            async def run_cypher(self, query, parameters=None):
+                return []  # Graph returns no nodes
+
+            async def initialize(self):
+                pass
+
+        with patch(
+            "wheeler.tools.graph_tools._get_backend",
+            new_callable=AsyncMock,
+            return_value=FakeBackend(),
+        ):
+            report = await check_consistency(config)
+
+        # The legacy Analysis node should be in json_only
+        assert legacy_analysis_id in report.json_only, (
+            "Legacy Analysis node should be detected as json_only "
+            "(exists in JSON but not in graph)"
+        )
+        assert report.total_json >= 1
+        assert report.total_graph == 0
+
+    async def test_provenance_execution_writes_all_layers(self, tmp_path):
+        """When execution_kind is set, the auto-created Execution should reach all layers."""
+        from wheeler.tools.graph_tools import execute_tool
+        from wheeler.knowledge.store import read_node
+        from wheeler.models import ExecutionModel
+
+        config = load_config()
+        knowledge_dir = tmp_path / "knowledge"
+        synthesis_dir = tmp_path / "synthesis"
+        knowledge_dir.mkdir()
+        synthesis_dir.mkdir()
+        config.knowledge_path = str(knowledge_dir)
+        config.synthesis_path = str(synthesis_dir)
+
+        # Add a finding with provenance-completing execution_kind
+        result_str = await execute_tool(
+            "add_finding",
+            {
+                "description": "Result from a script run",
+                "confidence": 0.8,
+                "execution_kind": "script_run",
+                "execution_description": "Ran analysis.py",
+                "session_id": "test-session",
+            },
+            config,
+        )
+        result = json.loads(result_str)
+        assert "error" not in result
+
+        # The provenance entry should include an execution ID
+        prov = result.get("provenance", {})
+        exec_id = prov.get("execution_id")
+        assert exec_id is not None, "No execution_id in provenance response"
+        assert exec_id.startswith("X-"), f"Expected X- prefix for Execution, got {exec_id}"
+
+        # Verify the Execution appears in JSON
+        json_path = knowledge_dir / f"{exec_id}.json"
+        assert json_path.exists(), (
+            f"Execution {exec_id} JSON file missing; "
+            "provenance fan-out did not write JSON"
+        )
+        exec_model = read_node(knowledge_dir, exec_id)
+        assert isinstance(exec_model, ExecutionModel)
+
+        # Verify the Execution appears in synthesis
+        synthesis_path = synthesis_dir / f"{exec_id}.md"
+        assert synthesis_path.exists(), (
+            f"Execution {exec_id} synthesis file missing; "
+            "provenance fan-out incomplete"
+        )
+
+        # Verify the Execution appears in graph
+        from wheeler.tools.graph_tools import _get_backend
+
+        backend = await _get_backend(config)
+        records = await backend.run_cypher(
+            f"MATCH (n:Execution {{id: $nid}}) RETURN n.id AS id", {"nid": exec_id}
+        )
+        assert len(records) > 0, (
+            f"Execution {exec_id} missing from graph; "
+            "provenance fan-out did not create graph node"
+        )

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -394,3 +394,176 @@ class TestRepairConsistency:
         result = await repair_consistency(config, report, dry_run=True)
         assert result["total"] == len(result["actions"])
         assert result["total"] == 5
+
+
+class TestSummarizeDrift:
+    def test_empty_report_is_clean(self):
+        from wheeler.consistency import summarize_drift
+
+        summary = summarize_drift(ConsistencyReport())
+        assert summary["total_divergent"] == 0
+        assert summary["exceeds_threshold"] is False
+        assert "json_only_by_prefix" not in summary
+        assert "graph_only_by_prefix" not in summary
+
+    def test_counts_all_categories(self):
+        from wheeler.consistency import summarize_drift
+
+        report = ConsistencyReport(
+            graph_only=["X-a", "F-b"],
+            json_only=["A-c"],
+            synthesis_missing=["A-c", "W-d"],
+            synthesis_orphaned=["F-e"],
+        )
+        summary = summarize_drift(report)
+        assert summary["graph_only"] == 2
+        assert summary["json_only"] == 1
+        assert summary["synthesis_missing"] == 2
+        assert summary["synthesis_orphaned"] == 1
+        assert summary["total_divergent"] == 6
+
+    def test_threshold_boundary(self):
+        from wheeler.consistency import summarize_drift
+
+        report = ConsistencyReport(json_only=[f"F-{i:04d}" for i in range(10)])
+        assert summarize_drift(report, threshold=10)["exceeds_threshold"] is False
+        report = ConsistencyReport(json_only=[f"F-{i:04d}" for i in range(11)])
+        assert summarize_drift(report, threshold=10)["exceeds_threshold"] is True
+
+    def test_prefix_breakdown_flags_whole_node_class(self):
+        """An entire node class missing from the graph (legacy A-* Analysis
+        files that only exist in JSON) shows up as a single loud prefix count."""
+        from wheeler.consistency import summarize_drift
+
+        report = ConsistencyReport(
+            json_only=[f"A-{i:08x}" for i in range(15)] + ["W-aaaa", "W-bbbb"],
+            graph_only=["X-1111", "X-2222", "F-3333"],
+        )
+        summary = summarize_drift(report)
+        assert summary["json_only_by_prefix"]["A"] == 15
+        assert summary["json_only_by_prefix"]["W"] == 2
+        assert summary["graph_only_by_prefix"]["X"] == 2
+        assert summary["graph_only_by_prefix"]["F"] == 1
+
+    def test_default_threshold_constant(self):
+        from wheeler.consistency import DRIFT_WARNING_THRESHOLD, summarize_drift
+
+        summary = summarize_drift(ConsistencyReport())
+        assert summary["threshold"] == DRIFT_WARNING_THRESHOLD
+
+
+class TestGraphHealthDriftSurfacing:
+    """graph_health surfaces triple-write drift proactively (issue #60)."""
+
+    async def test_warns_when_drift_exceeds_threshold(self):
+        report = ConsistencyReport(
+            json_only=[f"A-{i:08x}" for i in range(20)],
+            total_graph=5,
+            total_json=25,
+            total_synthesis=5,
+        )
+        mock_counts = {"Finding": 5}
+        with patch(
+            "wheeler.mcp_core.schema.get_status",
+            new_callable=AsyncMock,
+            return_value=mock_counts,
+        ), patch(
+            "wheeler.consistency.check_consistency",
+            new_callable=AsyncMock,
+            return_value=report,
+        ):
+            from wheeler.mcp_core import graph_health
+
+            result = await graph_health()
+
+        assert result["status"] == "connected"
+        assert result["drift"]["total_divergent"] == 20
+        assert result["drift"]["exceeds_threshold"] is True
+        assert result["drift"]["json_only_by_prefix"]["A"] == 20
+        assert any("drift" in w.lower() for w in result.get("warnings", []))
+
+    async def test_no_drift_warning_below_threshold(self):
+        report = ConsistencyReport(
+            json_only=["F-aaaa"],
+            total_graph=10,
+            total_json=11,
+            total_synthesis=11,
+        )
+        mock_counts = {"Finding": 10}
+        with patch(
+            "wheeler.mcp_core.schema.get_status",
+            new_callable=AsyncMock,
+            return_value=mock_counts,
+        ), patch(
+            "wheeler.consistency.check_consistency",
+            new_callable=AsyncMock,
+            return_value=report,
+        ):
+            from wheeler.mcp_core import graph_health
+
+            result = await graph_health()
+
+        assert result["status"] == "connected"
+        assert result["drift"]["total_divergent"] == 1
+        assert result["drift"]["exceeds_threshold"] is False
+        assert not any(
+            "drift" in w.lower() for w in result.get("warnings", [])
+        )
+
+    async def test_offline_graph_skips_drift_check(self):
+        mock_counts = {"Finding": 0, "_status": "offline", "_error": "Connection refused"}
+        with patch(
+            "wheeler.mcp_core.schema.get_status",
+            new_callable=AsyncMock,
+            return_value=mock_counts,
+        ):
+            from wheeler.mcp_core import graph_health
+
+            result = await graph_health()
+
+        assert result["status"] == "offline"
+        assert "drift" not in result
+
+    async def test_drift_check_failure_is_nonfatal(self):
+        mock_counts = {"Finding": 3}
+        with patch(
+            "wheeler.mcp_core.schema.get_status",
+            new_callable=AsyncMock,
+            return_value=mock_counts,
+        ), patch(
+            "wheeler.consistency.check_consistency",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("boom"),
+        ):
+            from wheeler.mcp_core import graph_health
+
+            result = await graph_health()
+
+        assert result["status"] == "connected"
+        assert result["drift"] == {"error": "boom"}
+
+
+class TestConsistencyCheckSummary:
+    """graph_consistency_check includes the compact drift summary (issue #60)."""
+
+    async def test_result_includes_summary(self):
+        report = ConsistencyReport(
+            json_only=["A-aaaa"],
+            graph_only=["X-bbbb"],
+            total_graph=2,
+            total_json=2,
+            total_synthesis=1,
+        )
+        with patch(
+            "wheeler.consistency.check_consistency",
+            new_callable=AsyncMock,
+            return_value=report,
+        ):
+            from wheeler.mcp_ops import graph_consistency_check
+
+            result = await graph_consistency_check(repair=False)
+
+        assert result["summary"]["total_divergent"] == 2
+        assert result["summary"]["json_only_by_prefix"] == {"A": 1}
+        assert result["summary"]["graph_only_by_prefix"] == {"X": 1}
+        assert result["summary"]["exceeds_threshold"] is False

--- a/wheeler/consistency.py
+++ b/wheeler/consistency.py
@@ -17,6 +17,9 @@ logger = logging.getLogger(__name__)
 # Synthesis index files that are NOT node files
 _SYNTHESIS_INDEX_FILES = frozenset({"INDEX", "OPEN_QUESTIONS", "EVIDENCE_MAP"})
 
+# Divergent-node count above which routine health checks warn loudly
+DRIFT_WARNING_THRESHOLD = 10
+
 
 @dataclass
 class ConsistencyReport:
@@ -71,6 +74,45 @@ async def check_consistency(config: WheelerConfig) -> ConsistencyReport:
         total_json=len(json_ids),
         total_synthesis=len(synth_ids),
     )
+
+
+def summarize_drift(
+    report: ConsistencyReport,
+    threshold: int = DRIFT_WARNING_THRESHOLD,
+) -> dict:
+    """Compact drift summary for embedding in routine health/status output.
+
+    Counts divergent nodes per category and breaks json_only and graph_only
+    down by node-ID prefix so that an entire missing node class (e.g. all
+    legacy A-* Analysis files present only in JSON) is visible at a glance.
+    """
+    def _by_prefix(ids: list[str]) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for nid in ids:
+            prefix = nid.split("-", 1)[0] if "-" in nid else nid
+            counts[prefix] = counts.get(prefix, 0) + 1
+        return counts
+
+    total_divergent = (
+        len(report.graph_only)
+        + len(report.json_only)
+        + len(report.synthesis_missing)
+        + len(report.synthesis_orphaned)
+    )
+    summary: dict = {
+        "total_divergent": total_divergent,
+        "graph_only": len(report.graph_only),
+        "json_only": len(report.json_only),
+        "synthesis_missing": len(report.synthesis_missing),
+        "synthesis_orphaned": len(report.synthesis_orphaned),
+        "threshold": threshold,
+        "exceeds_threshold": total_divergent > threshold,
+    }
+    if report.json_only:
+        summary["json_only_by_prefix"] = _by_prefix(report.json_only)
+    if report.graph_only:
+        summary["graph_only_by_prefix"] = _by_prefix(report.graph_only)
+    return summary
 
 
 async def repair_consistency(

--- a/wheeler/mcp_core.py
+++ b/wheeler/mcp_core.py
@@ -125,6 +125,25 @@ async def graph_health() -> dict:
         if result["status"] == "connected":
             result["warnings"] = ["knowledge/ directory does not exist -- run /wh:init"]
 
+    # Triple-write drift surfacing: compare graph, JSON, and synthesis
+    # inventories so drift is reported at routine health checks instead
+    # of only on a manual graph_consistency_check.
+    if result["status"] == "connected":
+        try:
+            from wheeler.consistency import check_consistency, summarize_drift
+
+            drift = summarize_drift(await check_consistency(_config))
+            result["drift"] = drift
+            if drift["exceeds_threshold"]:
+                result.setdefault("warnings", []).append(
+                    f"Triple-write drift: {drift['total_divergent']} nodes diverge "
+                    "across graph/JSON/synthesis layers "
+                    f"(threshold {drift['threshold']}). "
+                    "Run graph_consistency_check for details."
+                )
+        except Exception as exc:
+            result["drift"] = {"error": str(exc)}
+
     return result
 
 

--- a/wheeler/mcp_ops.py
+++ b/wheeler/mcp_ops.py
@@ -255,10 +255,11 @@ async def graph_consistency_check(repair: bool = False) -> dict:
     Use during /wh:dream consolidation or /wh:close end-of-session sweep.
     """
     from dataclasses import asdict
-    from wheeler.consistency import check_consistency, repair_consistency
+    from wheeler.consistency import check_consistency, repair_consistency, summarize_drift
 
     report = await check_consistency(_config)
     result = asdict(report)
+    result["summary"] = summarize_drift(report)
 
     if repair:
         repair_log = await repair_consistency(_config, report, dry_run=False)


### PR DESCRIPTION
## Summary
Adds summarize_drift() and DRIFT_WARNING_THRESHOLD to wheeler/consistency.py; graph_health now attaches a drift summary (with per-prefix breakdowns) on every connected health check and warns when divergence exceeds the threshold. graph_consistency_check gains the same summary block. The JSON-only A-* Analysis class was confirmed to be a legacy artifact of the PROV-DM migration; no current write path produces JSON-only nodes.

## Acceptance criteria (verified)
- [x] A-* cause identified (legacy, pre-migration); new Analysis-creating calls reach all three layers via add_script triple-write
- [x] Drift above threshold surfaces automatically in graph_health, not only on manual checks
- [x] Newly-created nodes show reconciled across graph/JSON/synthesis in a fresh check
- [x] No bulk repair, no auto repair=True

## Test results
- Regression test: tests/regression/test_issue_60.py passes (5/5)
- Full suite: 1612 passed, 2 skipped, 0 failures, 0 regressions vs main
- E2E (graph_query): 24/24 assertions against live Neo4j, including a seeded 12-node legacy drift scenario triggering the loud warning

## Verified by
wheeler-issue-cycle, independent Verifier on 2026-06-09.

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)