### PR TITLE
Asta input-side provenance: Execution USED the graph inputs the request was built from

### DIFF
--- a/.claude/commands/wh/asta-lit.md
+++ b/.claude/commands/wh/asta-lit.md
@@ -38,10 +38,10 @@ If the command exits non-zero, report the failure and stop. A failed run writes 
 Marshal the artifact into the graph with the single integrate verb:
 
 ```
-wheeler integrate ingest paper_finder /tmp/asta-paper-finder.json --link-to <Q- or PL- id>
+wheeler integrate ingest paper_finder /tmp/asta-paper-finder.json --link-to <Q- or PL- id> --used <Q- or PL- id>
 ```
 
-Omit `--link-to` if there is no target. The verb is idempotent: re-running the same artifact creates no duplicate papers or edges (dedupe is on `corpus_id`, edges are guarded by `link_once`).
+Omit `--link-to` if there is no target. Pass `--used` with the graph node ids the request was built from (at minimum the link target, the `Q-`/`PL-` that motivated the search): this records `Execution -[USED]-> each input` (input-side provenance), so every result traces back to the graph context that shaped the query, not just the literature returned. Omit `--used` if there were no graph inputs. The verb is idempotent: re-running the same artifact creates no duplicate papers, edges, or USED edges (dedupe is on `corpus_id`, edges are guarded by `link_once`).
 
 ## Report
 

--- a/.claude/commands/wh/asta-scholar.md
+++ b/.claude/commands/wh/asta-scholar.md
@@ -31,7 +31,7 @@ Semantic Scholar has four sub-queries. The ingest auto-detects which one from th
 
 ## Choose the sub-query, run it, and ingest
 
-Pick at most one link target: the Question (`Q-...`) or Plan (`PL-...`) this query supports. Each relevant result links `RELEVANT_TO` that node. Omit `--link-to` if there is no clear target. The verb is idempotent: re-running the same artifact creates no duplicate papers, findings, or edges (papers dedupe on `corpus_id`, snippet findings on a content hash, edges are guarded by `link_once`).
+Pick at most one link target: the Question (`Q-...`) or Plan (`PL-...`) this query supports. Each relevant result links `RELEVANT_TO` that node. Omit `--link-to` if there is no clear target. Pass `--used` with the graph node ids the query was built from (at minimum the link target, the `Q-`/`PL-` that motivated it): this records `Execution -[USED]-> each input` (input-side provenance), so every result traces back to the graph context that shaped the query. Omit `--used` if there were no graph inputs. The verb is idempotent: re-running the same artifact creates no duplicate papers, findings, edges, or USED edges (papers dedupe on `corpus_id`, snippet findings on a content hash, edges are guarded by `link_once`).
 
 ### Citations (build the citation graph)
 
@@ -39,28 +39,28 @@ The TARGET paper being cited is the CLI argument, NOT in the output. Pass it to 
 
 ```
 asta papers citations <paperId-or-DOI> --fields corpusId,title,authors,year,venue,citationCount --limit <N> > /tmp/asta-s2.json
-wheeler integrate ingest semantic_scholar /tmp/asta-s2.json --target <corpus_id-or-P-id> --link-to <Q- or PL- id>
+wheeler integrate ingest semantic_scholar /tmp/asta-s2.json --target <corpus_id-or-P-id> --link-to <Q- or PL- id> --used <Q- or PL- id>
 ```
 
 ### Search
 
 ```
 asta papers search "<query>" --fields corpusId,title,authors,year,venue,citationCount --limit <N> > /tmp/asta-s2.json
-wheeler integrate ingest semantic_scholar /tmp/asta-s2.json --link-to <Q- or PL- id>
+wheeler integrate ingest semantic_scholar /tmp/asta-s2.json --link-to <Q- or PL- id> --used <Q- or PL- id>
 ```
 
 ### Get one paper
 
 ```
 asta papers get <paperId-or-DOI> --fields corpusId,externalIds,title,authors,year,venue,citationCount,openAccessPdf,abstract > /tmp/asta-s2.json
-wheeler integrate ingest semantic_scholar /tmp/asta-s2.json --link-to <Q- or PL- id>
+wheeler integrate ingest semantic_scholar /tmp/asta-s2.json --link-to <Q- or PL- id> --used <Q- or PL- id>
 ```
 
 ### Snippet search
 
 ```
 asta papers snippet "<query>" --fields corpusId,title,authors --limit <N> > /tmp/asta-s2.json
-wheeler integrate ingest semantic_scholar /tmp/asta-s2.json --link-to <Q- or PL- id>
+wheeler integrate ingest semantic_scholar /tmp/asta-s2.json --link-to <Q- or PL- id> --used <Q- or PL- id>
 ```
 
 If any CLI command exits non-zero, report the failure and stop. A failed run writes nothing to the graph by design. The short alias `s2` works in place of `semantic_scholar`.

--- a/.claude/commands/wh/asta-theorize.md
+++ b/.claude/commands/wh/asta-theorize.md
@@ -39,10 +39,10 @@ If the command exits non-zero (including a login or auth failure), report it and
 Marshal the artifact into the graph with the single integrate verb:
 
 ```
-wheeler integrate ingest theorizer /tmp/asta-theorizer.json --link-to <Q- or PL- id>
+wheeler integrate ingest theorizer /tmp/asta-theorizer.json --link-to <Q- or PL- id> --used <Q- or PL- id>,<F-... seeded Finding ids>
 ```
 
-Omit `--link-to` if there is no target. The verb is idempotent: re-running the same artifact creates no duplicate theories, law hypotheses, papers, or edges. Each theory becomes a parent Finding (`artifact_type=theory`); each law becomes a Hypothesis the parent `CONTAINS`; supporting papers link `SUPPORTS` and contradicting papers link `CONTRADICTS` each law Hypothesis. The novelty verdict (established, derivable, new) is parked as `custom_novelty` on each Hypothesis, never in its `status`.
+Omit `--link-to` if there is no target. Pass `--used` with the graph node ids the request was built from: the link target (the `Q-`/`PL-` that motivated the run) AND every Finding id you seeded into the Theorizer extraction payload (the existing results that shaped the theory generation), comma-separated. This records `Execution -[USED]-> each input` (input-side provenance), so every generated theory traces back to the exact graph context it was built from, not just the literature support. Omit `--used` if there were no graph inputs. The verb is idempotent: re-running the same artifact creates no duplicate theories, law hypotheses, papers, edges, or USED edges. Each theory becomes a parent Finding (`artifact_type=theory`); each law becomes a Hypothesis the parent `CONTAINS`; supporting papers link `SUPPORTS` and contradicting papers link `CONTRADICTS` each law Hypothesis. The novelty verdict (established, derivable, new) is parked as `custom_novelty` on each Hypothesis, never in its `status`.
 
 ## Report
 

--- a/docs/asta-engine-spec.md
+++ b/docs/asta-engine-spec.md
@@ -1,0 +1,91 @@
+# Asta -> Wheeler engine spec: input-side provenance, service registry, skill-creator
+
+Status 2026-06-15. Implementation spec. Three pieces, built in this order:
+1. Input-side provenance (most important, concrete, build first).
+2. The service registry / engine (light, contract + manifest + loader).
+3. The skill-creator skill (scaffold an adapter from a contract).
+
+The unifying idea: a tool is a declarative CONTRACT (one manifest entry); a command opts
+in via a flag; a run is a step whose provenance reaches BACK to its graph inputs (USED) and
+FORWARD to its graph outputs (WAS_GENERATED_BY). Asta is instance #1.
+
+## 1. Input-side provenance (BUILD FIRST)
+
+The marshal-in synthesizes the tool payload FROM graph nodes (the question, the Findings
+seeded into Theorizer extraction_results, the gap that shaped the query, the Dataset paths
+handed to DataVoyager). That synthesis is a provenance relationship: the run USED those nodes.
+
+Record:
+- `Execution -[USED]-> each graph node the marshal-in consumed` (link_once, existence-guarded).
+- The chain is then complete and transitive without per-output edges:
+  `output -[WAS_GENERATED_BY]-> Execution -[USED]-> input`. Any Asta result traces back to the
+  exact graph context that shaped its request, not just the literature the service returned.
+
+Implementation:
+- Each ingest fn (`ingest_paper_finder`, `ingest_theorizer`, `ingest_semantic_scholar`) gains
+  `used_inputs: list[str] | None = None`. After the run Execution is created, record
+  `Execution -[USED]-> id` for every `used_inputs` id that exists in the graph (a generic
+  `_node_exists` + `_record_used` in `_marshal.py`, project-aware, link_once).
+- The CLI `ingest` verb gains `--used <comma-separated ids>` -> `used_inputs`.
+- The marshal-in acts pass `--used` with the node ids the prose consulted to build the request
+  (at minimum the `--link-to` question/plan; for theorize, the Finding ids seeded into
+  extraction_results; for analyze-data, the Dataset ids).
+- This is the INPUT half of the contract earning its keep (the output half already buckets).
+
+## 2. The service registry / engine
+
+A declarative manifest of available services; commands read it, never hardcode providers.
+
+`.wheeler/services.yaml` (user-editable; ships empty; Asta entries optional):
+```yaml
+services:
+  - id: asta-theorizer
+    provider: asta
+    name: Theorizer
+    description: literature-grounded theory generation with supporting/contradicting evidence
+    kind: shell-out                 # shell-out | local
+    act: /wh:asta-theorize
+    cost: "expensive (~$7, ~20min)"
+    available: "asta auth status"   # availability probe; filtered out on non-zero exit
+    when: "hypothesis or theory generation"
+    inputs:                          # input ports (the USED set + the marshalling map)
+      - { name: question, source: query, required: true }
+      - { name: extraction_results, source: findings }
+    output:
+      raw_node: document             # document (synthesis) | dataset (records)
+      nodes: [Finding, Hypothesis, Paper]
+```
+
+`wheeler/integrations/registry.py`: load `services.yaml`, run each `available` probe, return the
+available contracts (id, description, act, cost, kind, when, inputs, output). Pure read; no graph
+dependency.
+
+Consumers:
+- `/wh:asta` (generalize to `/wh:services`) reads the registry instead of its hardcoded routing
+  table: lists only available services, suggests by `when`/`description`, warns on `cost`.
+- Commands stay service-agnostic: an optional `--service <id>` / `--use <id>` resolves through the
+  registry; with no flag the command is provider-free.
+
+This is the light engine. The heavy generic marshalling DSL stays out (the parsers are
+tool-specific); the contract carries identity + ports + output shape, not a field-map language.
+
+## 3. The skill-creator skill
+
+A meta-skill that scaffolds a new adapter from a contract, closing the loop with the original
+skill-creator idea. `.claude/skills/wheeler-service-creator/` (or `/wh:service-new`): given a
+tool (interview the user, or read its `--help` / agent card), it:
+- drafts the `.wheeler/services.yaml` contract entry (identity, ports, output shape, availability),
+- scaffolds the marshal-out ingest skeleton (`wheeler/integrations/<provider>/<tool>.py`) wired to
+  `_marshal.py` + `register_output_artifact`,
+- scaffolds the marshal-in act (`/wh:<provider>-<tool>`) that reads graph context, passes `--used`
+  source ids, and shells out,
+- scaffolds a parse-unit + live-Neo4j e2e test stub.
+Then the human captures one real output, fills the parser against it, and the adversarial-review
+workflow lands it. Adding a service becomes: run the creator -> fill the parser -> review -> land.
+
+## Build order
+
+1. Input-side provenance (this spec, section 1): a focused change to the three adapters + CLI +
+   acts, adversarially reviewed. Lands now.
+2. Registry/engine (section 2): contract dataclass + `services.yaml` + loader + `/wh:asta` reads it.
+3. Skill-creator (section 3): the scaffolding meta-skill.

--- a/tests/integrations/asta/test_paper_finder.py
+++ b/tests/integrations/asta/test_paper_finder.py
@@ -546,6 +546,129 @@ class TestIngestPaperFinderE2E:
             rows = {r["cid"]: r["c"] async for r in result}
         assert rows == {"211234567": 1, "222345678": 1}
 
+    @pytest.mark.asyncio
+    async def test_used_inputs_record_input_provenance(self, e2e_config):
+        """Input-side provenance: Execution -[USED]-> each marshalled-in input.
+
+        Seed an OpenQuestion + a Finding via execute_tool, ingest the fixture
+        with used_inputs=[those ids, plus a fabricated id that does NOT exist],
+        and assert:
+          - Execution -[USED]-> each existing input exactly once,
+          - the missing id is skipped (no error, no edge, report.used counts
+            only the real ones),
+          - re-ingest does NOT duplicate the USED edges,
+          - the full chain is queryable: a produced node (the raw Dataset
+            artifact) -[WAS_GENERATED_BY]-> Execution -[USED]-> the input.
+        """
+        from wheeler.graph.driver import get_async_driver
+        from wheeler.integrations.asta.ingest import ingest_paper_finder
+        from wheeler.tools.graph_tools import execute_tool
+
+        doc = _load_fixture()
+        driver = get_async_driver(e2e_config)
+        db = e2e_config.neo4j.database
+
+        # Seed two real graph inputs the marshal-in would have consumed.
+        q_result = json.loads(await execute_tool(
+            "add_question",
+            {"question": "E2E USED: which SRM papers shaped this?", "priority": 5},
+            e2e_config,
+        ))
+        question_id = q_result["node_id"]
+        f_result = json.loads(await execute_tool(
+            "add_finding",
+            {"description": "E2E USED: prior SRM result", "confidence": 0.8},
+            e2e_config,
+        ))
+        finding_id = f_result["node_id"]
+        # A fabricated id that does NOT exist in the graph: must be skipped.
+        missing_id = "Q-doesnotexist99"
+
+        # Tag the seeded inputs too so teardown stays hermetic.
+        async with driver.session(database=db) as s:
+            await s.run(
+                "MATCH (n) WHERE n.id IN $ids SET n.e2e_tag = $tag",
+                ids=[question_id, finding_id], tag=self._e2e_tag,
+            )
+
+        used = [question_id, finding_id, missing_id]
+
+        # First ingest with used_inputs (no artifact path yet; the Execution is
+        # still produced, so USED can attach to it).
+        report1 = await ingest_paper_finder(
+            doc, link_to=question_id, config=e2e_config, used_inputs=used,
+        )
+        await self._tag_all(e2e_config, report1)
+        exec_id = report1.execution_id
+        # Only the two existing ids are linked; the missing id is skipped.
+        assert report1.used == 2
+
+        # Execution -[USED]-> each EXISTING input exactly once.
+        async with driver.session(database=db) as s:
+            res = await s.run(
+                "MATCH (x:Execution {id: $xid})-[r:USED]->(n) "
+                "WHERE n.id IN $ids RETURN n.id AS id, count(r) AS c",
+                xid=exec_id, ids=[question_id, finding_id],
+            )
+            rows = {r["id"]: r["c"] async for r in res}
+        assert rows == {question_id: 1, finding_id: 1}
+
+        # The missing id has NO USED edge (skipped, never fabricated).
+        async with driver.session(database=db) as s:
+            res = await s.run(
+                "MATCH (x:Execution {id: $xid})-[r:USED]->(n {id: $mid}) "
+                "RETURN count(r) AS c",
+                xid=exec_id, mid=missing_id,
+            )
+            assert (await res.single())["c"] == 0
+            # And no node was fabricated for the missing id.
+            res = await s.run(
+                "MATCH (n {id: $mid}) RETURN count(n) AS c", mid=missing_id,
+            )
+            assert (await res.single())["c"] == 0
+
+        # Re-ingest of the SAME artifact + used_inputs: USED edges not duplicated.
+        report2 = await ingest_paper_finder(
+            doc, link_to=question_id, config=e2e_config, used_inputs=used,
+        )
+        await self._tag_all(e2e_config, report2)
+        assert report2.execution_id == exec_id
+        # Every USED edge already existed, so none is newly created this run.
+        assert report2.used == 0
+        async with driver.session(database=db) as s:
+            res = await s.run(
+                "MATCH (x:Execution {id: $xid})-[r:USED]->(n) "
+                "WHERE n.id IN $ids RETURN count(r) AS c",
+                xid=exec_id, ids=[question_id, finding_id],
+            )
+            assert (await res.single())["c"] == 2
+
+        # The full chain is queryable: a produced node -[WAS_GENERATED_BY]->
+        # Execution -[USED]-> the input. Use the raw Dataset artifact (a
+        # Wheeler-produced node) by re-ingesting once with an artifact path. The
+        # cwd is the per-test temp dir (the autouse fixture chdir'd into it), so
+        # a relative path lands in the isolated sandbox.
+        artifact_file = Path("asta_pf_used_chain.json")
+        artifact_file.write_text(json.dumps(doc))
+        report3 = await ingest_paper_finder(
+            doc,
+            link_to=question_id,
+            config=e2e_config,
+            used_inputs=used,
+            artifact_path=str(artifact_file),
+        )
+        await self._tag_all(e2e_config, report3)
+        assert report3.artifact  # the produced raw Dataset node
+        async with driver.session(database=db) as s:
+            res = await s.run(
+                "MATCH (d {id: $aid})-[:WAS_GENERATED_BY]->"
+                "(x:Execution {id: $xid})-[:USED]->(n) "
+                "WHERE n.id IN $ids RETURN count(DISTINCT n) AS c",
+                aid=report3.artifact, xid=exec_id,
+                ids=[question_id, finding_id],
+            )
+            assert (await res.single())["c"] == 2
+
 
 # ---------------------------------------------------------------------------
 # 4. Live-Neo4j e2e: service tag reaches Neo4j on non-Paper node types

--- a/tests/integrations/asta/test_semantic_scholar.py
+++ b/tests/integrations/asta/test_semantic_scholar.py
@@ -720,3 +720,119 @@ class TestIngestSemanticScholarE2E:
                 sid=s2_paper_id,
             )
             assert (await res.single())["c"] == 1
+
+    @pytest.mark.asyncio
+    async def test_used_inputs_record_input_provenance(self, e2e_config):
+        """Input-side provenance: Execution -[USED]-> each marshalled-in input.
+
+        Seed an OpenQuestion + a Finding via execute_tool, ingest the search
+        fixture with used_inputs=[those ids, plus a fabricated missing id], and
+        assert:
+          - Execution -[USED]-> each existing input exactly once,
+          - the missing id is skipped (no error, no edge, no fabricated node),
+          - re-ingest does NOT duplicate the USED edges,
+          - the full chain is queryable: a produced node (the raw Dataset
+            artifact) -[WAS_GENERATED_BY]-> Execution -[USED]-> the input.
+        """
+        from wheeler.graph.driver import get_async_driver
+        from wheeler.integrations.asta.semantic_scholar import (
+            ingest_semantic_scholar,
+        )
+        from wheeler.tools.graph_tools import execute_tool
+
+        doc = _load(SEARCH_FIXTURE)
+        artifact_path = self._tmp / "s2_used_raw.json"
+        artifact_path.write_text(json.dumps(doc))
+        driver = get_async_driver(e2e_config)
+        db = e2e_config.neo4j.database
+
+        # Seed two real graph inputs the marshal-in would have consumed.
+        q_result = json.loads(await execute_tool(
+            "add_question",
+            {"question": "E2E USED s2: what shaped this search?", "priority": 5},
+            e2e_config,
+        ))
+        question_id = q_result["node_id"]
+        f_result = json.loads(await execute_tool(
+            "add_finding",
+            {"description": "E2E USED s2: prior result", "confidence": 0.7},
+            e2e_config,
+        ))
+        finding_id = f_result["node_id"]
+        missing_id = "Q-doesnotexist99"
+
+        # Tag the seeded inputs too so teardown stays hermetic.
+        async with driver.session(database=db) as s:
+            await s.run(
+                "MATCH (n) WHERE n.id IN $ids SET n.e2e_tag = $tag",
+                ids=[question_id, finding_id], tag=self._e2e_tag,
+            )
+
+        used = [question_id, finding_id, missing_id]
+
+        report1 = await ingest_semantic_scholar(
+            doc,
+            link_to=question_id,
+            config=e2e_config,
+            artifact_path=str(artifact_path),
+            used_inputs=used,
+        )
+        await self._tag_all(e2e_config, report1)
+        exec_id = report1.execution_id
+        # Only the two existing ids are linked; the missing id is skipped.
+        assert report1.used == 2
+
+        # Execution -[USED]-> each EXISTING input exactly once.
+        async with driver.session(database=db) as s:
+            res = await s.run(
+                "MATCH (x:Execution {id: $xid})-[r:USED]->(n) "
+                "WHERE n.id IN $ids RETURN n.id AS id, count(r) AS c",
+                xid=exec_id, ids=[question_id, finding_id],
+            )
+            rows = {r["id"]: r["c"] async for r in res}
+        assert rows == {question_id: 1, finding_id: 1}
+
+        # The missing id has NO USED edge and was NOT fabricated.
+        async with driver.session(database=db) as s:
+            res = await s.run(
+                "MATCH (x:Execution {id: $xid})-[r:USED]->(n {id: $mid}) "
+                "RETURN count(r) AS c",
+                xid=exec_id, mid=missing_id,
+            )
+            assert (await res.single())["c"] == 0
+            res = await s.run(
+                "MATCH (n {id: $mid}) RETURN count(n) AS c", mid=missing_id,
+            )
+            assert (await res.single())["c"] == 0
+
+        # The full chain is queryable: produced raw Dataset -[WAS_GENERATED_BY]->
+        # Execution -[USED]-> the input.
+        assert report1.artifact
+        async with driver.session(database=db) as s:
+            res = await s.run(
+                "MATCH (d {id: $aid})-[:WAS_GENERATED_BY]->"
+                "(x:Execution {id: $xid})-[:USED]->(n) "
+                "WHERE n.id IN $ids RETURN count(DISTINCT n) AS c",
+                aid=report1.artifact, xid=exec_id,
+                ids=[question_id, finding_id],
+            )
+            assert (await res.single())["c"] == 2
+
+        # Re-ingest of the SAME artifact + used_inputs: USED edges not duplicated.
+        report2 = await ingest_semantic_scholar(
+            doc,
+            link_to=question_id,
+            config=e2e_config,
+            artifact_path=str(artifact_path),
+            used_inputs=used,
+        )
+        await self._tag_all(e2e_config, report2)
+        assert report2.execution_id == exec_id
+        assert report2.used == 0
+        async with driver.session(database=db) as s:
+            res = await s.run(
+                "MATCH (x:Execution {id: $xid})-[r:USED]->(n) "
+                "WHERE n.id IN $ids RETURN count(r) AS c",
+                xid=exec_id, ids=[question_id, finding_id],
+            )
+            assert (await res.single())["c"] == 2

--- a/tests/integrations/asta/test_theorizer.py
+++ b/tests/integrations/asta/test_theorizer.py
@@ -497,14 +497,21 @@ class TestIngestTheorizerE2E:
         )
         await self._tag_all(e2e_config, report1)
         assert report1.execution_id.startswith("X-")
+        run_exec_id = report1.execution_id
+        tag = self._e2e_tag
         # parent Findings + Hypotheses + distinct Papers created.
         assert report1.created == N_THEORIES + N_HYPOTHESES + N_PAPERS
 
-        # Parent Finding(artifact_type=theory) exists, one per theory.
+        # Parent Finding(artifact_type=theory) exists, one per theory. Scoped to
+        # THIS run's e2e_tag (not the shared asta:theorizer service tag): the e2e
+        # config runs on the shared default namespace, so a leaked node from a
+        # prior interrupted run would otherwise inflate a by-service count and
+        # cascade-fail the next run. Every node this run created carries the tag.
         async with driver.session(database=db) as s:
             res = await s.run(
-                "MATCH (f:Finding {artifact_type: 'theory', service: 'asta:theorizer'}) "
-                "RETURN count(f) AS c"
+                "MATCH (f:Finding {artifact_type: 'theory'}) "
+                "WHERE f.e2e_tag = $tag RETURN count(f) AS c",
+                tag=tag,
             )
             assert (await res.single())["c"] == N_THEORIES
 
@@ -512,7 +519,8 @@ class TestIngestTheorizerE2E:
         async with driver.session(database=db) as s:
             res = await s.run(
                 "MATCH (f:Finding {artifact_type: 'theory'})-[r:CONTAINS]->(h:Hypothesis) "
-                "WHERE f.service = 'asta:theorizer' RETURN count(r) AS c"
+                "WHERE f.e2e_tag = $tag RETURN count(r) AS c",
+                tag=tag,
             )
             assert (await res.single())["c"] == N_HYPOTHESES
 
@@ -520,7 +528,8 @@ class TestIngestTheorizerE2E:
         async with driver.session(database=db) as s:
             res = await s.run(
                 "MATCH (p:Paper)-[r:SUPPORTS]->(h:Hypothesis) "
-                "WHERE h.service = 'asta:theorizer' RETURN count(r) AS c"
+                "WHERE h.e2e_tag = $tag RETURN count(r) AS c",
+                tag=tag,
             )
             assert (await res.single())["c"] == N_SUPPORTS
 
@@ -528,26 +537,30 @@ class TestIngestTheorizerE2E:
         async with driver.session(database=db) as s:
             res = await s.run(
                 "MATCH (p:Paper)-[r:CONTRADICTS]->(f:Finding {artifact_type: 'theory'}) "
-                "WHERE f.service = 'asta:theorizer' RETURN count(r) AS c"
+                "WHERE f.e2e_tag = $tag RETURN count(r) AS c",
+                tag=tag,
             )
             assert (await res.single())["c"] == N_CONTRADICTS
 
         # novelty parked in custom_novelty and queryable (NOT in status).
         async with driver.session(database=db) as s:
             res = await s.run(
-                "MATCH (h:Hypothesis {service: 'asta:theorizer'}) "
-                "WHERE h.custom_novelty = 'established' RETURN count(h) AS c"
+                "MATCH (h:Hypothesis) WHERE h.e2e_tag = $tag "
+                "AND h.custom_novelty = 'established' RETURN count(h) AS c",
+                tag=tag,
             )
             est_count = (await res.single())["c"]
             res = await s.run(
-                "MATCH (h:Hypothesis {service: 'asta:theorizer'}) "
-                "WHERE h.custom_novelty = 'derivable' RETURN count(h) AS c"
+                "MATCH (h:Hypothesis) WHERE h.e2e_tag = $tag "
+                "AND h.custom_novelty = 'derivable' RETURN count(h) AS c",
+                tag=tag,
             )
             der_count = (await res.single())["c"]
             # status must stay on the open/supported/rejected enum, never novelty.
             res = await s.run(
-                "MATCH (h:Hypothesis {service: 'asta:theorizer'}) "
-                "RETURN collect(DISTINCT h.status) AS statuses"
+                "MATCH (h:Hypothesis) WHERE h.e2e_tag = $tag "
+                "RETURN collect(DISTINCT h.status) AS statuses",
+                tag=tag,
             )
             statuses = (await res.single())["statuses"]
         assert est_count == 1  # one law has novelty="established"
@@ -559,21 +572,25 @@ class TestIngestTheorizerE2E:
         # Verify the novelty landed on the RIGHT Hypothesis (the EWGT law 2).
         async with driver.session(database=db) as s:
             res = await s.run(
-                "MATCH (h:Hypothesis {service: 'asta:theorizer'}) "
-                "WHERE h.custom_novelty = 'established' "
-                "RETURN h.statement AS stmt LIMIT 1"
+                "MATCH (h:Hypothesis) WHERE h.e2e_tag = $tag "
+                "AND h.custom_novelty = 'established' "
+                "RETURN h.statement AS stmt LIMIT 1",
+                tag=tag,
             )
             stmt = (await res.single())["stmt"]
         assert stmt.startswith("Biochemical gate & nonlinearity law")
 
-        # service-tagged Execution, exactly one per run, carrying benchmark fields.
+        # The run Execution, exactly one, carrying benchmark fields. Scoped to
+        # this run's Execution id (not the shared service tag) so a production
+        # asta:theorizer Execution on the shared namespace cannot perturb it.
         async with driver.session(database=db) as s:
             res = await s.run(
-                "MATCH (x:Execution {service: 'asta:theorizer'}) "
+                "MATCH (x:Execution {id: $xid}) "
                 "RETURN count(x) AS c, collect(x.kind)[0] AS kind, "
                 "collect(x.custom_run_id)[0] AS run_id, "
                 "collect(x.custom_cost)[0] AS cost, "
-                "collect(x.custom_time)[0] AS time"
+                "collect(x.custom_time)[0] AS time",
+                xid=run_exec_id,
             )
             rec = await res.single()
         assert rec["c"] == 1
@@ -584,11 +601,13 @@ class TestIngestTheorizerE2E:
 
         # Snapshot the WAS_GENERATED_BY fan-in to the Execution after the first
         # ingest. Re-ingest must NOT grow this (the Execution is idempotent and
-        # link_once guards every provenance edge), so we re-check it below.
+        # link_once guards every provenance edge), so we re-check it below. Scoped
+        # to this run's Execution id so the shared namespace cannot perturb it.
         async with driver.session(database=db) as s:
             res = await s.run(
-                "MATCH (n)-[r:WAS_GENERATED_BY]->(x:Execution {service: 'asta:theorizer'}) "
-                "RETURN count(r) AS c"
+                "MATCH (n)-[r:WAS_GENERATED_BY]->(x:Execution {id: $xid}) "
+                "RETURN count(r) AS c",
+                xid=run_exec_id,
             )
             gen_by_after_first = (await res.single())["c"]
         # The run Execution is WAS_GENERATED_BY the Wheeler-PRODUCED nodes only:
@@ -600,8 +619,9 @@ class TestIngestTheorizerE2E:
         # Papers carry NO WAS_GENERATED_BY: zero evidence papers in the fan-in.
         async with driver.session(database=db) as s:
             res = await s.run(
-                "MATCH (p:Paper)-[r:WAS_GENERATED_BY]->(x:Execution {service: 'asta:theorizer'}) "
-                "RETURN count(r) AS c"
+                "MATCH (p:Paper)-[r:WAS_GENERATED_BY]->(x:Execution {id: $xid}) "
+                "RETURN count(r) AS c",
+                xid=run_exec_id,
             )
             assert (await res.single())["c"] == 0
 
@@ -613,17 +633,18 @@ class TestIngestTheorizerE2E:
         # paper used by several laws to ONE USED edge, so the count is N_PAPERS.
         async with driver.session(database=db) as s:
             res = await s.run(
-                "MATCH (x:Execution {service: 'asta:theorizer'})-[r:USED]->(p:Paper) "
-                "RETURN count(r) AS c"
+                "MATCH (x:Execution {id: $xid})-[r:USED]->(p:Paper) "
+                "RETURN count(r) AS c",
+                xid=run_exec_id,
             )
             assert (await res.single())["c"] == N_PAPERS
         # The USED targets are exactly the evidence papers (reachable both via
         # Execution-USED and via SUPPORTS/CONTRADICTS).
         async with driver.session(database=db) as s:
             res = await s.run(
-                "MATCH (x:Execution {service: 'asta:theorizer'})-[:USED]->(p:Paper) "
+                "MATCH (x:Execution {id: $xid})-[:USED]->(p:Paper) "
                 "WHERE p.corpus_id IN $cids RETURN count(DISTINCT p) AS c",
-                cids=ALL_CORPUS_IDS,
+                xid=run_exec_id, cids=ALL_CORPUS_IDS,
             )
             assert (await res.single())["c"] == N_PAPERS
 
@@ -631,8 +652,8 @@ class TestIngestTheorizerE2E:
         async with driver.session(database=db) as s:
             res = await s.run(
                 "MATCH (f:Finding {artifact_type: 'theory'})-[r:AROSE_FROM]->(q {id: $qid}) "
-                "WHERE f.service = 'asta:theorizer' RETURN count(r) AS c",
-                qid=question_id,
+                "WHERE f.e2e_tag = $tag RETURN count(r) AS c",
+                qid=question_id, tag=tag,
             )
             assert (await res.single())["c"] == N_THEORIES
 
@@ -661,12 +682,13 @@ class TestIngestTheorizerE2E:
         assert float(raw_node["custom"]["cost"]) == pytest.approx(RUN_COST)
         assert float(raw_node["custom"]["time"]) == pytest.approx(RUN_TIME)
 
-        # raw Document WAS_GENERATED_BY the Execution.
+        # raw Document WAS_GENERATED_BY the run Execution (scoped to this run's
+        # Document id and Execution id, so the shared namespace cannot perturb it).
         async with driver.session(database=db) as s:
             res = await s.run(
-                "MATCH (w:Document {id: $wid})-[r:WAS_GENERATED_BY]->(x:Execution) "
-                "WHERE x.service = 'asta:theorizer' RETURN count(r) AS c",
-                wid=report1.artifact,
+                "MATCH (w:Document {id: $wid})-[r:WAS_GENERATED_BY]->(x:Execution {id: $xid}) "
+                "RETURN count(r) AS c",
+                wid=report1.artifact, xid=run_exec_id,
             )
             assert (await res.single())["c"] == 1
 
@@ -684,8 +706,9 @@ class TestIngestTheorizerE2E:
         # custom bag round-trips through the Pydantic model on read.
         async with driver.session(database=db) as s:
             res = await s.run(
-                "MATCH (h:Hypothesis {service: 'asta:theorizer'}) "
-                "WHERE h.custom_novelty = 'established' RETURN h.id AS id LIMIT 1"
+                "MATCH (h:Hypothesis) WHERE h.e2e_tag = $tag "
+                "AND h.custom_novelty = 'established' RETURN h.id AS id LIMIT 1",
+                tag=tag,
             )
             hyp_id = (await res.single())["id"]
         node = await backend.get_node("Hypothesis", hyp_id)
@@ -706,15 +729,18 @@ class TestIngestTheorizerE2E:
         assert report2.created == 0
         assert report2.deduped == N_THEORIES + N_HYPOTHESES + N_PAPERS
 
-        # Still exactly the same node counts.
+        # Still exactly the same node counts (scoped to this run's e2e_tag /
+        # Execution id so the shared default namespace cannot perturb them).
         async with driver.session(database=db) as s:
             res = await s.run(
-                "MATCH (f:Finding {artifact_type: 'theory', service: 'asta:theorizer'}) "
-                "RETURN count(f) AS c"
+                "MATCH (f:Finding {artifact_type: 'theory'}) "
+                "WHERE f.e2e_tag = $tag RETURN count(f) AS c",
+                tag=tag,
             )
             assert (await res.single())["c"] == N_THEORIES
             res = await s.run(
-                "MATCH (h:Hypothesis {service: 'asta:theorizer'}) RETURN count(h) AS c"
+                "MATCH (h:Hypothesis) WHERE h.e2e_tag = $tag RETURN count(h) AS c",
+                tag=tag,
             )
             assert (await res.single())["c"] == N_HYPOTHESES
             res = await s.run(
@@ -725,7 +751,8 @@ class TestIngestTheorizerE2E:
             assert (await res.single())["c"] == N_PAPERS
             # Still exactly one raw Document node (path-dedupe in the store).
             res = await s.run(
-                "MATCH (w:Document {service: 'asta:theorizer'}) RETURN count(w) AS c"
+                "MATCH (w:Document {id: $wid}) RETURN count(w) AS c",
+                wid=report1.artifact,
             )
             assert (await res.single())["c"] == 1
 
@@ -733,23 +760,26 @@ class TestIngestTheorizerE2E:
         async with driver.session(database=db) as s:
             res = await s.run(
                 "MATCH (f:Finding {artifact_type: 'theory'})-[r:CONTAINS]->(h:Hypothesis) "
-                "WHERE f.service = 'asta:theorizer' RETURN count(r) AS c"
+                "WHERE f.e2e_tag = $tag RETURN count(r) AS c",
+                tag=tag,
             )
             assert (await res.single())["c"] == N_HYPOTHESES
             res = await s.run(
                 "MATCH (p:Paper)-[r:SUPPORTS]->(h:Hypothesis) "
-                "WHERE h.service = 'asta:theorizer' RETURN count(r) AS c"
+                "WHERE h.e2e_tag = $tag RETURN count(r) AS c",
+                tag=tag,
             )
             assert (await res.single())["c"] == N_SUPPORTS
             res = await s.run(
                 "MATCH (p:Paper)-[r:CONTRADICTS]->(f:Finding {artifact_type: 'theory'}) "
-                "WHERE f.service = 'asta:theorizer' RETURN count(r) AS c"
+                "WHERE f.e2e_tag = $tag RETURN count(r) AS c",
+                tag=tag,
             )
             assert (await res.single())["c"] == N_CONTRADICTS
             res = await s.run(
                 "MATCH (f:Finding {artifact_type: 'theory'})-[r:AROSE_FROM]->(q {id: $qid}) "
-                "WHERE f.service = 'asta:theorizer' RETURN count(r) AS c",
-                qid=question_id,
+                "WHERE f.e2e_tag = $tag RETURN count(r) AS c",
+                qid=question_id, tag=tag,
             )
             assert (await res.single())["c"] == N_THEORIES
 
@@ -757,23 +787,191 @@ class TestIngestTheorizerE2E:
         # Re-ingesting the SAME artifact must NOT create a second Execution node,
         # and must NOT accumulate extra WAS_GENERATED_BY edges. (Regression:
         # add_execution was previously called unconditionally, so a re-ingest
-        # duplicated the Execution and its provenance fan-in.)
+        # duplicated the Execution and its provenance fan-in.) Scoped to this
+        # run's Execution id so the shared namespace cannot perturb the counts.
         async with driver.session(database=db) as s:
             res = await s.run(
-                "MATCH (x:Execution {service: 'asta:theorizer'}) RETURN count(x) AS c"
+                "MATCH (x:Execution {id: $xid}) RETURN count(x) AS c",
+                xid=run_exec_id,
             )
             assert (await res.single())["c"] == 1
             res = await s.run(
-                "MATCH (n)-[r:WAS_GENERATED_BY]->(x:Execution {service: 'asta:theorizer'}) "
-                "RETURN count(r) AS c"
+                "MATCH (n)-[r:WAS_GENERATED_BY]->(x:Execution {id: $xid}) "
+                "RETURN count(r) AS c",
+                xid=run_exec_id,
             )
             assert (await res.single())["c"] == gen_by_after_first
             # The Execution -[USED]-> evidence-paper edges are also link_once
             # guarded, so re-ingest must NOT grow them: still exactly N_PAPERS.
             res = await s.run(
-                "MATCH (x:Execution {service: 'asta:theorizer'})-[r:USED]->(p:Paper) "
-                "RETURN count(r) AS c"
+                "MATCH (x:Execution {id: $xid})-[r:USED]->(p:Paper) "
+                "RETURN count(r) AS c",
+                xid=run_exec_id,
             )
             assert (await res.single())["c"] == N_PAPERS
         # The report points at the same Execution both runs (reused, not new).
         assert report2.execution_id == report1.execution_id
+
+    @pytest.mark.asyncio
+    async def test_used_inputs_record_input_provenance(self, e2e_config):
+        """Input-side provenance: Execution -[USED]-> the marshalled-in inputs.
+
+        On TOP of the per-evidence-paper USED edges, seed an OpenQuestion + a
+        Finding (the prose-consulted inputs, e.g. the Finding ids seeded into
+        extraction_results) and pass them as used_inputs with a fabricated
+        missing id. Assert:
+          - Execution -[USED]-> each existing seeded input exactly once,
+          - the missing id is skipped (no error, no edge, no fabricated node),
+          - link_once collapses overlap (no extra USED to the evidence papers),
+          - re-ingest does NOT duplicate the USED edges,
+          - the full chain is queryable: a produced node (a parent theory
+            Finding) -[WAS_GENERATED_BY]-> Execution -[USED]-> the seeded input.
+        """
+        from wheeler.graph.driver import get_async_driver
+        from wheeler.integrations.asta.theorizer import ingest_theorizer
+        from wheeler.tools.graph_tools import execute_tool
+
+        doc = _load_fixture()
+        artifact_path = self._tmp / "theorizer_used_raw.json"
+        artifact_path.write_text(json.dumps(doc))
+        driver = get_async_driver(e2e_config)
+        db = e2e_config.neo4j.database
+
+        # Seed two real graph inputs the marshal-in would have consumed (the
+        # question that motivated the run + a Finding seeded into extraction).
+        q_result = json.loads(await execute_tool(
+            "add_question",
+            {"question": "E2E USED th: what governs the rate?", "priority": 5},
+            e2e_config,
+        ))
+        question_id = q_result["node_id"]
+        f_result = json.loads(await execute_tool(
+            "add_finding",
+            {"description": "E2E USED th: seeded extraction result", "confidence": 0.8},
+            e2e_config,
+        ))
+        finding_id = f_result["node_id"]
+        missing_id = "Q-doesnotexist99"
+
+        # Tag the seeded inputs too so teardown stays hermetic.
+        async with driver.session(database=db) as s:
+            await s.run(
+                "MATCH (n) WHERE n.id IN $ids SET n.e2e_tag = $tag",
+                ids=[question_id, finding_id], tag=self._e2e_tag,
+            )
+
+        used = [question_id, finding_id, missing_id]
+
+        report1 = await ingest_theorizer(
+            doc,
+            link_to=question_id,
+            config=e2e_config,
+            artifact_path=str(artifact_path),
+            used_inputs=used,
+        )
+        await self._tag_all(e2e_config, report1)
+        exec_id = report1.execution_id
+        # Only the two existing seeded ids are linked by _record_used; the
+        # missing id is skipped. (The evidence-paper USED edges are counted in
+        # report.linked, not report.used.)
+        assert report1.used == 2
+
+        # Execution -[USED]-> each EXISTING seeded input exactly once.
+        async with driver.session(database=db) as s:
+            res = await s.run(
+                "MATCH (x:Execution {id: $xid})-[r:USED]->(n) "
+                "WHERE n.id IN $ids RETURN n.id AS id, count(r) AS c",
+                xid=exec_id, ids=[question_id, finding_id],
+            )
+            rows = {r["id"]: r["c"] async for r in res}
+        assert rows == {question_id: 1, finding_id: 1}
+
+        # The missing id has NO USED edge and was NOT fabricated.
+        async with driver.session(database=db) as s:
+            res = await s.run(
+                "MATCH (x:Execution {id: $xid})-[r:USED]->(n {id: $mid}) "
+                "RETURN count(r) AS c",
+                xid=exec_id, mid=missing_id,
+            )
+            assert (await res.single())["c"] == 0
+            res = await s.run(
+                "MATCH (n {id: $mid}) RETURN count(n) AS c", mid=missing_id,
+            )
+            assert (await res.single())["c"] == 0
+
+        # The evidence-paper USED edges are untouched (link_once collapses any
+        # overlap; the seeded inputs are not papers, so still exactly N_PAPERS).
+        async with driver.session(database=db) as s:
+            res = await s.run(
+                "MATCH (x:Execution {id: $xid})-[r:USED]->(p:Paper) "
+                "RETURN count(r) AS c",
+                xid=exec_id,
+            )
+            assert (await res.single())["c"] == N_PAPERS
+
+        # The full chain is queryable: a produced parent theory Finding
+        # -[WAS_GENERATED_BY]-> Execution -[USED]-> the seeded input.
+        async with driver.session(database=db) as s:
+            res = await s.run(
+                "MATCH (f:Finding {artifact_type: 'theory'})"
+                "-[:WAS_GENERATED_BY]->(x:Execution {id: $xid})-[:USED]->(n) "
+                "WHERE n.id IN $ids RETURN count(DISTINCT n) AS c",
+                xid=exec_id, ids=[question_id, finding_id],
+            )
+            assert (await res.single())["c"] == 2
+
+        # Re-ingest of the SAME artifact + used_inputs: USED edges not duplicated.
+        report2 = await ingest_theorizer(
+            doc,
+            link_to=question_id,
+            config=e2e_config,
+            artifact_path=str(artifact_path),
+            used_inputs=used,
+        )
+        await self._tag_all(e2e_config, report2)
+        assert report2.execution_id == exec_id
+        assert report2.used == 0
+        async with driver.session(database=db) as s:
+            res = await s.run(
+                "MATCH (x:Execution {id: $xid})-[r:USED]->(n) "
+                "WHERE n.id IN $ids RETURN count(r) AS c",
+                xid=exec_id, ids=[question_id, finding_id],
+            )
+            assert (await res.single())["c"] == 2
+
+        # --- Direct overlap path: a used_input that is ALSO an evidence paper ---
+        # _ingest_paper_edge already created Execution -[USED]-> each evidence
+        # paper. Passing one of those P-ids back as a used_input must collapse via
+        # link_once: _record_used sees the edge already exists, so report.used
+        # counts it as NOT newly linked (0), and the total USED-to-Paper count
+        # does not grow. This exercises the overlap branch directly (the seeded
+        # Question/Finding above are non-papers, so they never hit it).
+        assert report1.paper_ids, "fixture should have at least one evidence paper"
+        evidence_paper_id = report1.paper_ids[0]
+        report3 = await ingest_theorizer(
+            doc,
+            link_to=question_id,
+            config=e2e_config,
+            artifact_path=str(artifact_path),
+            used_inputs=[evidence_paper_id],
+        )
+        await self._tag_all(e2e_config, report3)
+        assert report3.execution_id == exec_id
+        # The evidence paper was already USED by _ingest_paper_edge, so the
+        # explicit used_input adds NO new USED edge (link_once collapse).
+        assert report3.used == 0
+        async with driver.session(database=db) as s:
+            # That paper still has exactly one USED edge from the Execution.
+            res = await s.run(
+                "MATCH (x:Execution {id: $xid})-[r:USED]->(p:Paper {id: $pid}) "
+                "RETURN count(r) AS c",
+                xid=exec_id, pid=evidence_paper_id,
+            )
+            assert (await res.single())["c"] == 1
+            # And the total Execution-USED-Paper fan-out is unchanged (N_PAPERS).
+            res = await s.run(
+                "MATCH (x:Execution {id: $xid})-[r:USED]->(p:Paper) "
+                "RETURN count(r) AS c",
+                xid=exec_id,
+            )
+            assert (await res.single())["c"] == N_PAPERS

--- a/wheeler/_data/commands/asta-lit.md
+++ b/wheeler/_data/commands/asta-lit.md
@@ -38,10 +38,10 @@ If the command exits non-zero, report the failure and stop. A failed run writes 
 Marshal the artifact into the graph with the single integrate verb:
 
 ```
-wheeler integrate ingest paper_finder /tmp/asta-paper-finder.json --link-to <Q- or PL- id>
+wheeler integrate ingest paper_finder /tmp/asta-paper-finder.json --link-to <Q- or PL- id> --used <Q- or PL- id>
 ```
 
-Omit `--link-to` if there is no target. The verb is idempotent: re-running the same artifact creates no duplicate papers or edges (dedupe is on `corpus_id`, edges are guarded by `link_once`).
+Omit `--link-to` if there is no target. Pass `--used` with the graph node ids the request was built from (at minimum the link target, the `Q-`/`PL-` that motivated the search): this records `Execution -[USED]-> each input` (input-side provenance), so every result traces back to the graph context that shaped the query, not just the literature returned. Omit `--used` if there were no graph inputs. The verb is idempotent: re-running the same artifact creates no duplicate papers, edges, or USED edges (dedupe is on `corpus_id`, edges are guarded by `link_once`).
 
 ## Report
 

--- a/wheeler/_data/commands/asta-scholar.md
+++ b/wheeler/_data/commands/asta-scholar.md
@@ -31,7 +31,7 @@ Semantic Scholar has four sub-queries. The ingest auto-detects which one from th
 
 ## Choose the sub-query, run it, and ingest
 
-Pick at most one link target: the Question (`Q-...`) or Plan (`PL-...`) this query supports. Each relevant result links `RELEVANT_TO` that node. Omit `--link-to` if there is no clear target. The verb is idempotent: re-running the same artifact creates no duplicate papers, findings, or edges (papers dedupe on `corpus_id`, snippet findings on a content hash, edges are guarded by `link_once`).
+Pick at most one link target: the Question (`Q-...`) or Plan (`PL-...`) this query supports. Each relevant result links `RELEVANT_TO` that node. Omit `--link-to` if there is no clear target. Pass `--used` with the graph node ids the query was built from (at minimum the link target, the `Q-`/`PL-` that motivated it): this records `Execution -[USED]-> each input` (input-side provenance), so every result traces back to the graph context that shaped the query. Omit `--used` if there were no graph inputs. The verb is idempotent: re-running the same artifact creates no duplicate papers, findings, edges, or USED edges (papers dedupe on `corpus_id`, snippet findings on a content hash, edges are guarded by `link_once`).
 
 ### Citations (build the citation graph)
 
@@ -39,28 +39,28 @@ The TARGET paper being cited is the CLI argument, NOT in the output. Pass it to 
 
 ```
 asta papers citations <paperId-or-DOI> --fields corpusId,title,authors,year,venue,citationCount --limit <N> > /tmp/asta-s2.json
-wheeler integrate ingest semantic_scholar /tmp/asta-s2.json --target <corpus_id-or-P-id> --link-to <Q- or PL- id>
+wheeler integrate ingest semantic_scholar /tmp/asta-s2.json --target <corpus_id-or-P-id> --link-to <Q- or PL- id> --used <Q- or PL- id>
 ```
 
 ### Search
 
 ```
 asta papers search "<query>" --fields corpusId,title,authors,year,venue,citationCount --limit <N> > /tmp/asta-s2.json
-wheeler integrate ingest semantic_scholar /tmp/asta-s2.json --link-to <Q- or PL- id>
+wheeler integrate ingest semantic_scholar /tmp/asta-s2.json --link-to <Q- or PL- id> --used <Q- or PL- id>
 ```
 
 ### Get one paper
 
 ```
 asta papers get <paperId-or-DOI> --fields corpusId,externalIds,title,authors,year,venue,citationCount,openAccessPdf,abstract > /tmp/asta-s2.json
-wheeler integrate ingest semantic_scholar /tmp/asta-s2.json --link-to <Q- or PL- id>
+wheeler integrate ingest semantic_scholar /tmp/asta-s2.json --link-to <Q- or PL- id> --used <Q- or PL- id>
 ```
 
 ### Snippet search
 
 ```
 asta papers snippet "<query>" --fields corpusId,title,authors --limit <N> > /tmp/asta-s2.json
-wheeler integrate ingest semantic_scholar /tmp/asta-s2.json --link-to <Q- or PL- id>
+wheeler integrate ingest semantic_scholar /tmp/asta-s2.json --link-to <Q- or PL- id> --used <Q- or PL- id>
 ```
 
 If any CLI command exits non-zero, report the failure and stop. A failed run writes nothing to the graph by design. The short alias `s2` works in place of `semantic_scholar`.

--- a/wheeler/_data/commands/asta-theorize.md
+++ b/wheeler/_data/commands/asta-theorize.md
@@ -39,10 +39,10 @@ If the command exits non-zero (including a login or auth failure), report it and
 Marshal the artifact into the graph with the single integrate verb:
 
 ```
-wheeler integrate ingest theorizer /tmp/asta-theorizer.json --link-to <Q- or PL- id>
+wheeler integrate ingest theorizer /tmp/asta-theorizer.json --link-to <Q- or PL- id> --used <Q- or PL- id>,<F-... seeded Finding ids>
 ```
 
-Omit `--link-to` if there is no target. The verb is idempotent: re-running the same artifact creates no duplicate theories, law hypotheses, papers, or edges. Each theory becomes a parent Finding (`artifact_type=theory`); each law becomes a Hypothesis the parent `CONTAINS`; supporting papers link `SUPPORTS` and contradicting papers link `CONTRADICTS` each law Hypothesis. The novelty verdict (established, derivable, new) is parked as `custom_novelty` on each Hypothesis, never in its `status`.
+Omit `--link-to` if there is no target. Pass `--used` with the graph node ids the request was built from: the link target (the `Q-`/`PL-` that motivated the run) AND every Finding id you seeded into the Theorizer extraction payload (the existing results that shaped the theory generation), comma-separated. This records `Execution -[USED]-> each input` (input-side provenance), so every generated theory traces back to the exact graph context it was built from, not just the literature support. Omit `--used` if there were no graph inputs. The verb is idempotent: re-running the same artifact creates no duplicate theories, law hypotheses, papers, edges, or USED edges. Each theory becomes a parent Finding (`artifact_type=theory`); each law becomes a Hypothesis the parent `CONTAINS`; supporting papers link `SUPPORTS` and contradicting papers link `CONTRADICTS` each law Hypothesis. The novelty verdict (established, derivable, new) is parked as `custom_novelty` on each Hypothesis, never in its `status`.
 
 ## Report
 

--- a/wheeler/integrations/asta/CLAUDE.md
+++ b/wheeler/integrations/asta/CLAUDE.md
@@ -151,6 +151,26 @@ side plus the subprocess boundary. No workflow engine, daemon, or router.
   durable save dedupes on path and `ensure_artifact` dedupes on path, so
   re-ingest creates no duplicate node or edges. Artifact registration is
   best-effort and never aborts ingest.
+- **Input-side provenance (`Execution -[USED]-> the marshalled-in inputs`).**
+  The marshal-in synthesizes the tool payload FROM graph nodes (the question,
+  the Findings seeded into the Theorizer extraction payload, the gap that shaped
+  the query). That synthesis means the run USED those nodes, so each ingest fn
+  takes `used_inputs: list[str] | None` and, after the run Execution is created
+  and deduped, records `Execution -[USED]-> id` for each input via
+  `_record_used` (in `_marshal.py`). The CLI `--used` flag carries them
+  (comma-separated); the acts pass at minimum the `--link-to` Question/Plan, and
+  `/wh:asta-theorize` additionally passes the seeded Finding ids. Each id is
+  existence-guarded with the generic, label-agnostic `_node_exists` (a missing
+  id is SKIPPED and logged, never fabricated) and linked with `link_once` (so
+  re-ingest dedupes the USED edge, and a USED edge already recorded by another
+  path, e.g. the Theorizer per-evidence-paper `USED`, is not duplicated).
+  `USED` is the registered input-provenance verb (`graph/schema.py`,
+  `_complete_provenance` in `mutations.py` uses it the same way). NO per-output
+  `WAS_DERIVED_FROM` is needed for this: the chain
+  `output -[WAS_GENERATED_BY]-> Execution -[USED]-> input` is already
+  transitive, so any Asta result traces back to the exact graph context that
+  shaped its request. The linked-USED count surfaces as `ImportReport.used`
+  (`to_dict` + the printed summary).
 - **Failure isolation.** A failed or canceled CLI run writes nothing. Retries,
   auth, and timeouts stay inside the asta CLI.
 

--- a/wheeler/integrations/asta/_marshal.py
+++ b/wheeler/integrations/asta/_marshal.py
@@ -50,6 +50,7 @@ class ImportReport:
     deduped: int = 0
     linked: int = 0
     skipped: int = 0
+    used: int = 0
     execution_id: str = ""
     artifact: str = ""
     paper_ids: list[str] = field(default_factory=list)
@@ -60,6 +61,7 @@ class ImportReport:
             "deduped": self.deduped,
             "linked": self.linked,
             "skipped": self.skipped,
+            "used": self.used,
             "execution_id": self.execution_id,
             "artifact": self.artifact,
             "paper_ids": list(self.paper_ids),
@@ -218,3 +220,73 @@ async def _link_once(
     )
     result = json.loads(result_str)
     return result.get("status") == "linked"
+
+
+# ---------------------------------------------------------------------------
+# Input-side provenance: Execution -[USED]-> the marshalled-in graph nodes
+# ---------------------------------------------------------------------------
+
+
+async def _node_exists(backend, config: WheelerConfig, node_id: str) -> bool:
+    """Return True if a node with this id (any label) lives in the graph.
+
+    The generic, label-agnostic sibling of ``_paper_exists``: a marshalled-in
+    USED input can be any node type (an OpenQuestion, a Finding, a Plan, a
+    Dataset), so the guard matches on id alone rather than a fixed label. Keyed
+    on the globally-unique id, project-aware (scoped to ``project_tag`` when
+    Community Edition isolation is on, mirroring the read scoping in the query
+    handlers). Used to existence-guard every USED edge so the run never
+    fabricates an input it cannot find: a missing id is skipped, never created.
+    """
+    if not node_id:
+        return False
+    ptag = getattr(config.neo4j, "project_tag", "") or ""
+    if ptag:
+        query = (
+            "MATCH (n {id: $id}) "
+            "WHERE n._wheeler_project = $ptag RETURN n.id AS id LIMIT 1"
+        )
+        params = {"id": node_id, "ptag": ptag}
+    else:
+        query = "MATCH (n {id: $id}) RETURN n.id AS id LIMIT 1"
+        params = {"id": node_id}
+    rows = await backend.run_cypher(query, params)
+    return bool(rows)
+
+
+async def _record_used(
+    backend, config: WheelerConfig, exec_id: str, used_inputs: list[str],
+) -> int:
+    """Record Execution -[USED]-> each existing marshalled-in graph node.
+
+    Input-side provenance: the marshal-in synthesized the tool payload FROM
+    these graph nodes (the question, the Findings seeded into extraction, the
+    gap that shaped the query), so the run USED them. The chain is then
+    transitive without per-output edges:
+    ``output -[WAS_GENERATED_BY]-> Execution -[USED]-> input``.
+
+    Each id is existence-guarded with ``_node_exists`` (a missing id is skipped
+    and logged, never fabricated) and linked with ``_link_once`` (so re-ingest
+    dedupes the edge and a USED already recorded by another path, e.g. the
+    Theorizer evidence-paper USED, is not duplicated). Self-edges (an id equal to
+    the Execution) and blanks are skipped. Returns the count of USED edges newly
+    created this call.
+    """
+    if not exec_id or not used_inputs:
+        return 0
+    linked = 0
+    seen: set[str] = set()
+    for raw_id in used_inputs:
+        node_id = (raw_id or "").strip()
+        if not node_id or node_id == exec_id or node_id in seen:
+            continue
+        seen.add(node_id)
+        if not await _node_exists(backend, config, node_id):
+            logger.warning(
+                "record_used: skipping missing input id %r (not in graph)",
+                node_id,
+            )
+            continue
+        if await _link_once(backend, config, exec_id, "USED", node_id):
+            linked += 1
+    return linked

--- a/wheeler/integrations/asta/cli.py
+++ b/wheeler/integrations/asta/cli.py
@@ -48,6 +48,15 @@ def ingest(
             "or a P-id). Each citing paper links CITES it. Ignored otherwise."
         ),
     ),
+    used: Optional[str] = typer.Option(
+        None,
+        "--used",
+        help=(
+            "Comma-separated graph node ids the request was built FROM (the "
+            "question/plan, the seeded Finding ids). The run Execution USED "
+            "each one that exists in the graph (input-side provenance)."
+        ),
+    ),
 ) -> None:
     """Marshal an external-tool artifact into the Wheeler knowledge graph."""
     tool_key = tool.strip().lower()
@@ -73,12 +82,24 @@ def ingest(
 
     config = load_config()
 
+    # Comma-separated node ids the request was marshalled in FROM. Trimmed and
+    # blanks dropped; the run Execution USED each existing one (input-side
+    # provenance). Normalized to None when the parse yields nothing (whether the
+    # flag was absent, empty, or all-blank like "   " / ",,,"), so the
+    # no-USED-edges path is reached identically rather than passing an empty list.
+    _parsed_used = [i.strip() for i in used.split(",") if i.strip()] if used else []
+    used_inputs = _parsed_used or None
+
     if tool_key == "theorizer":
         from wheeler.integrations.asta.theorizer import ingest_theorizer
 
         report = asyncio.run(
             ingest_theorizer(
-                doc, link_to=link_to, config=config, artifact_path=str(artifact)
+                doc,
+                link_to=link_to,
+                config=config,
+                artifact_path=str(artifact),
+                used_inputs=used_inputs,
             )
         )
     elif tool_key in ("semantic_scholar", "semantic-scholar", "s2"):
@@ -91,6 +112,7 @@ def ingest(
                 target=target,
                 config=config,
                 artifact_path=str(artifact),
+                used_inputs=used_inputs,
             )
         )
     else:
@@ -98,13 +120,17 @@ def ingest(
 
         report = asyncio.run(
             ingest_paper_finder(
-                doc, link_to=link_to, config=config, artifact_path=str(artifact)
+                doc,
+                link_to=link_to,
+                config=config,
+                artifact_path=str(artifact),
+                used_inputs=used_inputs,
             )
         )
 
     typer.echo(
         f"created={report.created} deduped={report.deduped} "
-        f"linked={report.linked} skipped={report.skipped} "
+        f"linked={report.linked} skipped={report.skipped} used={report.used} "
         f"execution={report.execution_id or '-'}"
     )
     if report.paper_ids:

--- a/wheeler/integrations/asta/ingest.py
+++ b/wheeler/integrations/asta/ingest.py
@@ -35,6 +35,7 @@ from ._marshal import (
     _link_once,
     _load_index,
     _paper_exists,
+    _record_used,
     _save_index,
 )
 from .schemas import PaperRecord, parse_paper_finder
@@ -55,6 +56,7 @@ async def ingest_paper_finder(
     link_to: str | None,
     config: WheelerConfig,
     artifact_path: str | None = None,
+    used_inputs: list[str] | None = None,
 ) -> ImportReport:
     """Ingest a parsed Asta Paper Finder artifact into the knowledge graph.
 
@@ -68,9 +70,14 @@ async def ingest_paper_finder(
             artifact), linked WAS_GENERATED_BY the run Execution, and every
             Paper is linked WAS_DERIVED_FROM it. Best-effort: an artifact
             failure never breaks paper ingest.
+        used_inputs: Optional graph node ids the marshal-in consumed to build
+            the request (at minimum the link target that motivated the search).
+            The run Execution -[USED]-> each one that exists in the graph
+            (existence-guarded, link_once): input-side provenance. A missing id
+            is skipped and logged, never fabricated.
 
     Returns:
-        An ImportReport with created / deduped / linked / skipped counts.
+        An ImportReport with created / deduped / linked / skipped / used counts.
     """
     from wheeler.tools.graph_tools import execute_tool
     from wheeler.tools.graph_tools import _get_backend
@@ -125,6 +132,13 @@ async def ingest_paper_finder(
                     exec_id, update_result,
                 )
     report.execution_id = exec_id
+
+    # Input-side provenance: the marshal-in built this request FROM graph nodes
+    # (at minimum the link target that motivated the search), so the run USED
+    # them. Existence-guarded + link_once, so re-ingest dedupes and a missing id
+    # is skipped, never fabricated.
+    if exec_id and used_inputs:
+        report.used += await _record_used(backend, config, exec_id, used_inputs)
 
     # Every service output is an artifact: register the raw -o JSON dump as a
     # Dataset node, linked WAS_GENERATED_BY the run Execution. Best-effort:
@@ -194,8 +208,10 @@ async def ingest_paper_finder(
 
     _save_index(index)
     logger.info(
-        "ingest_paper_finder: created=%d deduped=%d linked=%d skipped=%d (exec=%s)",
-        report.created, report.deduped, report.linked, report.skipped, exec_id,
+        "ingest_paper_finder: created=%d deduped=%d linked=%d skipped=%d "
+        "used=%d (exec=%s)",
+        report.created, report.deduped, report.linked, report.skipped,
+        report.used, exec_id,
     )
     return report
 

--- a/wheeler/integrations/asta/semantic_scholar.py
+++ b/wheeler/integrations/asta/semantic_scholar.py
@@ -91,6 +91,7 @@ from wheeler.integrations.asta._marshal import (
     _link_once,
     _load_index,
     _paper_exists,
+    _record_used,
     _save_index,
 )
 from wheeler.integrations.asta.schemas import _normalize_corpus_id
@@ -636,6 +637,7 @@ async def ingest_semantic_scholar(
     target: str | None = None,
     config: WheelerConfig,
     artifact_path: str | None = None,
+    used_inputs: list[str] | None = None,
 ) -> ImportReport:
     """Ingest a parsed Asta Semantic Scholar REST artifact into the graph.
 
@@ -661,9 +663,14 @@ async def ingest_semantic_scholar(
             Execution (the Dataset is Wheeler-produced), and every generated node
             (papers, snippet Findings) links WAS_DERIVED_FROM it. Best-effort: an
             artifact failure never breaks ingest.
+        used_inputs: Optional graph node ids the marshal-in consumed to build
+            the request (at minimum the link target that motivated the query).
+            The run Execution -[USED]-> each one that exists in the graph
+            (existence-guarded, link_once): input-side provenance. A missing id
+            is skipped and logged, never fabricated.
 
     Returns:
-        An ImportReport with created / deduped / linked / skipped counts.
+        An ImportReport with created / deduped / linked / skipped / used counts.
     """
     from wheeler.tools.graph_tools import _get_backend, execute_tool
 
@@ -707,6 +714,13 @@ async def ingest_semantic_scholar(
         )
         exec_id = exec_result.get("node_id", "")
     report.execution_id = exec_id
+
+    # Input-side provenance: the marshal-in built this request FROM graph nodes
+    # (at minimum the link target that motivated the query), so the run USED
+    # them. Existence-guarded + link_once, so re-ingest dedupes and a missing id
+    # is skipped, never fabricated.
+    if exec_id and used_inputs:
+        report.used += await _record_used(backend, config, exec_id, used_inputs)
 
     # Every service output is an artifact: the raw S2 dump registers as a Dataset
     # (D-) node (structured reference records, NOT synthesized writing). S2 has no
@@ -817,12 +831,13 @@ async def ingest_semantic_scholar(
     _save_fallback_index(fallback_index)
     logger.info(
         "ingest_semantic_scholar: sub_kind=%s created=%d deduped=%d linked=%d "
-        "skipped=%d (exec=%s)",
+        "skipped=%d used=%d (exec=%s)",
         parsed.sub_kind,
         report.created,
         report.deduped,
         report.linked,
         report.skipped,
+        report.used,
         exec_id,
     )
     return report

--- a/wheeler/integrations/asta/theorizer.py
+++ b/wheeler/integrations/asta/theorizer.py
@@ -104,6 +104,7 @@ from wheeler.integrations.asta._marshal import (
     _link_once,
     _load_index,
     _paper_exists,
+    _record_used,
     _save_index,
 )
 from wheeler.integrations.asta.schemas import _normalize_corpus_id
@@ -943,6 +944,7 @@ async def ingest_theorizer(
     link_to: str | None = None,
     config: WheelerConfig,
     artifact_path: str | None = None,
+    used_inputs: list[str] | None = None,
 ) -> ImportReport:
     """Ingest a parsed Asta Theorizer A2A Task into the knowledge graph.
 
@@ -957,9 +959,16 @@ async def ingest_theorizer(
             WAS_GENERATED_BY the run Execution, and every generated node is
             linked WAS_DERIVED_FROM it. Best-effort: an artifact failure never
             breaks theory ingest.
+        used_inputs: Optional graph node ids the marshal-in consumed to build
+            the request: the link target (the Question/Plan that motivated the
+            run) plus the Finding ids seeded into the Theorizer extraction
+            payload. The run Execution -[USED]-> each one that exists in the
+            graph (existence-guarded, link_once): input-side provenance, on top
+            of the per-evidence-paper USED edges. A missing id is skipped and
+            logged, never fabricated.
 
     Returns:
-        An ImportReport with created / deduped / linked / skipped counts.
+        An ImportReport with created / deduped / linked / skipped / used counts.
         ``paper_ids`` collects every Paper touched (created or deduped).
     """
     from wheeler.tools.graph_tools import _get_backend, execute_tool
@@ -1017,6 +1026,15 @@ async def ingest_theorizer(
             await _stamp_custom(execute_tool, config, exec_id, run_meta.custom_bag())
     report.execution_id = exec_id
 
+    # Input-side provenance: the marshal-in built this request FROM graph nodes
+    # (the link target that motivated the run plus the Finding ids seeded into
+    # the extraction payload), so the run USED them. This is on TOP of the
+    # per-evidence-paper USED edges added in _ingest_paper_edge; link_once
+    # collapses any overlap. Existence-guarded, so a missing id is skipped, never
+    # fabricated; re-ingest dedupes.
+    if exec_id and used_inputs:
+        report.used += await _record_used(backend, config, exec_id, used_inputs)
+
     # The raw service output is synthesized WRITING, so it registers as a
     # Document (W-) node (not a Dataset). register_output_artifact copies the
     # ephemeral file into the durable raw store, registers the right node type,
@@ -1069,11 +1087,13 @@ async def ingest_theorizer(
     _save_hyp_index(hyp_index)
     _save_theory_index(theory_index)
     logger.info(
-        "ingest_theorizer: created=%d deduped=%d linked=%d skipped=%d (exec=%s)",
+        "ingest_theorizer: created=%d deduped=%d linked=%d skipped=%d "
+        "used=%d (exec=%s)",
         report.created,
         report.deduped,
         report.linked,
         report.skipped,
+        report.used,
         exec_id,
     )
     return report


### PR DESCRIPTION
Follow-up to #72. Implements piece 1 of `docs/asta-engine-spec.md`.

## What

Records the **input** half of the tool contract. The marshal-in synthesizes a tool payload FROM graph nodes (the question/plan, the Findings seeded into Theorizer `extraction_results`), and the run Execution now `USED` those nodes. This completes the bidirectional provenance chain:

```
output -[WAS_GENERATED_BY]-> Execution -[USED]-> input
```

so any Asta result traces back to the exact graph context that shaped its request, not just the literature the service returned.

## How

- `_marshal.py`: `_node_exists` (generic existence guard) + `_record_used` (Execution `-[USED]->` each existing input, `link_once`, skip+log missing ids). `ImportReport.used`.
- All three ingest fns gain `used_inputs`; the CLI `ingest` verb gains `--used <ids>`; the `/wh:asta-*` acts pass `--used` with the graph ids the request was built from (the `--link-to` question/plan, plus the seeded Finding ids for Theorizer).
- e2e per adapter: USED edges for existing inputs, missing ids skipped (no fabrication), re-ingest and evidence-paper overlap add no duplicate USED edges, the full chain is queryable. Hardened the by-service e2e count assertions to the per-run `e2e_tag` (kills a pre-existing contamination-cascade flake).

## Tests

1825 passed, 2 skipped. ruff + mypy clean. Adversarially reviewed (3 lenses, all agree). No live asta calls in tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)