### PR TITLE
fix: uv tool install update path and statusLine update badge (closes #69, #70)

### DIFF
--- a/tests/regression/test_issue_69.py
+++ b/tests/regression/test_issue_69.py
@@ -1,0 +1,317 @@
+"""Regression test for issue #69: wheeler update fails on uv tool installs.
+
+The update command must detect uv-managed tool installs and use uv to upgrade,
+not pip (which is not available in uv tool venvs).
+
+All tests here assert EXPECTED FIXED behavior. On main (before fix), the
+uv-path tests will FAIL. The pip-path test may PASS as baseline confirmation.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import wheeler
+import wheeler.installer as installer
+
+
+@pytest.fixture()
+def fake_home(tmp_path, monkeypatch):
+    """Override Path.home() to use tmp_path."""
+    home = tmp_path / "home"
+    home.mkdir()
+    claude_dir = home / ".claude"
+    claude_dir.mkdir()
+
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
+    monkeypatch.setattr(installer, "INSTALL_BASE", claude_dir)
+    monkeypatch.setattr(installer, "MANIFEST_PATH", claude_dir / "wheeler-manifest.json")
+    return home
+
+
+def test_detect_install_source_returns_uv_when_executable_is_in_uv_tools_path(monkeypatch):
+    """After fix: _detect_install_source() returns 'uv' when sys.executable is in ~/.local/share/uv/tools/.
+
+    This is the primary signal for a uv tool install. When the Python executable
+    is at ~/.local/share/uv/tools/wheeler/bin/python, the installer knows to use
+    'uv tool upgrade'.
+
+    Expected behavior after fix: returns 'uv'
+    Current behavior on main: returns 'github' (FAIL)
+    """
+    # Simulate sys.executable pointing to a uv tool venv
+    uv_tool_python = Path.home() / ".local" / "share" / "uv" / "tools" / "wheeler" / "bin" / "python"
+
+    monkeypatch.setattr(sys, "executable", str(uv_tool_python))
+
+    # Mock subprocess.run so pip show doesn't actually run
+    def fake_run(cmd, *args, **kwargs):
+        result = MagicMock()
+        result.returncode = 1
+        result.stdout = ""
+        return result
+
+    monkeypatch.setattr(installer.subprocess, "run", fake_run)
+
+    # After fix, should detect uv from the executable path
+    detected = installer._detect_install_source()
+    assert detected == "uv", (
+        f"Expected 'uv' but got '{detected}'. "
+        f"sys.executable={sys.executable} should signal uv tool install."
+    )
+
+
+def test_detect_install_source_returns_uv_when_pip_unavailable_and_uv_available(monkeypatch):
+    """After fix: _detect_install_source() returns 'uv' when pip fails and uv is on PATH.
+
+    When pip is not available (pip show fails) but 'uv' command is available on
+    the system PATH, the installer should infer a uv tool install and return 'uv'.
+
+    Expected behavior after fix: returns 'uv'
+    Current behavior on main: returns 'github' (FAIL)
+    """
+    call_log = []
+
+    def fake_run(cmd, *args, **kwargs):
+        call_log.append(cmd)
+        if isinstance(cmd, list):
+            cmd_str = " ".join(str(c) for c in cmd)
+        else:
+            cmd_str = str(cmd)
+
+        # pip show fails (pip not available in uv tool venv)
+        if "pip" in cmd_str and "show" in cmd_str:
+            result = MagicMock()
+            result.returncode = 1
+            result.stdout = ""
+            return result
+
+        result = MagicMock()
+        result.returncode = 0
+        return result
+
+    monkeypatch.setattr(installer.subprocess, "run", fake_run)
+
+    # Mock shutil.which to report uv is available
+    def fake_which(cmd):
+        if cmd == "uv":
+            return "/usr/local/bin/uv"
+        return None
+
+    monkeypatch.setattr(installer.shutil, "which", fake_which)
+
+    # After fix: should detect uv when pip fails but uv is available
+    detected = installer._detect_install_source()
+    assert detected == "uv", (
+        f"Expected 'uv' but got '{detected}'. "
+        f"When pip unavailable but uv available, should return 'uv'."
+    )
+
+
+def test_update_with_uv_source_uses_uv_tool_upgrade(monkeypatch, fake_home):
+    """After fix: update(source='uv') runs 'uv tool upgrade wheeler' via subprocess.
+
+    When the installer detects or is told source='uv', it must invoke
+    'uv tool upgrade wheeler', NOT 'python -m pip install'.
+
+    This test captures the subprocess call log and verifies the correct command
+    is used for uv-managed installs.
+
+    Expected: calls uv tool upgrade, does NOT call python -m pip
+    Current on main: pip path will be taken, subprocess.CalledProcessError raised (FAIL)
+    """
+    call_log = []
+
+    def fake_run(cmd, *args, **kwargs):
+        call_log.append(cmd)
+
+        if isinstance(cmd, list):
+            cmd_str = " ".join(str(c) for c in cmd)
+        else:
+            cmd_str = str(cmd)
+
+        # uv tool upgrade should succeed
+        if "uv" in cmd_str and "tool" in cmd_str and "upgrade" in cmd_str:
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        # If pip is invoked, that's wrong for uv path
+        if "pip" in cmd_str and "install" in cmd_str:
+            raise subprocess.CalledProcessError(1, cmd)
+
+        result = MagicMock()
+        result.returncode = 0
+        return result
+
+    monkeypatch.setattr(installer.subprocess, "run", fake_run)
+
+    # Create minimal manifest
+    manifest_path = fake_home / ".claude" / "wheeler-manifest.json"
+    manifest_path.write_text(json.dumps({"version": "0.9.1", "files": {}}))
+
+    with patch.object(installer, "install"):
+        # After fix: this should succeed
+        result = installer.update(source="uv")
+
+    # Verify the call log contains uv tool upgrade, not pip
+    uv_calls = [c for c in call_log if isinstance(c, list) and "uv" in str(c)]
+    pip_calls = [c for c in call_log if isinstance(c, list) and "pip" in str(c) and "install" in str(c)]
+
+    assert len(uv_calls) > 0, (
+        f"Expected 'uv tool upgrade' call in subprocess log, but got none. "
+        f"Call log: {call_log}"
+    )
+    assert len(pip_calls) == 0, (
+        f"Expected NO pip install calls for source='uv', but got {len(pip_calls)}. "
+        f"Call log: {call_log}"
+    )
+
+
+def test_update_with_github_source_uses_pip_unchanged(monkeypatch, fake_home):
+    """Baseline: update(source='github') still uses pip for traditional installs.
+
+    This test confirms that pip-based upgrade paths are NOT broken by the fix.
+    When pip IS available and source='github' or source='pypi', the code should
+    continue to use pip as before.
+
+    Expected: calls python -m pip install --upgrade
+    This test may PASS on main (baseline) and should still PASS after fix.
+    """
+    call_log = []
+
+    def fake_run(cmd, *args, **kwargs):
+        call_log.append(cmd)
+
+        if isinstance(cmd, list):
+            cmd_str = " ".join(str(c) for c in cmd)
+        else:
+            cmd_str = str(cmd)
+
+        # pip show succeeds (normal pip install)
+        if "pip" in cmd_str and "show" in cmd_str:
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "Name: wheeler\nLocation: /usr/lib/python3/site-packages\n"
+            return result
+
+        # pip install --upgrade succeeds
+        if "pip" in cmd_str and "install" in cmd_str and "upgrade" in cmd_str:
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        result = MagicMock()
+        result.returncode = 0
+        return result
+
+    monkeypatch.setattr(installer.subprocess, "run", fake_run)
+
+    # Create minimal manifest
+    manifest_path = fake_home / ".claude" / "wheeler-manifest.json"
+    manifest_path.write_text(json.dumps({"version": "0.9.1", "files": {}}))
+
+    with patch.object(installer, "install"):
+        # Should succeed using pip
+        result = installer.update(source="github")
+
+    # Verify pip install --upgrade was called
+    pip_upgrade_calls = [
+        c for c in call_log
+        if isinstance(c, list) and "pip" in str(c) and "upgrade" in str(c)
+    ]
+
+    assert len(pip_upgrade_calls) > 0, (
+        f"Expected 'pip install --upgrade' call for source='github', but got none. "
+        f"Call log: {call_log}"
+    )
+
+
+def test_issue_69_end_to_end_uv_scenario(monkeypatch, fake_home):
+    """Integration test: reproduce the exact scenario from issue #69.
+
+    Setup: Python is in a uv tool venv (no pip), uv is available on PATH.
+    Action: Call update() with auto-detection.
+    Expected after fix:
+      - _detect_install_source() returns 'uv'
+      - update() calls 'uv tool upgrade wheeler' (not pip)
+      - No CalledProcessError is raised
+      - Version is reloaded and returned
+
+    Current on main: FAILS with CalledProcessError("No module named pip")
+    """
+    call_log = []
+
+    # Simulate sys.executable in uv tool venv
+    uv_tool_python = Path.home() / ".local" / "share" / "uv" / "tools" / "wheeler" / "bin" / "python"
+    monkeypatch.setattr(sys, "executable", str(uv_tool_python))
+
+    def fake_run(cmd, *args, **kwargs):
+        call_log.append(cmd)
+
+        if isinstance(cmd, list):
+            cmd_str = " ".join(str(c) for c in cmd)
+        else:
+            cmd_str = str(cmd)
+
+        # pip show fails (no pip in uv tool venv)
+        if "pip" in cmd_str and "show" in cmd_str:
+            result = MagicMock()
+            result.returncode = 1
+            return result
+
+        # uv tool upgrade succeeds
+        if "uv" in cmd_str and "tool" in cmd_str and "upgrade" in cmd_str:
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        # If pip install is called, that's the bug
+        if "pip" in cmd_str and "install" in cmd_str:
+            raise subprocess.CalledProcessError(
+                1,
+                cmd,
+                output="No module named pip"
+            )
+
+        result = MagicMock()
+        result.returncode = 0
+        return result
+
+    monkeypatch.setattr(installer.subprocess, "run", fake_run)
+
+    # Mock shutil.which to report uv is available
+    def fake_which(cmd):
+        if cmd == "uv":
+            return "/usr/local/bin/uv"
+        return None
+
+    monkeypatch.setattr(installer.shutil, "which", fake_which)
+
+    # Create minimal manifest
+    manifest_path = fake_home / ".claude" / "wheeler-manifest.json"
+    manifest_path.write_text(json.dumps({"version": "0.9.1", "files": {}}))
+
+    with patch.object(installer, "install"):
+        # After fix: should succeed without raising CalledProcessError
+        result = installer.update()  # Auto-detect should find 'uv'
+
+    # Verify uv was used, not pip
+    uv_calls = [c for c in call_log if isinstance(c, list) and "uv" in str(c)]
+    pip_install_calls = [
+        c for c in call_log
+        if isinstance(c, list) and "pip" in str(c) and "install" in str(c)
+    ]
+
+    assert len(uv_calls) > 0, (
+        f"Expected 'uv tool upgrade' but got call log: {call_log}"
+    )
+    assert len(pip_install_calls) == 0, (
+        f"Expected NO 'pip install' for uv scenario, but got: {pip_install_calls}"
+    )

--- a/tests/regression/test_issue_70.py
+++ b/tests/regression/test_issue_70.py
@@ -1,0 +1,218 @@
+"""Regression test for issue #70: update badge never appears.
+
+Issue: The version-check cache correctly records update_available: true,
+but the update badge is never displayed to the user because the statusLine
+hook (wheeler-statusline.js) is never registered in ~/.claude/settings.json.
+
+This test verifies that:
+1. The install() function copies both wheeler-check-update.js and wheeler-statusline.js
+2. The _register_hooks() function registers the SessionStart hook for check-update
+3. The _register_hooks() function registers the statusLine hook for statusline
+4. When update_available is true in the cache, the statusline hook can read it
+5. Both hooks are present in settings.json after installation
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import wheeler.installer as installer
+
+
+@pytest.fixture()
+def fake_home(tmp_path, monkeypatch):
+    """Override Path.home() and INSTALL_BASE/MANIFEST_PATH to use tmp_path."""
+    home = tmp_path / "home"
+    home.mkdir()
+    claude_dir = home / ".claude"
+    claude_dir.mkdir()
+
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
+    monkeypatch.setattr(installer, "INSTALL_BASE", claude_dir)
+    monkeypatch.setattr(installer, "MANIFEST_PATH", claude_dir / "wheeler-manifest.json")
+    return home
+
+
+@pytest.fixture()
+def fake_data(tmp_path):
+    """Create a fake _data/ directory with both hook files."""
+    data = tmp_path / "_data"
+    hooks = data / "hooks"
+    hooks.mkdir(parents=True)
+
+    # Create both hook files
+    (hooks / "wheeler-check-update.js").write_text("// check-update hook")
+    (hooks / "wheeler-statusline.js").write_text("// statusline hook")
+
+    return data
+
+
+def test_install_copies_both_hooks(fake_home, fake_data, monkeypatch):
+    """Verify both hook files are copied during installation."""
+    monkeypatch.setattr(installer, "_get_data_path", lambda: fake_data)
+
+    files = installer.install()
+
+    # Both hooks should be copied
+    check_update_path = fake_home / ".claude" / "hooks" / "wheeler-check-update.js"
+    statusline_path = fake_home / ".claude" / "hooks" / "wheeler-statusline.js"
+
+    assert check_update_path.exists(), "wheeler-check-update.js should be copied"
+    assert statusline_path.exists(), "wheeler-statusline.js should be copied"
+
+    # Both should be in the returned manifest
+    assert any("wheeler-check-update" in k for k in files.keys()), (
+        "Manifest should include wheeler-check-update hook"
+    )
+    assert any("wheeler-statusline" in k for k in files.keys()), (
+        "Manifest should include wheeler-statusline hook"
+    )
+
+
+def test_session_start_hook_registered(fake_home, fake_data, monkeypatch):
+    """Verify SessionStart hook is registered in settings.json."""
+    monkeypatch.setattr(installer, "_get_data_path", lambda: fake_data)
+
+    installer.install()
+
+    settings_path = fake_home / ".claude" / "settings.json"
+    assert settings_path.exists(), "settings.json should be created"
+
+    settings = json.loads(settings_path.read_text())
+    hooks = settings.get("hooks", {})
+    session_start = hooks.get("SessionStart", [])
+
+    # SessionStart should have at least one entry with wheeler-check-update
+    assert len(session_start) > 0, "SessionStart hooks should be registered"
+    assert any(
+        "wheeler-check-update" in h.get("command", "")
+        for entry in session_start
+        for h in entry.get("hooks", [])
+    ), "wheeler-check-update should be in SessionStart hooks"
+
+
+def test_statusline_hook_registered(fake_home, fake_data, monkeypatch):
+    """Verify the statusLine command is registered in settings.json.
+
+    This is the critical test for issue #70: the statusLine command must be
+    registered so that the update badge can be displayed to the user.
+
+    Note: in Claude Code's settings schema, statusLine is a TOP-LEVEL
+    settings key with shape {"type": "command", "command": "..."}. It is
+    NOT an entry under the "hooks" object. Registering it under "hooks"
+    would never be read by Claude Code, so this test asserts the top-level
+    location.
+    """
+    monkeypatch.setattr(installer, "_get_data_path", lambda: fake_data)
+
+    installer.install()
+
+    settings_path = fake_home / ".claude" / "settings.json"
+    assert settings_path.exists(), "settings.json should be created"
+
+    settings = json.loads(settings_path.read_text())
+
+    # The statusLine command MUST be registered at the top level
+    statusline = settings.get("statusLine")
+    assert statusline is not None, (
+        "statusLine hook should be registered in settings.json after install(). "
+        "This is the root cause of issue #70: the cache is written but never read "
+        "because the statusline hook is never registered."
+    )
+    assert isinstance(statusline, dict), "statusLine should be a dict"
+
+    # Should contain a command that references wheeler-statusline.js
+    command = statusline.get("command", "")
+    assert "wheeler-statusline" in command or isinstance(statusline.get("type"), str), (
+        f"statusLine command should reference wheeler-statusline.js, got: {statusline}"
+    )
+
+
+def test_statusline_reads_update_cache():
+    """Verify the statusline hook logic can read update_available from cache.
+
+    This is a conceptual test showing that IF the statusLine hook were
+    registered, it would correctly read the update_available flag.
+    """
+    # Simulate what wheeler-statusline.js does
+    cache_data = {
+        "update_available": True,
+        "installed": "0.9.1",
+        "latest": "0.9.8",
+        "checked": 1781118722,
+    }
+
+    # The statusline script checks: if cache.update_available then show badge
+    assert cache_data["update_available"] is True, (
+        "Cache indicates update is available"
+    )
+    assert cache_data["latest"] != cache_data["installed"], (
+        "Versions differ, update is needed"
+    )
+
+
+def test_uninstall_removes_both_hooks(fake_home, fake_data, monkeypatch):
+    """Verify both hooks are removed during uninstallation."""
+    monkeypatch.setattr(installer, "_get_data_path", lambda: fake_data)
+
+    # Install first
+    installer.install()
+
+    check_update_path = fake_home / ".claude" / "hooks" / "wheeler-check-update.js"
+    statusline_path = fake_home / ".claude" / "hooks" / "wheeler-statusline.js"
+
+    assert check_update_path.exists()
+    assert statusline_path.exists()
+
+    # Now uninstall
+    installer.uninstall()
+
+    assert not check_update_path.exists(), "wheeler-check-update.js should be removed"
+    assert not statusline_path.exists(), "wheeler-statusline.js should be removed"
+
+
+def test_statusline_registration_preserves_existing_hooks(fake_home, fake_data, monkeypatch):
+    """Verify registration doesn't overwrite existing hooks (e.g., from GSD)."""
+    monkeypatch.setattr(installer, "_get_data_path", lambda: fake_data)
+
+    settings_path = fake_home / ".claude" / "settings.json"
+
+    # Pre-populate with an existing hook (simulating GSD)
+    existing_settings = {
+        "hooks": {
+            "SessionStart": [
+                {
+                    "hooks": [
+                        {"type": "command", "command": "node /gsd-check-update.js"}
+                    ]
+                }
+            ]
+        }
+    }
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text(json.dumps(existing_settings, indent=2) + "\n")
+
+    # Install Wheeler
+    installer.install()
+
+    # Both Wheeler and GSD hooks should be present
+    settings = json.loads(settings_path.read_text())
+    session_start = settings.get("hooks", {}).get("SessionStart", [])
+
+    gsd_found = any(
+        "gsd-check-update" in h.get("command", "")
+        for entry in session_start
+        for h in entry.get("hooks", [])
+    )
+    wheeler_found = any(
+        "wheeler-check-update" in h.get("command", "")
+        for entry in session_start
+        for h in entry.get("hooks", [])
+    )
+
+    assert gsd_found, "Existing GSD hook should be preserved"
+    assert wheeler_found, "Wheeler check-update hook should be added"

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -336,6 +336,59 @@ def test_uninstall_removes_hook_files(fake_home, fake_data, monkeypatch):
     assert not (fake_home / ".claude" / "hooks" / "wheeler-statusline.js").exists()
 
 
+def test_install_registers_statusline(fake_home, fake_data, monkeypatch):
+    """install() registers the top-level statusLine command."""
+    monkeypatch.setattr(installer, "_get_data_path", lambda: fake_data)
+
+    installer.install()
+
+    settings = json.loads((fake_home / ".claude" / "settings.json").read_text())
+    statusline = settings.get("statusLine")
+    assert isinstance(statusline, dict)
+    assert statusline.get("type") == "command"
+    assert "wheeler-statusline" in statusline.get("command", "")
+
+
+def test_install_preserves_custom_statusline(fake_home, fake_data, monkeypatch):
+    """A pre-existing non-Wheeler statusLine must not be overwritten."""
+    monkeypatch.setattr(installer, "_get_data_path", lambda: fake_data)
+
+    settings_path = fake_home / ".claude" / "settings.json"
+    custom = {"type": "command", "command": "node my-custom-statusline.js"}
+    settings_path.write_text(json.dumps({"statusLine": custom}))
+
+    installer.install()
+
+    settings = json.loads(settings_path.read_text())
+    assert settings["statusLine"] == custom
+
+
+def test_uninstall_deregisters_statusline(fake_home, fake_data, monkeypatch):
+    """uninstall() removes the Wheeler-owned statusLine entry."""
+    monkeypatch.setattr(installer, "_get_data_path", lambda: fake_data)
+
+    installer.install()
+    installer.uninstall()
+
+    settings = json.loads((fake_home / ".claude" / "settings.json").read_text())
+    assert "statusLine" not in settings
+
+
+def test_uninstall_preserves_custom_statusline(fake_home, fake_data, monkeypatch):
+    """uninstall() leaves a non-Wheeler statusLine in place."""
+    monkeypatch.setattr(installer, "_get_data_path", lambda: fake_data)
+
+    settings_path = fake_home / ".claude" / "settings.json"
+    custom = {"type": "command", "command": "node my-custom-statusline.js"}
+    settings_path.write_text(json.dumps({"statusLine": custom}))
+
+    installer.install()
+    installer.uninstall()
+
+    settings = json.loads(settings_path.read_text())
+    assert settings.get("statusLine") == custom
+
+
 def test_register_hooks_malformed_settings(fake_home, monkeypatch):
     """Malformed settings.json should be replaced cleanly."""
     settings_path = fake_home / ".claude" / "settings.json"

--- a/wheeler/installer.py
+++ b/wheeler/installer.py
@@ -44,7 +44,8 @@ def install(link: bool = False) -> dict[str, str]:
 
     Installs commands, agents, and hooks. Registers the SessionStart
     hook in ~/.claude/settings.json so the update checker runs on
-    every session.
+    every session, and the statusLine command so the update badge
+    is rendered when an update is available.
 
     Args:
         link: If True, create symlinks instead of copies.
@@ -88,7 +89,10 @@ def _register_hooks() -> None:
     """Register Wheeler hooks in ~/.claude/settings.json.
 
     Adds the SessionStart hook for update checking without
-    overwriting existing hooks from other tools (e.g. GSD).
+    overwriting existing hooks from other tools (e.g. GSD), and
+    registers the top-level statusLine command that renders the
+    update badge. A pre-existing non-Wheeler statusLine is left
+    untouched.
     """
     settings_path = INSTALL_BASE / "settings.json"
     if settings_path.exists():
@@ -119,6 +123,20 @@ def _register_hooks() -> None:
         session_start.append({
             "hooks": [{"type": "command", "command": hook_command}]
         })
+
+    # statusLine is a top-level settings key in Claude Code (not part of
+    # the hooks object). It renders the update badge from the version
+    # cache. Never clobber a custom statusLine the user already set.
+    statusline_path = str(INSTALL_BASE / HOOKS_REL / "wheeler-statusline.js")
+    statusline_command = f'node "{statusline_path}"'
+    existing_statusline = settings.get("statusLine")
+    if existing_statusline is None:
+        settings["statusLine"] = {"type": "command", "command": statusline_command}
+    elif (
+        isinstance(existing_statusline, dict)
+        and "wheeler-statusline" in existing_statusline.get("command", "")
+    ):
+        existing_statusline["command"] = statusline_command
 
     settings_path.write_text(json.dumps(settings, indent=2) + "\n")
 
@@ -168,8 +186,21 @@ def _deregister_hooks() -> None:
         )
     ]
 
+    changed = False
     if len(filtered) != len(session_start):
         hooks["SessionStart"] = filtered
+        changed = True
+
+    # Remove the statusLine only if it is the Wheeler-owned one
+    statusline = settings.get("statusLine")
+    if (
+        isinstance(statusline, dict)
+        and "wheeler-statusline" in statusline.get("command", "")
+    ):
+        del settings["statusLine"]
+        changed = True
+
+    if changed:
         settings_path.write_text(json.dumps(settings, indent=2) + "\n")
 
 

--- a/wheeler/installer.py
+++ b/wheeler/installer.py
@@ -247,12 +247,33 @@ def _deregister_mcp_servers() -> None:
         settings_path.write_text(json.dumps(settings, indent=2) + "\n")
 
 
+def _is_uv_tool_install() -> bool:
+    """Best-effort check for a working uv when pip is unavailable.
+
+    A venv without pip is almost always uv-managed; confirm uv is on
+    PATH and responds before routing the upgrade through it.
+    """
+    if shutil.which("uv") is None:
+        return False
+    probe = subprocess.run(
+        ["uv", "tool", "list"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return probe.returncode == 0
+
+
 def _detect_install_source() -> str:
     """Detect how wheeler was installed.
 
     Returns:
-        "editable" | "github" | "pypi"
+        "editable" | "uv" | "github" | "pypi"
     """
+    exe_parts = Path(sys.executable).parts
+    for i in range(len(exe_parts) - 1):
+        if exe_parts[i] == "uv" and exe_parts[i + 1] == "tools":
+            return "uv"
     try:
         result = subprocess.run(
             [sys.executable, "-m", "pip", "show", "wheeler"],
@@ -266,6 +287,8 @@ def _detect_install_source() -> str:
                     return "editable"
                 if line.startswith("Location:") and "site-packages" not in line:
                     return "editable"
+        elif _is_uv_tool_install():
+            return "uv"
     except Exception:
         pass
     return "github"
@@ -275,7 +298,7 @@ def update(source: str | None = None) -> str:
     """Backup local mods, upgrade wheeler, then reinstall files.
 
     Args:
-        source: Force install source ("pypi", "github", or "editable").
+        source: Force install source ("pypi", "github", "editable", or "uv").
                 Auto-detected if None.
 
     Returns:
@@ -298,6 +321,13 @@ def update(source: str | None = None) -> str:
         )
         subprocess.run(
             [sys.executable, "-m", "pip", "install", "-e", str(repo_root)],
+            check=True,
+        )
+    elif source == "uv":
+        # uv tool venvs ship without pip; uv reinstalls from the
+        # original spec (git or PyPI) on upgrade.
+        subprocess.run(
+            ["uv", "tool", "upgrade", "wheeler"],
             check=True,
         )
     elif source == "github":

--- a/wheeler/tools/cli.py
+++ b/wheeler/tools/cli.py
@@ -553,11 +553,11 @@ def cmd_update(
         None,
         "--source",
         "-s",
-        help="Install source: pypi, github, or editable (auto-detected if omitted)",
+        help="Install source: pypi, github, editable, or uv (auto-detected if omitted)",
     ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
 ) -> None:
-    """Upgrade Wheeler via pip and reinstall files."""
+    """Upgrade Wheeler (pip or uv, per install source) and reinstall files."""
     import wheeler
     from wheeler.installer import (
         _detect_install_source,
@@ -604,7 +604,7 @@ def cmd_update(
             f"[green]Updated: {old_version} → {new_version}[/green]"
         )
     except subprocess.CalledProcessError as exc:
-        console.print(f"[red]pip upgrade failed:[/red] {exc}")
+        console.print(f"[red]Upgrade failed:[/red] {exc}")
         raise typer.Exit(1)
     except Exception as exc:
         console.print(f"[red]Update failed:[/red] {exc}")


### PR DESCRIPTION
## Summary

Two related fixes to the update path in wheeler/installer.py:

- Issue #69: `wheeler update` now detects uv tool installs (executable under a `uv/tools/` path, or pip unavailable while a working `uv` is on PATH) and upgrades via `uv tool upgrade wheeler` instead of shelling out to the missing pip. pip and editable paths are byte-identical to before.
- Issue #70: `installer.install()` now registers the `wheeler-statusline.js` hook as the TOP-LEVEL `statusLine` key in `~/.claude/settings.json` (the correct Claude Code schema, not `hooks.statusLine`), so the update badge actually renders. A pre-existing custom statusLine is never clobbered; uninstall removes only the Wheeler-owned entry.

## Why this is a draft

Independent verification returned PASS on every gate for #69, and PARTIAL for #70 on one criterion: "a failed network check falls back to the cached flag rather than showing nothing." The badge render path is cache-only and never blanks on network failure, but the PRE-EXISTING background checkers (`wheeler-check-update.js` line 103 and `installer.py` check_version) write `update_available: false` when the network is unreachable, clobbering a previously cached `true`. That behavior predates this branch and the issue's scope boundary excludes changing the check logic, so the cycle did not extend the fix autonomously.

Reviewer decision: merge as-is (the surfacing bug, which is what #70 reports, is fixed), or ask for a one-line extension so the checkers keep the previous cache value when `latest` cannot be determined.

## Acceptance criteria (verified independently)

Issue #69:
- [x] update succeeds on uv tool installs (no pip): E2E subprocess run of the CLI with a stub uv on PATH and isolated HOME exited 0, called exactly `uv tool upgrade wheeler`, zero pip calls
- [x] uv-managed install detected and routed: detection at installer.py:309-322, both detection regression tests pass
- [x] version transition reported: "Updated: old -> new" line renders on the uv path
- [x] pip-based installs unchanged: github/pypi subprocess invocations byte-identical to main; baseline regression test passes
- [x] existing tests pass: full suite 1664 passed, 2 skipped, 0 regressions vs main

Issue #70:
- [x] badge appears when cache has update_available true: after real `wheeler install` in sandboxed HOME, settings.json has top-level statusLine; running the installed script under node printed the yellow badge
- [x] badge references how to update: output contains "/wh:update"
- [x] badge clears after successful update: update() unlinks the version cache; E2E confirmed badge gone after flip and after unlink
- [ ] offline check falls back to cached flag: PARTIAL, see "Why this is a draft" above

## Test results

- Regression tests: tests/regression/test_issue_69.py (5 tests) and test_issue_70.py pass at HEAD; key tests fail on main, confirming they exercise the fixes
- Full suite: 1664 passed, 2 skipped, 0 failures, 0 regressions vs main (both verifiers ran it independently)
- E2E (cli): pass for both issues; real subprocess invocations with sandboxed HOME, stub uv, node-rendered statusline, install/uninstall round-trip including custom-statusLine preservation
- Note: the test_issue_70.py assertion was corrected from `hooks.statusLine` to top-level `statusLine` (the Reproducer's guess encoded the wrong settings schema); documented in the commit body

## Verified by

wheeler-issue-cycle, two independent Verifiers (one per issue) on 2026-06-11.

Closes #69
Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)