### PR TITLE
Asta engine: service registry + plan-lifecycle anchoring + wheeler-service-creator skill

### DIFF
--- a/.claude/commands/wh/asta.md
+++ b/.claude/commands/wh/asta.md
@@ -6,6 +6,10 @@ allowed-tools:
   - Read
   - AskUserQuestion
   - Skill
+  - Bash(asta auth status)
+  - Bash(wheeler graph status)
+  - Bash(./.venv/bin/python -c *)
+  - Bash(python -c *)
   - mcp__wheeler_core__graph_context
   - mcp__wheeler_core__search_context
   - mcp__wheeler_core__graph_gaps
@@ -15,57 +19,74 @@ allowed-tools:
   - mcp__wheeler_query__query_findings
 ---
 
-# Asta Router
+# Asta / Service Router
 
-Pick the right Asta service for the user's research intent and dispatch the matching
-`/wh:asta-*` act. Read the graph first, then suggest. Confirm before anything paid.
+Pick the right service for the user's research intent and dispatch the matching
+`/wh:*` act. The available services come from the registry (a declarative
+manifest), not a hardcoded table. Read the graph first, then suggest. Confirm
+before anything paid.
+
+## Read the registry first
+
+The service list is data, not prose in this file. Load the AVAILABLE services
+(those whose availability probe passes) from the registry:
+
+```bash
+./.venv/bin/python -c "from wheeler.config import load_config; from wheeler.integrations.registry import available_services; import json; print(json.dumps([{'id': c.id, 'name': c.name, 'act': c.act, 'kind': c.kind, 'cost': c.cost, 'when': c.when, 'description': c.description} for c in available_services(load_config())], indent=2))"
+```
+
+(If `./.venv/bin/python` is not present, use plain `python`.) The registry reads
+the user override at `.wheeler/services.yaml` if it exists, else the bundled
+default. It runs each service's `available` probe (for example `asta auth
+status`) and returns only the ones that pass, so an unauthenticated or
+uninstalled service simply will not appear. Do NOT maintain a service table in
+this file; trust the registry. If the list is empty, tell the user no services
+are available (likely asta is not authenticated: `asta auth status`) and stop.
 
 ## Routing procedure
 
-1. If `$ARGUMENTS` is non-empty, treat it as the intent and skip to step 3.
-2. If `$ARGUMENTS` is empty: read the graph (`graph_context`, `graph_gaps`) and propose
-   the highest-value next Asta action from the graph state (see Graph-aware suggestions),
-   then confirm with the user via AskUserQuestion (offer 2-4 concrete options).
-3. Match intent to a service:
-   - Broad literature discovery ("find papers on X", "what is known about Y") ->
-     `/wh:asta-lit` (Paper Finder). Cheap.
-   - A specific paper, its citations, or snippet evidence ("look up Z", "what cites Y",
-     "find the quote about X") -> `/wh:asta-scholar` (Semantic Scholar). Cheap. Citations
-     build the CITES citation graph.
-   - Hypothesis or theory generation ("generate theories about X", "what could explain
-     Y", "form hypotheses") -> `/wh:asta-theorize` (Theorizer). EXPENSIVE (about 7 dollars,
-     about 20 minutes): confirm with the user before dispatching.
-   - Analyze the user's own data ("analyze this CSV", "find patterns in my .mat",
-     "statistics on this dataset") -> DataVoyager. NOT YET BUILT (planned, Phase 4): say so
-     plainly and do not pretend to run it. Offer Paper Finder or Semantic Scholar instead
-     if literature would help.
-4. Before dispatching an expensive service (Theorizer, and DataVoyager once built), confirm
-   cost and time with the user. For the cheap services, dispatch directly.
-5. Invoke the chosen `/wh:asta-*` act via the Skill tool, prefixed with a one-line
-   explanation of the routing choice.
-6. If the task is not an Asta-suited research action, say so plainly and point the user to
-   `/wh:start` for general Wheeler routing.
+1. Load the available services from the registry (above).
+2. If `$ARGUMENTS` is non-empty, treat it as the intent and skip to step 4.
+3. If `$ARGUMENTS` is empty: read the graph (`graph_context`, `graph_gaps`) and
+   propose the highest-value next action from the graph state (see Graph-aware
+   suggestions), then confirm with the user via AskUserQuestion (offer 2-4
+   concrete options drawn from the available services).
+4. Match the intent to one of the AVAILABLE services using its `when` and
+   `description` fields. Do not offer a service that is not in the list.
+5. Warn on `cost`. Before dispatching any service whose `cost` is not "free" or
+   "cheap" (for example Theorizer at about 7 dollars, about 20 minutes), confirm
+   cost and time with the user. For free or cheap services, dispatch directly.
+6. Invoke the chosen service's `act` via the Skill tool, prefixed with a
+   one-line explanation of the routing choice.
+7. If the intent is not served by any available service (for example
+   "analyze my CSV" when DataVoyager is not built or not authenticated), say so
+   plainly: name the missing capability, do not pretend to run it, and offer the
+   closest available service (literature discovery often helps) or point the
+   user to `/wh:start` for general Wheeler routing.
 
 ## Graph-aware suggestions
 
-Use the graph state to suggest the highest-value next action, not just a keyword match.
-Read `graph_gaps` and `search_context`, then look for:
-- An OpenQuestion with linked Papers but no Hypotheses -> suggest Theorizer.
-- A Finding or Hypothesis with no supporting literature -> suggest Paper Finder or
-  Semantic Scholar.
-- A Paper with no CITES edges -> suggest `asta papers citations` via `/wh:asta-scholar`.
-- A Dataset with an open analysis question -> suggest DataVoyager (once built).
+Use the graph state to suggest the highest-value next action, not just a keyword
+match. Read `graph_gaps` and `search_context`, then look for these patterns and
+map each to an AVAILABLE service (skip the suggestion if the matching service is
+not in the registry list):
 
-Surface the trade-offs when you suggest:
-- Paper Finder: broad semantic discovery, relevance-ranked.
-- Semantic Scholar: precise lookup plus the citation graph plus snippet evidence.
-- Theorizer: literature-grounded theories with supporting and contradicting evidence
-  (expensive).
-- DataVoyager: code-executing analysis of your own data (paid, uploads files; not yet
-  built).
+- An OpenQuestion with linked Papers but no Hypotheses -> suggest the theory
+  service (Theorizer) if available. Warn on its cost.
+- A Finding or Hypothesis with no supporting literature -> suggest a literature
+  service (Paper Finder or Semantic Scholar) if available.
+- A Paper with no CITES edges -> suggest the citation lookup (Semantic Scholar
+  `papers citations`) if available.
+- A Dataset with an open analysis question -> suggest a data-analysis service
+  (DataVoyager) if it appears in the available list; otherwise say it is not
+  available and offer literature instead.
+
+Surface the trade-offs from each service's `description` when you suggest, and
+always state the `cost` for paid services.
 
 ## Style
 
 - Never use em dashes. Use colons, commas, periods, parentheses.
 - Be brief. The user wants to get into the right tool, not read about tools.
-- Always confirm before a paid service. Never claim to have run a service that is not built.
+- Always confirm before a paid service. Never claim to have run a service that
+  is unavailable or not built.

--- a/.claude/commands/wh/execute.md
+++ b/.claude/commands/wh/execute.md
@@ -71,6 +71,10 @@ When running from a registered plan (PL-xxxx):
 9. When all WHEELER tasks complete, run **Step 2.5: Honor the contract** if any contract field is set. Otherwise jump straight to checking success criteria.
 10. Call `update_node(node_id=PL-xxxx, status="completed")` (or leave as in-progress if gaps remain). Update plan file frontmatter to mirror.
 
+### External research steps (route through the service router)
+
+When a task needs external research that Wheeler does not do itself (finding literature, generating candidate theories, analyzing data with an outside agent), launch `/wh:asta`, the service router, rather than doing it inline. Do not name or hardcode any specific service: `/wh:asta` reads the service registry (`.wheeler/services.yaml`, else the bundled default) to discover what is available for the current step, suggests the right one, and warns on cost. Stay service-agnostic: the plan only knows "this step needs external work, so route it through the service router." Pass the running plan id as `--link-to PL-xxxx` so the run's Execution is anchored to the Plan (`Execution -[AROSE_FROM]-> Plan`) and its results land RELEVANT_TO it: the Plan, its Asta runs, and their outputs stay one provenance chain readable at `/wh:close`. Surface the launch as a checkpoint when it incurs cost; otherwise proceed and record the run in the SUMMARY.
+
 ### Artifact organization (canonical export directory)
 
 The archive root for a plan-based execute is `analysis_exports/<investigation_slug>_<YYYY-MM-DD>/`. Once Step 2.4 has created the directory, treat this as the source of truth for figure and dataset outputs:

--- a/.claude/commands/wh/plan.md
+++ b/.claude/commands/wh/plan.md
@@ -314,6 +314,9 @@ Rules:
 ## Handoff Awareness
 When the plan is clear and remaining work is mostly grinding (lit search, data wrangling, boilerplate code, graph ops), recognize the handoff moment and propose tasks inline — don't wait for the scientist to invoke `/wh:handoff`. Present each task with description, assignee (SCIENTIST/WHEELER/PAIR), model (sonnet/haiku), time estimate, and checkpoint conditions. But don't force it — only when it's natural and the question is sharp.
 
+## External research steps (offer the service router)
+When a plan step needs external research that Wheeler does not do itself (finding literature, generating candidate theories, analyzing data with an outside agent), offer to launch `/wh:asta`, the service router. Do not name or hardcode any specific service: `/wh:asta` reads the service registry (`.wheeler/services.yaml`, else the bundled default) to discover what is actually available, suggests the right service for the step, and warns on cost. Stay service-agnostic: the plan only knows "this step needs external work, so route it through the service router." Hand off with the plan context and pass the plan id as `--link-to PL-xxxx` so the run's Execution is anchored to the Plan (`Execution -[AROSE_FROM]-> Plan`) and its results land RELEVANT_TO it, keeping the Plan, its runs, and their outputs in one provenance chain. Offer this, do not auto-run it.
+
 If $ARGUMENTS names a clear research topic, call `search_context` with it and briefly summarize what the graph knows. Otherwise, ask what the scientist wants to investigate, use AskUserQuestion to clarify intent, then call `search_context` once the topic is sharp.
 
 $ARGUMENTS

--- a/.claude/skills/wheeler-service-creator/SKILL.md
+++ b/.claude/skills/wheeler-service-creator/SKILL.md
@@ -1,0 +1,319 @@
+---
+name: wheeler-service-creator
+description: >-
+  Scaffold a NEW Wheeler service adapter from a tool, closing the loop with the
+  tool-contract idea. Given a tool (interview the scientist, or read its
+  `--help` / agent card), it drafts (a) the `.wheeler/services.yaml` registry
+  entry (identity, ports, output shape, availability, cost), (b) a marshal-out
+  ingest skeleton `wheeler/integrations/<provider>/<tool>.py` wired to
+  `_marshal.py` helpers + `register_output_artifact` (the only `execute_tool`
+  caller, lazy import), (c) the marshal-in act `/wh:<provider>-<tool>` that reads
+  graph context, passes `--used` source ids, and shells out, and (d) a
+  parse-unit + live-Neo4j e2e test stub following the per-run `e2e_tag`
+  hermetic-teardown convention. Use whenever the user wants to "create a wheeler
+  service", "add a new tool adapter", "scaffold an integration", "wrap a service
+  for wheeler", "ingest a new tool's output into the graph", or onboard any
+  external research tool (a search API, a generator, an analyzer, an agent card)
+  as a provenance-tracked Wheeler adapter. The skill mostly emits prose
+  instructions and skeleton files; it tells the human to capture one real output,
+  fill the parser against it, then run the adversarial-review workflow to land it.
+  Do NOT trigger for using an EXISTING adapter (that is `/wh:asta-*`), for graph
+  lookups, or for generic coding.
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+---
+
+# Wheeler service creator
+
+You scaffold a new Wheeler service adapter from a tool. A tool becomes a
+declarative **contract** (one `.wheeler/services.yaml` entry); a command opts in
+via a flag; a run is a step whose provenance reaches BACK to its graph inputs
+(`USED`) and FORWARD to its graph outputs (`WAS_GENERATED_BY`). The Asta
+adapters are instance #1 and your concrete template. You produce the four
+pieces, then hand the scientist a short to-do list: capture one real output,
+fill the parser against it, run the adversarial review, land it.
+
+You write SKELETONS, not finished adapters. The parser is tool-specific and can
+only be written against a real captured output, which you do not have at scaffold
+time. Your job is to lay down every piece of the structure correctly so the human
+fills one function (`parse_<tool>`) and reviews.
+
+## When this fires
+
+The scientist wants to wrap an external tool so its output lands in the graph
+with provenance. Examples: a new Asta sub-tool, a different literature API, a
+domain analyzer that emits JSON, an agent with an A2A card. Read the spec
+`docs/asta-engine-spec.md` section 3 for the design intent.
+
+Do NOT fire for running an existing adapter (that is the `/wh:<provider>-<tool>`
+act itself), for graph queries, or for generic coding.
+
+## The template you are copying
+
+Study these before you scaffold. They are the canonical example; mirror their
+structure, their docstrings, and their invariants. All paths are relative to the
+repo root.
+
+- `wheeler/integrations/asta/_marshal.py` -- the SHARED marshal-out helpers
+  (`ImportReport`, the persisted corpus_id index, `_link_once` / `_edge_exists`,
+  `_node_exists` / `_record_used` for input-side provenance). Your adapter
+  imports these; it does NOT reimplement them.
+- `wheeler/integrations/asta/ingest.py` -- Paper Finder, the simplest adapter
+  (output is a Dataset of reference records).
+- `wheeler/integrations/asta/theorizer.py` -- the richest adapter (parses an A2A
+  Task into a Finding/Hypothesis/Paper subgraph, output is a Document).
+- `wheeler/integrations/asta/semantic_scholar.py` -- a multi-shape adapter
+  (auto-detects sub-kind, output is a Dataset).
+- `wheeler/integrations/asta/artifacts.py` -- `register_output_artifact`: durably
+  saves the raw `-o` dump and registers it as a Document (W-) or Dataset (D-)
+  node `WAS_GENERATED_BY` the run Execution.
+- `wheeler/integrations/asta/cli.py` -- the single `wheeler integrate ingest`
+  verb that the act shells out to (`--link-to`, `--used`, `--target`).
+- `.claude/commands/wh/asta-lit.md`, `asta-theorize.md`, `asta-scholar.md` -- the
+  marshal-in acts. Each reads graph context, picks a link target, shells out to
+  the tool CLI, then calls `wheeler integrate ingest ... --used <ids>`.
+- `tests/integrations/asta/test_theorizer.py` -- the test template: parse-unit
+  tests (no live call) PLUS a live-Neo4j e2e class with the per-run `e2e_tag`
+  hermetic-teardown convention.
+
+If the user has an `assets/` scaffolder available next to this SKILL.md, you MAY
+run it to emit the skeleton files mechanically (see "Optional scaffolder"
+below). Otherwise write them by hand from the templates. Markdown-driven (writing
+the files yourself) is fully acceptable.
+
+## Step 1: gather the contract
+
+Interview the scientist, or read the tool's `--help` / agent card. You need a
+small contract dict. Ask only for what you cannot infer; default the rest.
+
+- **provider**: the family (e.g. `asta`, `s2`, `myorg`). Lower-case, slug-safe.
+- **tool**: the specific tool (e.g. `paper-finder`, `theorizer`, `datavoyager`).
+  Lower-case, slug-safe. Together they give the service id
+  `<provider>-<tool>`, the service tag `<provider>:<tool>`, the act
+  `/wh:<provider>-<tool>`, and the module `wheeler/integrations/<provider>/<tool>.py`.
+- **name** + **description**: human label and one line of what it does.
+- **kind**: `shell-out` (a CLI you invoke, the common case) or `local`.
+- **cli_invocation**: the exact command the act runs, with `-o <tempfile>` so it
+  dumps JSON (e.g. `asta literature find "$QUERY" -o /tmp/<tool>.json`). Capture
+  the auth requirement and rough cost/time.
+- **availability**: the probe command whose zero exit means the tool is usable
+  (e.g. `asta auth status`). The registry filters out services whose probe fails.
+- **cost**: a short human string (e.g. `"expensive (~$7, ~20min)"` or `"free"`).
+- **when**: a one-line trigger phrase for the router (e.g. `"hypothesis or
+  theory generation"`).
+- **inputs (ports)**: the graph nodes the marshal-in synthesizes the request
+  FROM. Each is `{name, source, required}` where `source` is `query`
+  (the sharpened question), `findings` (seeded Finding ids), `datasets`
+  (Dataset paths), etc. These are exactly the ids that become `--used` arguments.
+- **output shape**:
+  - `raw_node`: `document` (synthesized WRITING, like Theorizer) or `dataset`
+    (structured reference RECORDS, like Paper Finder / Semantic Scholar). Pick
+    `document` for prose/theories, `dataset` for records/data. NEVER call
+    everything a Dataset.
+  - `nodes`: the Wheeler node types the parser produces (e.g.
+    `[Finding, Hypothesis, Paper]`, or `[Paper]`).
+  - `dedupe`: the natural key per produced node type (corpus_id for Papers, a
+    content hash for nodes with no external id).
+  - `edges`: the semantic relationships (SUPPORTS, CONTRADICTS, CITES,
+    APPEARS_IN, RELEVANT_TO, AROSE_FROM, CONTAINS) and which node pairs they join.
+
+Write the contract back to the scientist in one block and confirm it before
+generating. A wrong contract means wrong skeletons.
+
+## Step 2: the `.wheeler/services.yaml` entry
+
+Append (do not overwrite) an entry under `services:`. `services.yaml` is
+user-editable and ships empty; create it with a `services: []` root if absent.
+Mirror the spec's shape exactly:
+
+```yaml
+  - id: <provider>-<tool>
+    provider: <provider>
+    name: <Name>
+    description: <one line>
+    kind: shell-out                 # shell-out | local
+    act: /wh:<provider>-<tool>
+    cost: "<cost string>"
+    available: "<probe command>"    # filtered out on non-zero exit
+    when: "<router trigger phrase>"
+    inputs:                          # the USED set + the marshalling map
+      - { name: <port>, source: <query|findings|datasets>, required: true }
+    output:
+      raw_node: <document|dataset>
+      nodes: [<NodeType>, ...]
+```
+
+This is the contract. Identity + ports + output shape, NOT a field-map language:
+the parser stays tool-specific Python. Leave a comment pointing at the module
+that implements it.
+
+## Step 3: the marshal-out ingest skeleton
+
+Create `wheeler/integrations/<provider>/<tool>.py` (and an empty
+`wheeler/integrations/<provider>/__init__.py` if the provider package is new).
+Copy the structure of `theorizer.py` (for a node-subgraph output) or `ingest.py`
+(for a flat record output). The skeleton MUST:
+
+1. Open with a docstring stating the REAL output shape (fill the placeholder once
+   a real output is captured), the bucketing/mapping, and the standing
+   invariants verbatim from the template:
+   - Defensive: every step tolerates missing pieces, counts and skips, never
+     raises.
+   - Sequential writes only. Never `asyncio.gather`: `execute_tool` reuses one
+     cached backend singleton and Neo4j forbids concurrent queries.
+   - link_once: every edge is existence-guarded because the backend's
+     `create_relationship` is a bare CREATE that duplicates on re-run.
+   - One Execution per RUN, tagged service `<provider>:<tool>`.
+2. Define `_SERVICE_TAG = "<provider>:<tool>"` and
+   `_RAW_NODE_TYPE = "<document|dataset>"`.
+3. Import the SHARED helpers from `_marshal.py`
+   (`ImportReport`, `_find_execution`, `_link_once`, `_load_index`,
+   `_paper_exists`, `_record_used`, `_save_index`, ...). Do NOT reimplement them.
+4. Provide a pure `parse_<tool>(doc) -> (records, run_meta)` that is defensive and
+   NEVER raises (leave the body a clearly-marked `# TODO: fill against a real
+   captured output` stub returning `([], RunMeta())`, with the small coercion
+   helpers `_as_str` / `_as_float` / `_first` copied in so the human only writes
+   the shape-walk).
+5. Provide `async def ingest_<tool>(doc, *, link_to=None, config, artifact_path=None,
+   used_inputs=None) -> ImportReport`. It MUST, in order:
+   - `from wheeler.tools.graph_tools import _get_backend, execute_tool` (lazy,
+     function-local: this is the ONLY `execute_tool` caller, so the triple-write
+     + write-receipt + trace-id + embedding wiring fires, and `graph_tools/`
+     stays adapter-free, mirroring `wheeler/validation/ledger.py`).
+   - dedupe-or-create ONE Execution per run via `_find_execution` (idempotent),
+     tagged `service=_SERVICE_TAG` with a stable `session_id`.
+   - record input-side provenance: `report.used += await _record_used(backend,
+     config, exec_id, used_inputs)` (existence-guarded, link_once, never
+     fabricates a missing id).
+   - register the raw output via `register_output_artifact(artifact_path,
+     execution_id=exec_id, service=_SERVICE_TAG, config=config,
+     node_type=_RAW_NODE_TYPE, ...)` (best-effort, never raises).
+   - bucket each parsed record into its nodes, every WRITE through
+     `execute_tool`, every edge through `_link_once`.
+   - apply the Paper rule when the output references papers: papers dedupe on
+     `corpus_id`, are REFERENCE ENTITIES (NO `WAS_GENERATED_BY`), and if the
+     produced knowledge was DERIVED from a paper, the run `Execution -[USED]->`
+     that paper.
+   - return the `ImportReport` with created / deduped / linked / skipped / used
+     counts.
+
+Every graph write routes through `execute_tool`. Never write the backend or the
+files directly.
+
+## Step 4: register the CLI verb
+
+The act does not call Python directly; it shells out to `wheeler integrate ingest
+<tool> <artifact.json> --link-to <id> --used <ids>`. Wire the new tool into
+`wheeler/integrations/asta/cli.py` (or a sibling `<provider>/cli.py` if the
+provider is new and gets its own sub-app):
+
+1. Add the tool name (and any alias) to the `_INGESTERS` set.
+2. Add a dispatch branch that lazily imports `ingest_<tool>` and calls it inside
+   `asyncio.run(...)`, forwarding `link_to`, `config`, `artifact_path=str(artifact)`,
+   and `used_inputs`. Keep the existing `--used` parsing (comma-split, blanks
+   dropped, normalized to `None`).
+
+If you create a new provider sub-app, register it on the top-level Typer app the
+same way `integrate_app` is registered, and keep one `ingest` verb only (no
+send/dispatch verb: Wheeler must not become a second router that invokes the tool).
+
+## Step 5: the marshal-in act
+
+Create `.claude/commands/wh/<provider>-<tool>.md`, copying `asta-theorize.md` (or
+`asta-lit.md` for a flat search). The act IS the system prompt. It MUST:
+
+- Frontmatter: `name: wh:<provider>-<tool>`, a narrow `description` (the trigger
+  vocabulary, demanding tool + knowledge-graph words so it does not auto-fire on
+  generic coding), `argument-hint`, and `allowed-tools` limited to `Read`, the
+  tool's `Bash(<tool>:*)`, `Bash(wheeler integrate:*)`, and the read-only MCP
+  tools the preflight needs (`mcp__wheeler_core__search_context`, the relevant
+  `mcp__wheeler_query__query_*`).
+- **Preflight**: confirm the tool is installed (its `--version` / availability
+  probe); stop cleanly if not. Read graph context with `search_context` and the
+  typed `query_*` to SHARPEN the request and pick a link target. "Do not invent
+  results / theories. Do not do the scientist's thinking."
+- **Choose the request + link target**: the request is `$ARGUMENTS` or derived
+  from the active question; pick at most one `Q-`/`PL-` link target.
+- **Run**: the exact `cli_invocation` writing to a temp file. A non-zero exit
+  reports and stops (a failed run writes nothing to the graph by design).
+- **Ingest**: `wheeler integrate ingest <tool> <tempfile> --link-to <id> --used
+  <id>,<id>`. Spell out that `--used` carries the graph node ids the request was
+  built FROM (the link target plus any seeded source ids), recording
+  `Execution -[USED]-> each input` so every result traces back to the graph
+  context that shaped it. State that the verb is idempotent.
+- **Report**: relay the printed summary in one or two sentences; suggest the
+  `query_*` filters to browse the new nodes. Never editorialize the science.
+- **No em dashes** anywhere.
+
+After writing acts you MUST sync the `_data` mirror so the shipped package
+matches (the same command exists in `.claude/commands/wh/` and
+`wheeler/_data/commands/`): run
+`python -c "from wheeler.installer import sync_data; sync_data()"`.
+
+## Step 6: the test stub
+
+Create `tests/integrations/<provider>/test_<tool>.py` (and an empty
+`__init__.py`), copying `tests/integrations/asta/test_theorizer.py`. Two layers,
+NEITHER making a live tool call:
+
+1. **Parse-unit** (`class TestParse<Tool>`): assert `parse_<tool>` against a
+   trimmed REAL fixture in `tests/integrations/<provider>/fixtures/`, plus
+   shape-drift / garbage tolerance (a non-dict, an empty artifacts list, missing
+   keys -> `([], RunMeta())`, never raises). Leave the fixture path and the
+   expected-count constants as clearly-marked TODOs the human fills once a real
+   output is captured.
+2. **Live-Neo4j e2e** (`class TestIngest<Tool>E2E`): skipped automatically when
+   Neo4j is unreachable. Follow the per-run `e2e_tag` hermetic-teardown
+   convention EXACTLY:
+   - A module-scoped `e2e_config` fixture pointing at local Neo4j, a
+     `neo4j_available` probe, and a `_reset_driver_singleton` autouse fixture
+     (copy them verbatim from `test_theorizer.py`).
+   - A `_cleanup_<tool>(e2e_config, e2e_tag)` helper whose teardown is EXACTLY
+     `MATCH (n) WHERE n.e2e_tag = $tag DETACH DELETE n` and nothing else. NEVER
+     delete by `service` or `corpus_id`: the e2e config runs on the SHARED
+     default namespace where production nodes carry the same service tag and the
+     same corpus_ids, so a service-scoped or corpus_id-scoped delete would wipe
+     real user data.
+   - An autouse `_skip_and_cleanup` fixture that `monkeypatch.chdir(tmp_path)`
+     (so the on-disk indices and the durable raw store are isolated per test),
+     mints a per-run unique tag `f"integrations_e2e_{uuid.uuid4().hex}"`, and
+     pre-cleans + post-cleans on it.
+   - A `_tag_all(e2e_config, report)` helper that tags ONLY the nodes THIS run
+     created, scoped off the returned `report` ids (Execution, artifact, every
+     Paper) PLUS the run's `WAS_GENERATED_BY` fan-in. NEVER tag by service or
+     corpus_id. Papers are reference entities (no `WAS_GENERATED_BY`), so they
+     are tagged by `report.paper_ids`, not via the fan-in.
+   - One test that ingests the fixture, tags, asserts the bucketing subgraph
+     (node counts, edge counts, custom fields) scoped to THIS run's `e2e_tag`,
+     then RE-INGESTS the same artifact and asserts idempotency (identical counts,
+     `created==0` on the second pass).
+
+## Step 7: hand off to the human
+
+You scaffolded the structure; the parser is the one thing only a real output can
+teach. Tell the scientist, in this order:
+
+1. **Capture one real output**: run the tool once for real
+   (`<cli_invocation>`), save the `-o` JSON, and drop a trimmed copy under
+   `tests/integrations/<provider>/fixtures/<tool>_real_sample.json`.
+2. **Fill the parser**: write `parse_<tool>` against that captured shape, and
+   fill the fixture path + expected-count constants in the test. The skeleton's
+   defensive helpers and invariants are already in place; only the shape-walk is
+   missing.
+3. **Run the tests**: `./.venv/bin/python -m pytest
+   tests/integrations/<provider>/test_<tool>.py -q` (the e2e class needs a live
+   Neo4j; it skips otherwise).
+4. **Adversarial review**: run the repo's adversarial-review workflow on the
+   adapter (a fresh reviewer agent re-checks every claim: provenance edges, the
+   Paper reference-entity rule, the `--used` input provenance, idempotency, the
+   hermetic teardown) before landing. Adding a service is then: run the creator
+   -> fill the parser -> review -> land.
+
+Report back the four files you created (the `services.yaml` entry, the ingest
+skeleton, the act, the test stub) plus the CLI verb wiring, and the exact to-do
+list above. Never use em dashes.

--- a/.claude/skills/wheeler-service-creator/assets/scaffold_service.py
+++ b/.claude/skills/wheeler-service-creator/assets/scaffold_service.py
@@ -1,0 +1,826 @@
+"""Stdlib-only scaffolder for a new Wheeler service adapter.
+
+Given a small CONTRACT dict, emit the four skeleton files the
+``wheeler-service-creator`` skill describes:
+
+  1. a ``.wheeler/services.yaml`` entry (appended, never overwriting),
+  2. a marshal-out ingest skeleton ``wheeler/integrations/<provider>/<tool>.py``,
+  3. a marshal-in act ``.claude/commands/wh/<provider>-<tool>.md``,
+  4. a parse-unit + live-Neo4j e2e test stub
+     ``tests/integrations/<provider>/test_<tool>.py``.
+
+This is a MECHANICAL boilerplate writer, not the adapter. The one thing it can
+NOT write is the parser body (``parse_<tool>``): that is tool-specific and only a
+real captured output can teach it, so the skeleton leaves it a clearly-marked
+TODO returning ``([], RunMeta())``. The skill's prose is the source of truth; this
+helper just saves the human from hand-copying boilerplate. Markdown-driven
+scaffolding (the model writing the files itself) is equally valid.
+
+Stdlib only (no PyYAML): the services.yaml entry is emitted as hand-rolled YAML
+text, mirroring the shape in ``docs/asta-engine-spec.md`` section 2. Pure I/O;
+no graph dependency, no LLM-provider import.
+
+Run as a module for a smoke scaffold::
+
+    python scaffold_service.py --provider myorg --tool widget \\
+        --name Widget --raw-node dataset --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Valid raw-node types (the raw output node). document = synthesized WRITING
+# (W-), dataset = structured reference RECORDS (D-). Never call everything a
+# Dataset; reserve it for genuine data / records.
+_RAW_NODE_TYPES = {"document", "dataset"}
+
+
+def _slug(value: str) -> str:
+    """Lower-case, filesystem-and-id-safe slug (letters, digits, hyphens)."""
+    s = re.sub(r"[^a-z0-9]+", "-", (value or "").strip().lower())
+    return s.strip("-")
+
+
+def _ident(value: str) -> str:
+    """Python-identifier-safe token (slug with hyphens -> underscores)."""
+    return _slug(value).replace("-", "_") or "tool"
+
+
+def _camel(value: str) -> str:
+    """CamelCase token for class names (e.g. 'paper-finder' -> 'PaperFinder')."""
+    return "".join(part.capitalize() for part in _slug(value).split("-") if part)
+
+
+@dataclass
+class ServiceContract:
+    """The minimal contract that drives the scaffold.
+
+    Identity + ports + output shape, NOT a field-map language: the parser stays
+    tool-specific Python. ``raw_node`` is ``document`` (synthesized writing) or
+    ``dataset`` (structured records).
+    """
+
+    provider: str
+    tool: str
+    name: str = ""
+    description: str = ""
+    kind: str = "shell-out"
+    cli_invocation: str = ""
+    available: str = ""
+    cost: str = "unknown"
+    when: str = ""
+    raw_node: str = "dataset"
+    nodes: list[str] = field(default_factory=lambda: ["Paper"])
+    inputs: list[dict] = field(default_factory=list)
+
+    # --- derived identity ---
+    @property
+    def provider_slug(self) -> str:
+        return _slug(self.provider) or "provider"
+
+    @property
+    def tool_slug(self) -> str:
+        return _slug(self.tool) or "tool"
+
+    @property
+    def tool_ident(self) -> str:
+        return _ident(self.tool)
+
+    @property
+    def tool_camel(self) -> str:
+        return _camel(self.tool) or "Tool"
+
+    @property
+    def service_id(self) -> str:
+        return f"{self.provider_slug}-{self.tool_slug}"
+
+    @property
+    def service_tag(self) -> str:
+        return f"{self.provider_slug}:{self.tool_slug}"
+
+    @property
+    def act_name(self) -> str:
+        return f"wh:{self.provider_slug}-{self.tool_slug}"
+
+    @property
+    def display_name(self) -> str:
+        return self.name or self.tool_camel
+
+    @property
+    def cli_binary(self) -> str:
+        """The CLI command the act invokes; drives the ``Bash(<binary>:*)`` grant.
+
+        Taken from the first token of ``cli_invocation`` (e.g. ``asta`` from
+        ``asta literature find ...``), so the allowed-tools Bash prefix matches
+        the real binary the act runs, mirroring ``Bash(asta:*)`` in the Asta
+        acts. Falls back to the tool slug when no invocation is given.
+        """
+        head = (self.cli_invocation or "").strip().split()
+        return head[0] if head else self.tool_slug
+
+    def __post_init__(self) -> None:
+        if (self.raw_node or "").lower() not in _RAW_NODE_TYPES:
+            raise ValueError(
+                f"raw_node must be one of {sorted(_RAW_NODE_TYPES)}, "
+                f"got {self.raw_node!r}"
+            )
+        self.raw_node = self.raw_node.lower()
+        # Reject a blank provider/tool BEFORE the slug fallback masks it: an empty
+        # or whitespace-only input is a genuine error, not a "provider"/"tool"
+        # default.
+        if not _slug(self.provider) or not _slug(self.tool):
+            raise ValueError("provider and tool are required and must be slug-safe")
+
+
+# ---------------------------------------------------------------------------
+# Renderers (each returns the file text; pure, no I/O)
+# ---------------------------------------------------------------------------
+
+
+def render_services_entry(c: ServiceContract) -> str:
+    """Render one ``services.yaml`` list entry (hand-rolled YAML, stdlib only)."""
+    inputs = c.inputs or [{"name": "query", "source": "query", "required": True}]
+    lines = [
+        f"  - id: {c.service_id}",
+        f"    provider: {c.provider_slug}",
+        f"    name: {c.display_name}",
+        f"    description: {c.description or c.display_name}",
+        f"    kind: {c.kind}",
+        f"    act: /{c.act_name}",
+        f'    cost: "{c.cost}"',
+        f'    available: "{c.available or c.tool_slug + " --version"}"',
+        f'    when: "{c.when or c.description or c.display_name}"',
+        "    inputs:",
+    ]
+    for port in inputs:
+        name = port.get("name", "query")
+        source = port.get("source", "query")
+        required = "true" if port.get("required") else "false"
+        lines.append(
+            f"      - {{ name: {name}, source: {source}, required: {required} }}"
+        )
+    node_list = ", ".join(c.nodes) if c.nodes else "Paper"
+    lines += [
+        "    output:",
+        f"      raw_node: {c.raw_node}",
+        f"      nodes: [{node_list}]",
+        f"    # implemented by wheeler/integrations/{c.provider_slug}/{c.tool_ident}.py",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def render_ingest(c: ServiceContract) -> str:
+    """Render the marshal-out ingest skeleton (parser left a TODO stub)."""
+    return f'''"""Marshal-out (deterministic): ingest a {c.display_name} artifact.
+
+SCAFFOLD. Fill ``parse_{c.tool_ident}`` against ONE real captured output, then
+run the adversarial review. A marshal-out module mirroring the Asta adapters: it
+imports ``execute_tool`` lazily (function-local) so every graph write routes
+through the triple-write + write-receipt + trace-id + embedding wiring, and
+reuses the shared helpers in ``_marshal.py`` plus ``register_output_artifact`` in
+``artifacts.py``.
+
+REAL output shape: TODO (capture one real run and document it here).
+
+Invariants (verbatim from the template, keep them true):
+  - Defensive: every step tolerates missing pieces, counts and skips, never
+    raises. A partial or shape-drifted artifact never aborts ingest.
+  - Sequential writes only. Never ``asyncio.gather``: ``execute_tool`` reuses
+    one cached backend singleton and Neo4j forbids concurrent queries.
+  - link_once: every edge is existence-guarded because the backend's
+    ``create_relationship`` is a bare CREATE that duplicates on re-run.
+  - One Execution per RUN, tagged service ``{c.service_tag}``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from wheeler.config import WheelerConfig
+from wheeler.integrations.{c.provider_slug}._marshal import (  # type: ignore[import-not-found]
+    ImportReport,
+    _find_execution,
+    _link_once,
+    _record_used,
+)
+
+logger = logging.getLogger(__name__)
+
+_SERVICE_TAG = "{c.service_tag}"
+# document = synthesized WRITING (W-), dataset = structured RECORDS (D-).
+_RAW_NODE_TYPE = "{c.raw_node}"
+
+
+@dataclass
+class RunMeta:
+    """Benchmark fields lifted from the run (run_id, cost, time, model)."""
+
+    run_id: str = ""
+    cost: float | None = None
+    time: float | None = None
+    model: str = ""
+
+    def custom_bag(self) -> dict[str, Any]:
+        bag: dict[str, Any] = {{"service": _SERVICE_TAG}}
+        if self.run_id:
+            bag["run_id"] = self.run_id
+        if self.cost is not None:
+            bag["cost"] = self.cost
+        if self.time is not None:
+            bag["time"] = self.time
+        if self.model:
+            bag["model"] = self.model
+        return bag
+
+
+# --- defensive coercion helpers (copied from the template) ---
+
+
+def _first(d: dict[str, Any], *keys: str, default: Any = None) -> Any:
+    for key in keys:
+        if key in d and d[key] is not None:
+            return d[key]
+    return default
+
+
+def _as_str(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    return str(value)
+
+
+def _as_float(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value.strip())
+        except ValueError:
+            return None
+    return None
+
+
+def parse_{c.tool_ident}(doc: Any) -> tuple[list[Any], RunMeta]:
+    """Parse a {c.display_name} output into records + run metadata.
+
+    TODO: fill against a real captured output. Defensive throughout: a doc that
+    is not the expected shape yields ``([], RunMeta())`` so a partial artifact
+    never aborts ingest.
+    """
+    if not isinstance(doc, dict):
+        logger.warning(
+            "parse_{c.tool_ident}: doc is not a dict, got %s", type(doc).__name__
+        )
+        return [], RunMeta()
+    # TODO: walk the real shape into records and lift the run metadata.
+    return [], RunMeta()
+
+
+async def ingest_{c.tool_ident}(
+    doc: dict[str, Any],
+    *,
+    link_to: str | None = None,
+    config: WheelerConfig,
+    artifact_path: str | None = None,
+    used_inputs: list[str] | None = None,
+) -> ImportReport:
+    """Ingest a parsed {c.display_name} output into the knowledge graph.
+
+    Args:
+        doc: The raw {c.display_name} output dict.
+        link_to: Optional node id (Question/Plan) each produced node links to.
+        config: Active Wheeler config.
+        artifact_path: Optional path to the raw output file; registered as the
+            declared raw node ({c.raw_node}) WAS_GENERATED_BY the run Execution.
+        used_inputs: Optional graph node ids the marshal-in consumed to build the
+            request. The run Execution -[USED]-> each one that exists (input-side
+            provenance, existence-guarded, link_once, never fabricated).
+
+    Returns:
+        An ImportReport with created / deduped / linked / skipped / used counts.
+    """
+    from wheeler.tools.graph_tools import _get_backend, execute_tool
+
+    report = ImportReport()
+    records, run_meta = parse_{c.tool_ident}(doc)
+    if not records:
+        logger.warning("ingest_{c.tool_ident}: no parseable records in artifact")
+        return report
+
+    backend = await _get_backend(config)
+
+    # One Execution per RUN, tagged with the service. session_id correlates every
+    # node written this turn and makes the run idempotent.
+    session_id = run_meta.run_id or "TODO-stable-run-key"
+    exec_id = await _find_execution(
+        backend, config, service=_SERVICE_TAG, session_id=session_id
+    )
+    if not exec_id:
+        import json
+
+        exec_result = json.loads(
+            await execute_tool(
+                "add_execution",
+                {{
+                    "kind": "{c.tool_slug}",
+                    "description": f"{c.display_name}: {{run_meta.run_id}}",
+                    "agent_id": "{c.provider_slug}",
+                    "status": "completed",
+                    "session_id": session_id,
+                    "service": _SERVICE_TAG,
+                }},
+                config,
+            )
+        )
+        exec_id = exec_result.get("node_id", "")
+    report.execution_id = exec_id
+
+    # Input-side provenance: the marshal-in built this request FROM graph nodes,
+    # so the run USED them. Existence-guarded; a missing id is skipped, never
+    # fabricated; re-ingest dedupes via link_once.
+    if exec_id and used_inputs:
+        report.used += await _record_used(backend, config, exec_id, used_inputs)
+
+    # The raw output is saved durably and registered as the declared node type,
+    # linked WAS_GENERATED_BY the run Execution. Best-effort: never raises.
+    try:
+        from wheeler.integrations.{c.provider_slug}.artifacts import (  # type: ignore[import-not-found]
+            register_output_artifact,
+        )
+
+        await register_output_artifact(
+            artifact_path,
+            execution_id=exec_id,
+            service=_SERVICE_TAG,
+            config=config,
+            node_type=_RAW_NODE_TYPE,
+            run_id=run_meta.run_id,
+            benchmark=run_meta.custom_bag(),
+            description=f"{{_SERVICE_TAG}} raw output",
+        )
+    except Exception:
+        logger.warning(
+            "ingest_{c.tool_ident}: artifact registration raised (best-effort)",
+            exc_info=True,
+        )
+
+    # TODO: bucket each record into its nodes. Every WRITE goes through
+    # execute_tool; every edge through _link_once. If the output references
+    # papers: dedupe on corpus_id, papers carry NO WAS_GENERATED_BY (reference
+    # entities), and the run Execution -[USED]-> a paper the knowledge was
+    # derived from. Link produced nodes WAS_GENERATED_BY exec_id and, when
+    # link_to is given, to it (AROSE_FROM / RELEVANT_TO as the contract says).
+    _ = (backend, execute_tool, link_to, _link_once)  # placeholders, fill above
+
+    logger.info(
+        "ingest_{c.tool_ident}: created=%d deduped=%d linked=%d skipped=%d "
+        "used=%d (exec=%s)",
+        report.created,
+        report.deduped,
+        report.linked,
+        report.skipped,
+        report.used,
+        exec_id,
+    )
+    return report
+'''
+
+
+def render_act(c: ServiceContract) -> str:
+    """Render the marshal-in act (the system prompt) for the new tool."""
+    cli = c.cli_invocation or f'{c.tool_slug} run "$ARGUMENTS" -o /tmp/{c.tool_slug}.json'
+    probe = c.available or f"{c.cli_binary} --version"
+    return f'''---
+name: {c.act_name}
+description: Use when the user wants to run {c.display_name} and ingest the results into the Wheeler knowledge graph
+argument-hint: "[request]"
+allowed-tools:
+  - Read
+  - Bash({c.cli_binary}:*)
+  - Bash(wheeler integrate:*)
+  - mcp__wheeler_core__search_context
+  - mcp__wheeler_query__query_findings
+
+---
+
+You are Wheeler, running {c.display_name} over a request and marshalling the results into the knowledge graph. You orchestrate; the {c.tool_slug} CLI does the work and owns its own auth and timeouts; one deterministic `wheeler integrate` verb writes the graph.
+
+## Preflight
+
+1. Confirm the tool is installed: `{probe}`. If that fails, say {c.display_name} is not available and stop. Do not attempt the run.
+2. Read context so the request is shaped by the graph. Use `mcp__wheeler_core__search_context` with the user's request (or the active question) to see what is already known, and the relevant `mcp__wheeler_query__query_*` for existing nodes. Use this only to sharpen the request and choose a link target. Do not invent results. Do not do the scientist's thinking.
+
+## Choose the request and link target
+
+- The request is `$ARGUMENTS` when provided. If empty, ask the user or derive one from the active investigation.
+- Pick at most one link target: the Question (`Q-...`) or Plan (`PL-...`) this run supports. If there is no clear target, run without one.
+
+## Run
+
+Run the CLI, writing the artifact to a temp file:
+
+```
+{cli}
+```
+
+If the command exits non-zero (including a login or auth failure), report it and stop. A failed run writes nothing to the graph by design.
+
+## Ingest
+
+Marshal the artifact into the graph with the single integrate verb:
+
+```
+wheeler integrate ingest {c.tool_ident} /tmp/{c.tool_slug}.json --link-to <Q- or PL- id> --used <Q- or PL- id>,<source ids>
+```
+
+Omit `--link-to` if there is no target. Pass `--used` with the graph node ids the request was built FROM (at minimum the link target, plus any seeded source ids): this records `Execution -[USED]-> each input` (input-side provenance), so every result traces back to the graph context that shaped the request, not just what the tool returned. Omit `--used` if there were no graph inputs. The verb is idempotent: re-running the same artifact creates no duplicate nodes, edges, or USED edges.
+
+## Report
+
+Relay the printed summary (`created`, `deduped`, `linked`, `skipped`, the run Execution id, and the new node ids) to the user in one or two sentences. The results are now in the graph; suggest the relevant `query_*` filters to browse them. Do not editorialize the science. Never use em dashes.
+'''
+
+
+def render_test(c: ServiceContract) -> str:
+    """Render the parse-unit + live-Neo4j e2e test stub for the new tool."""
+    cleanup = f"_cleanup_{c.tool_ident}"
+    return f'''"""Tests for the {c.display_name} adapter.
+
+SCAFFOLD. Two layers, NEITHER making a live {c.tool_slug} call:
+  1. parse_{c.tool_ident}: parse a trimmed REAL fixture plus shape-drift /
+     garbage tolerance (never raises). Fill the fixture + expected counts.
+  2. live-Neo4j e2e: ingest the real fixture, assert the bucketing subgraph,
+     then re-ingest the SAME artifact and assert idempotency. Skipped
+     automatically when Neo4j is not reachable.
+
+Run: python -m pytest tests/integrations/{c.provider_slug}/test_{c.tool_ident}.py -q
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+
+import pytest
+
+from wheeler.integrations.{c.provider_slug}.{c.tool_ident} import (  # type: ignore[import-not-found]
+    RunMeta,
+    parse_{c.tool_ident},
+)
+
+# Trimmed REAL output captured from one live run (TODO: capture + commit).
+FIXTURE = Path(__file__).parent / "fixtures" / "{c.tool_ident}_real_sample.json"
+SERVICE_TAG = "{c.service_tag}"
+
+# TODO: fill expected bucketing totals derived from the fixture.
+# N_NODES = ...
+
+
+def _load_fixture() -> dict:
+    return json.loads(FIXTURE.read_text())
+
+
+# ---------------------------------------------------------------------------
+# 1. Defensive parse against the REAL shape
+# ---------------------------------------------------------------------------
+
+
+class TestParse{c.tool_camel}:
+    def test_non_dict_is_empty(self):
+        records, run_meta = parse_{c.tool_ident}("not a dict")
+        assert records == []
+        assert isinstance(run_meta, RunMeta)
+
+    def test_empty_doc_is_empty(self):
+        records, run_meta = parse_{c.tool_ident}({{}})
+        assert records == []
+        assert isinstance(run_meta, RunMeta)
+
+    @pytest.mark.skipif(not FIXTURE.exists(), reason="real fixture not captured yet")
+    def test_returns_records_and_run_meta(self):
+        records, run_meta = parse_{c.tool_ident}(_load_fixture())
+        assert isinstance(run_meta, RunMeta)
+        # TODO: assert record count + run metadata against the fixture.
+        assert records is not None
+
+
+# ---------------------------------------------------------------------------
+# 2. Live-Neo4j e2e (per-run e2e_tag, hermetic teardown)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def e2e_config():
+    from wheeler.config import Neo4jConfig, ProjectMeta, WheelerConfig
+
+    return WheelerConfig(
+        neo4j=Neo4jConfig(
+            uri="bolt://localhost:7687",
+            username="neo4j",
+            password="research-graph",
+            database="neo4j",
+        ),
+        project=ProjectMeta(name="Integrations-E2E-Test"),
+    )
+
+
+@pytest.fixture(scope="module")
+def neo4j_available(e2e_config) -> bool:
+    import asyncio
+
+    from neo4j import AsyncGraphDatabase, NotificationMinimumSeverity
+
+    async def _check():
+        driver = AsyncGraphDatabase.driver(
+            e2e_config.neo4j.uri,
+            auth=(e2e_config.neo4j.username, e2e_config.neo4j.password),
+            notifications_min_severity=NotificationMinimumSeverity.OFF,
+        )
+        try:
+            async with driver.session(database=e2e_config.neo4j.database) as s:
+                await s.run("RETURN 1")
+            return True
+        except Exception:
+            return False
+        finally:
+            await driver.close()
+
+    return asyncio.run(_check())
+
+
+@pytest.fixture(autouse=True)
+def _reset_driver_singleton():
+    import wheeler.graph.driver as drv
+
+    drv._async_driver = None
+    drv._async_driver_uri = None
+    yield
+    drv._async_driver = None
+    drv._async_driver_uri = None
+
+
+def {cleanup}(e2e_config, e2e_tag: str) -> None:
+    """Hermetic teardown: delete ONLY the nodes THIS run tagged.
+
+    EXACTLY ``MATCH (n) WHERE n.e2e_tag = $tag DETACH DELETE n`` and nothing
+    else. NEVER delete by ``service`` or ``corpus_id``: the e2e config runs on
+    the SHARED default namespace where production nodes carry the same service
+    tag and the same corpus_ids, so a service- or corpus_id-scoped delete would
+    wipe real user data.
+    """
+    import asyncio
+
+    from neo4j import AsyncGraphDatabase, NotificationMinimumSeverity
+
+    async def _run():
+        driver = AsyncGraphDatabase.driver(
+            e2e_config.neo4j.uri,
+            auth=(e2e_config.neo4j.username, e2e_config.neo4j.password),
+            notifications_min_severity=NotificationMinimumSeverity.OFF,
+        )
+        try:
+            async with driver.session(database=e2e_config.neo4j.database) as s:
+                await s.run(
+                    "MATCH (n) WHERE n.e2e_tag = $tag DETACH DELETE n",
+                    tag=e2e_tag,
+                )
+        finally:
+            await driver.close()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.skipif(not FIXTURE.exists(), reason="real fixture not captured yet")
+class TestIngest{c.tool_camel}E2E:
+    @pytest.fixture(autouse=True)
+    def _skip_and_cleanup(self, neo4j_available, e2e_config, tmp_path, monkeypatch):
+        if not neo4j_available:
+            pytest.skip("Neo4j not available -- skipping integrations e2e")
+        # Temp cwd so the on-disk indices + durable raw store land in a sandbox
+        # we delete; per-run unique tag so teardown never touches another test.
+        monkeypatch.chdir(tmp_path)
+        self._tmp = tmp_path
+        self._e2e_tag = f"integrations_e2e_{{uuid.uuid4().hex}}"
+        {cleanup}(e2e_config, self._e2e_tag)
+        yield
+        {cleanup}(e2e_config, self._e2e_tag)
+
+    async def _tag_all(self, e2e_config, report):
+        """Tag ONLY the nodes THIS run created, scoped off the report ids plus
+        the run's WAS_GENERATED_BY fan-in. NEVER by service or corpus_id. Papers
+        are reference entities (no WAS_GENERATED_BY); tag them via paper_ids."""
+        from wheeler.graph.driver import get_async_driver
+
+        driver = get_async_driver(e2e_config)
+        db = e2e_config.neo4j.database
+        run_ids = [i for i in (report.execution_id, report.artifact) if i]
+        run_ids += [pid for pid in report.paper_ids if pid]
+        async with driver.session(database=db) as s:
+            if run_ids:
+                await s.run(
+                    "MATCH (n) WHERE n.id IN $ids SET n.e2e_tag = $tag",
+                    ids=run_ids, tag=self._e2e_tag,
+                )
+            if report.execution_id:
+                await s.run(
+                    "MATCH (n)-[:WAS_GENERATED_BY]->(x:Execution {{id: $xid}}) "
+                    "SET n.e2e_tag = $tag",
+                    xid=report.execution_id, tag=self._e2e_tag,
+                )
+
+    @pytest.mark.asyncio
+    async def test_ingest_buckets_and_is_idempotent(self, e2e_config):
+        from wheeler.integrations.{c.provider_slug}.{c.tool_ident} import (  # type: ignore[import-not-found]
+            ingest_{c.tool_ident},
+        )
+
+        doc = _load_fixture()
+        artifact_path = self._tmp / "{c.tool_ident}_raw.json"
+        artifact_path.write_text(json.dumps(doc))
+
+        # --- First ingest ---
+        report1 = await ingest_{c.tool_ident}(
+            doc, config=e2e_config, artifact_path=str(artifact_path)
+        )
+        await self._tag_all(e2e_config, report1)
+        assert report1.execution_id
+        # TODO: assert node + edge counts scoped to self._e2e_tag.
+
+        # --- Re-ingest: idempotent ---
+        report2 = await ingest_{c.tool_ident}(
+            doc, config=e2e_config, artifact_path=str(artifact_path)
+        )
+        await self._tag_all(e2e_config, report2)
+        assert report2.created == 0  # nothing new on the second pass
+'''
+
+
+# ---------------------------------------------------------------------------
+# Writers (idempotent-ish file emission)
+# ---------------------------------------------------------------------------
+
+
+def _write(path: Path, text: str, *, overwrite: bool, dry_run: bool) -> str:
+    """Write ``text`` to ``path``; return a one-line action note."""
+    if path.exists() and not overwrite:
+        return f"skip (exists)  {path}"
+    if dry_run:
+        return f"would write    {path}"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+    return f"wrote          {path}"
+
+
+def _append_service_entry(
+    path: Path, entry: str, *, dry_run: bool
+) -> str:
+    """Append a services.yaml entry, creating the file with a root if absent.
+
+    Idempotent on the entry id: if an entry with the same ``id:`` line already
+    exists, it is left untouched.
+    """
+    id_line = entry.splitlines()[0].strip()  # "- id: <provider>-<tool>"
+    existing = path.read_text() if path.exists() else ""
+    if id_line in existing:
+        return f"skip (entry exists)  {path}"
+    if not existing.strip():
+        body = "services:\n" + entry
+    elif "services:" in existing:
+        sep = "" if existing.endswith("\n") else "\n"
+        body = existing + sep + entry
+    else:
+        body = existing.rstrip("\n") + "\nservices:\n" + entry
+    if dry_run:
+        return f"would append   {path}"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+    return f"appended       {path}"
+
+
+def scaffold(
+    contract: ServiceContract,
+    repo_root: Path,
+    *,
+    overwrite: bool = False,
+    dry_run: bool = False,
+) -> list[str]:
+    """Emit all four skeleton files under ``repo_root``; return action notes.
+
+    The ingest module, act, and test are written; the services.yaml entry is
+    appended (never overwriting other services). The empty package ``__init__``
+    files are created when the provider package is new.
+    """
+    notes: list[str] = []
+    provider = contract.provider_slug
+    tool = contract.tool_ident
+
+    # 1. services.yaml entry (append).
+    notes.append(
+        _append_service_entry(
+            repo_root / ".wheeler" / "services.yaml",
+            render_services_entry(contract),
+            dry_run=dry_run,
+        )
+    )
+
+    # 2. ingest skeleton + package __init__.
+    pkg_init = repo_root / "wheeler" / "integrations" / provider / "__init__.py"
+    if not pkg_init.exists():
+        notes.append(_write(pkg_init, "", overwrite=False, dry_run=dry_run))
+    notes.append(
+        _write(
+            repo_root / "wheeler" / "integrations" / provider / f"{tool}.py",
+            render_ingest(contract),
+            overwrite=overwrite,
+            dry_run=dry_run,
+        )
+    )
+
+    # 3. marshal-in act.
+    notes.append(
+        _write(
+            repo_root / ".claude" / "commands" / "wh"
+            / f"{provider}-{contract.tool_slug}.md",
+            render_act(contract),
+            overwrite=overwrite,
+            dry_run=dry_run,
+        )
+    )
+
+    # 4. test stub + test package __init__.
+    test_init = repo_root / "tests" / "integrations" / provider / "__init__.py"
+    if not test_init.exists():
+        notes.append(_write(test_init, "", overwrite=False, dry_run=dry_run))
+    notes.append(
+        _write(
+            repo_root / "tests" / "integrations" / provider / f"test_{tool}.py",
+            render_test(contract),
+            overwrite=overwrite,
+            dry_run=dry_run,
+        )
+    )
+    return notes
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--provider", required=True)
+    p.add_argument("--tool", required=True)
+    p.add_argument("--name", default="")
+    p.add_argument("--description", default="")
+    p.add_argument("--kind", default="shell-out")
+    p.add_argument("--cli", dest="cli_invocation", default="")
+    p.add_argument("--available", default="")
+    p.add_argument("--cost", default="unknown")
+    p.add_argument("--when", default="")
+    p.add_argument("--raw-node", dest="raw_node", default="dataset")
+    p.add_argument(
+        "--nodes", default="Paper", help="comma-separated node types"
+    )
+    p.add_argument(
+        "--repo-root", default=".", help="repo root to scaffold under"
+    )
+    p.add_argument("--overwrite", action="store_true")
+    p.add_argument("--dry-run", action="store_true")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    contract = ServiceContract(
+        provider=args.provider,
+        tool=args.tool,
+        name=args.name,
+        description=args.description,
+        kind=args.kind,
+        cli_invocation=args.cli_invocation,
+        available=args.available,
+        cost=args.cost,
+        when=args.when,
+        raw_node=args.raw_node,
+        nodes=[n.strip() for n in args.nodes.split(",") if n.strip()],
+    )
+    notes = scaffold(
+        contract,
+        Path(args.repo_root),
+        overwrite=args.overwrite,
+        dry_run=args.dry_run,
+    )
+    for note in notes:
+        print(note)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ wh-triage-workspace/
 .claude/skills/*
 # except wheeler-brief, which is versioned with the repo
 !.claude/skills/wheeler-brief/
+# except wheeler-service-creator, which is versioned with the repo
+!.claude/skills/wheeler-service-creator/
 # brief HTML/JSON outputs (.plans/ is already ignored; listed for clarity)
 .plans/brief/
 

--- a/tests/integrations/asta/test_semantic_scholar.py
+++ b/tests/integrations/asta/test_semantic_scholar.py
@@ -836,3 +836,140 @@ class TestIngestSemanticScholarE2E:
                 xid=exec_id, ids=[question_id, finding_id],
             )
             assert (await res.single())["c"] == 2
+
+    @pytest.mark.asyncio
+    async def test_run_arose_from_plan(self, e2e_config):
+        """Plan lifecycle: the run Execution AROSE_FROM the Plan it was launched for.
+
+        Anchors the Asta run to a Plan node so the run is part of the plan
+        provenance chain (not just the results RELEVANT_TO it). Asserts:
+          - link_to=<PL- id> creates Execution -[AROSE_FROM]-> the Plan exactly once
+            (report.plan_linked == 1), AND the search results still link RELEVANT_TO
+            the Plan as before,
+          - a non-Plan link_to (a Q- id) creates NO AROSE_FROM edge from the run
+            Execution (the Plan anchor is PL-only),
+          - re-ingest does NOT duplicate the AROSE_FROM edge (link_once),
+          - the full chain is queryable: a produced raw Dataset
+            -[WAS_GENERATED_BY]-> Execution -[AROSE_FROM]-> Plan.
+        """
+        from wheeler.graph.driver import get_async_driver
+        from wheeler.integrations.asta.semantic_scholar import (
+            ingest_semantic_scholar,
+        )
+        from wheeler.tools.graph_tools import execute_tool
+
+        doc = _load(SEARCH_FIXTURE)
+        artifact_path = self._tmp / "s2_plan_raw.json"
+        artifact_path.write_text(json.dumps(doc))
+        driver = get_async_driver(e2e_config)
+        db = e2e_config.neo4j.database
+
+        # Seed a Plan node the run is a step of, plus a non-Plan node (a Question)
+        # that link_to must NOT treat as a plan anchor.
+        plan_result = json.loads(await execute_tool(
+            "add_plan",
+            {"title": "E2E AROSE_FROM: plan that launched this Asta run",
+             "status": "approved"},
+            e2e_config,
+        ))
+        plan_id = plan_result["node_id"]
+        assert plan_id.startswith("PL-")
+        q_result = json.loads(await execute_tool(
+            "add_question",
+            {"question": "E2E AROSE_FROM: non-plan link target", "priority": 5},
+            e2e_config,
+        ))
+        question_id = q_result["node_id"]
+
+        # Tag the seeded nodes so teardown stays hermetic.
+        async with driver.session(database=db) as s:
+            await s.run(
+                "MATCH (n) WHERE n.id IN $ids SET n.e2e_tag = $tag",
+                ids=[plan_id, question_id], tag=self._e2e_tag,
+            )
+
+        # --- Ingest with link_to = the Plan id ---
+        report1 = await ingest_semantic_scholar(
+            doc,
+            link_to=plan_id,
+            config=e2e_config,
+            artifact_path=str(artifact_path),
+        )
+        await self._tag_all(e2e_config, report1)
+        exec_id = report1.execution_id
+        # Exactly one Execution -[AROSE_FROM]-> Plan edge recorded this run.
+        assert report1.plan_linked == 1
+
+        async with driver.session(database=db) as s:
+            res = await s.run(
+                "MATCH (x:Execution {id: $xid})-[r:AROSE_FROM]->(p:Plan {id: $pid}) "
+                "RETURN count(r) AS c",
+                xid=exec_id, pid=plan_id,
+            )
+            assert (await res.single())["c"] == 1
+
+        # The results STILL link RELEVANT_TO the Plan, as before (the AROSE_FROM
+        # edge is ADDITIVE, it does not replace the result relevance edges).
+        async with driver.session(database=db) as s:
+            res = await s.run(
+                "MATCH (p:Paper)-[r:RELEVANT_TO]->(pl:Plan {id: $pid}) "
+                "WHERE p.corpus_id IN $cids RETURN count(r) AS c",
+                pid=plan_id, cids=SEARCH_CORPUS_IDS,
+            )
+            assert (await res.single())["c"] == len(SEARCH_CORPUS_IDS)
+
+        # Full chain is queryable: produced raw Dataset -[WAS_GENERATED_BY]->
+        # Execution -[AROSE_FROM]-> Plan.
+        assert report1.artifact
+        async with driver.session(database=db) as s:
+            res = await s.run(
+                "MATCH (d {id: $aid})-[:WAS_GENERATED_BY]->"
+                "(x:Execution {id: $xid})-[:AROSE_FROM]->(p:Plan {id: $pid}) "
+                "RETURN count(p) AS c",
+                aid=report1.artifact, xid=exec_id, pid=plan_id,
+            )
+            assert (await res.single())["c"] == 1
+
+        # --- Re-ingest of the SAME artifact + Plan link_to: AROSE_FROM not duplicated.
+        report2 = await ingest_semantic_scholar(
+            doc,
+            link_to=plan_id,
+            config=e2e_config,
+            artifact_path=str(artifact_path),
+        )
+        await self._tag_all(e2e_config, report2)
+        assert report2.execution_id == exec_id
+        # The edge already existed, so link_once does not re-create it.
+        assert report2.plan_linked == 0
+        async with driver.session(database=db) as s:
+            res = await s.run(
+                "MATCH (x:Execution {id: $xid})-[r:AROSE_FROM]->(p:Plan {id: $pid}) "
+                "RETURN count(r) AS c",
+                xid=exec_id, pid=plan_id,
+            )
+            assert (await res.single())["c"] == 1
+
+        # --- A NON-Plan link_to (a Question id) creates NO AROSE_FROM from the run.
+        # Use a distinct artifact so it gets its own Execution (its own session_id),
+        # isolating the assertion from the Plan run's Execution above.
+        doc_q = dict(doc)
+        doc_q["offset"] = 999  # perturb the content sha so session_id differs
+        artifact_q = self._tmp / "s2_plan_nonplan_raw.json"
+        artifact_q.write_text(json.dumps(doc_q))
+        report3 = await ingest_semantic_scholar(
+            doc_q,
+            link_to=question_id,
+            config=e2e_config,
+            artifact_path=str(artifact_q),
+        )
+        await self._tag_all(e2e_config, report3)
+        assert report3.execution_id != exec_id
+        # No Plan anchor: a Q- link_to is not a PL- id, so plan_linked stays 0.
+        assert report3.plan_linked == 0
+        async with driver.session(database=db) as s:
+            res = await s.run(
+                "MATCH (x:Execution {id: $xid})-[r:AROSE_FROM]->() "
+                "RETURN count(r) AS c",
+                xid=report3.execution_id,
+            )
+            assert (await res.single())["c"] == 0

--- a/tests/integrations/test_registry.py
+++ b/tests/integrations/test_registry.py
@@ -1,0 +1,273 @@
+"""Unit tests for the light service-extension registry.
+
+No Neo4j, no live asta. Availability probes are stubbed with a ``python -c``
+command that exits 0 or 1, so the subprocess path is exercised without any
+external dependency.
+"""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+
+from wheeler.config import WheelerConfig
+from wheeler.integrations.registry import (
+    ServiceContract,
+    available_services,
+    load_services,
+)
+
+
+def _config_for(project_root: Path) -> WheelerConfig:
+    return WheelerConfig(project_root=str(project_root))
+
+
+def _exit_zero() -> str:
+    """A probe command that always exits 0 (available)."""
+    return f"{sys.executable} -c \"import sys; sys.exit(0)\""
+
+
+def _exit_one() -> str:
+    """A probe command that always exits 1 (unavailable)."""
+    return f"{sys.executable} -c \"import sys; sys.exit(1)\""
+
+
+def _write_user_manifest(project_root: Path, body: str) -> Path:
+    wheeler_dir = project_root / ".wheeler"
+    wheeler_dir.mkdir(parents=True, exist_ok=True)
+    path = wheeler_dir / "services.yaml"
+    path.write_text(textwrap.dedent(body))
+    return path
+
+
+# ---------------------------------------------------------------------------
+# load_services: default manifest
+# ---------------------------------------------------------------------------
+
+
+class TestLoadDefault:
+    def test_default_manifest_parses_into_contracts(self) -> None:
+        # No user override present -> bundled default is used.
+        contracts = load_services(None)
+        assert contracts, "default manifest should yield contracts"
+        assert all(isinstance(c, ServiceContract) for c in contracts)
+
+    def test_default_has_the_three_asta_services_plus_a_local(self) -> None:
+        contracts = load_services(None)
+        by_id = {c.id: c for c in contracts}
+
+        assert {"paper-finder", "theorizer", "semantic-scholar"} <= set(by_id)
+
+        # The three live Asta services are shell-out + asta provider.
+        for sid in ("paper-finder", "theorizer", "semantic-scholar"):
+            assert by_id[sid].provider == "asta"
+            assert by_id[sid].kind == "shell-out"
+
+        # Acts and cost hints are wired correctly.
+        assert by_id["paper-finder"].act == "/wh:asta-lit"
+        assert by_id["semantic-scholar"].act == "/wh:asta-scholar"
+        assert by_id["theorizer"].act == "/wh:asta-theorize"
+        assert "expensive" in by_id["theorizer"].cost.lower()
+        assert "$7" in by_id["theorizer"].cost
+
+        # At least one local-kind example ships in the default.
+        local = [c for c in contracts if c.kind == "local"]
+        assert local, "default manifest should include a local example"
+
+    def test_contract_has_all_required_fields(self) -> None:
+        contracts = load_services(None)
+        c = next(c for c in contracts if c.id == "paper-finder")
+        assert c.id
+        assert c.provider
+        assert c.name
+        assert c.description
+        assert c.kind in ("shell-out", "local")
+        assert c.act
+        assert c.cost
+        assert c.available
+        assert c.when
+
+    def test_default_used_when_user_file_absent(self, tmp_path: Path) -> None:
+        # Config points at a project with no .wheeler/services.yaml.
+        config = _config_for(tmp_path)
+        contracts = load_services(config)
+        ids = {c.id for c in contracts}
+        # Falls back to the bundled default.
+        assert "paper-finder" in ids
+
+
+# ---------------------------------------------------------------------------
+# load_services: user override
+# ---------------------------------------------------------------------------
+
+
+class TestUserOverride:
+    def test_user_manifest_is_preferred_over_default(self, tmp_path: Path) -> None:
+        _write_user_manifest(
+            tmp_path,
+            """
+            services:
+              - id: my-custom-tool
+                provider: local
+                name: Custom Tool
+                description: a project-specific local tool
+                kind: local
+                act: /wh:custom
+                cost: "free"
+                available: "true"
+                when: "anytime"
+            """,
+        )
+        config = _config_for(tmp_path)
+        contracts = load_services(config)
+        ids = {c.id for c in contracts}
+
+        # The user file wins; the default asta entries are NOT merged in.
+        assert ids == {"my-custom-tool"}
+        assert "paper-finder" not in ids
+
+    def test_empty_user_manifest_yields_no_services(self, tmp_path: Path) -> None:
+        # The user file ships empty in some setups; that means "no services",
+        # not "fall back to default".
+        _write_user_manifest(tmp_path, "services: []\n")
+        config = _config_for(tmp_path)
+        assert load_services(config) == []
+
+
+# ---------------------------------------------------------------------------
+# load_services: malformed / defensive
+# ---------------------------------------------------------------------------
+
+
+class TestMalformed:
+    def test_malformed_entries_are_skipped_not_raised(self, tmp_path: Path) -> None:
+        _write_user_manifest(
+            tmp_path,
+            """
+            services:
+              - id: good
+                provider: local
+                name: Good
+                description: a valid entry
+                kind: local
+                act: /wh:good
+                cost: "free"
+                available: "true"
+                when: "anytime"
+              - id: missing-fields
+                provider: local
+              - id: bad-kind
+                provider: local
+                name: Bad Kind
+                description: unknown kind value
+                kind: not-a-kind
+                act: /wh:bad
+                cost: "free"
+                available: "true"
+                when: "anytime"
+              - not-a-mapping
+            """,
+        )
+        config = _config_for(tmp_path)
+        contracts = load_services(config)
+        ids = {c.id for c in contracts}
+
+        # Only the well-formed entry survives; nothing raised.
+        assert ids == {"good"}
+
+    def test_garbage_yaml_falls_back_to_empty(self, tmp_path: Path) -> None:
+        _write_user_manifest(tmp_path, "::: not valid yaml :::\n[\n")
+        config = _config_for(tmp_path)
+        # Defensive: malformed file -> empty list, no exception.
+        assert load_services(config) == []
+
+    def test_services_key_not_a_list(self, tmp_path: Path) -> None:
+        _write_user_manifest(tmp_path, "services:\n  id: oops\n")
+        config = _config_for(tmp_path)
+        assert load_services(config) == []
+
+
+# ---------------------------------------------------------------------------
+# available_services: stubbed probes
+# ---------------------------------------------------------------------------
+
+
+class TestAvailability:
+    def test_filters_out_failing_probe(self, tmp_path: Path) -> None:
+        _write_user_manifest(
+            tmp_path,
+            f"""
+            services:
+              - id: up
+                provider: local
+                name: Up
+                description: probe exits 0
+                kind: local
+                act: /wh:up
+                cost: "free"
+                available: {_exit_zero()!r}
+                when: "anytime"
+              - id: down
+                provider: local
+                name: Down
+                description: probe exits 1
+                kind: local
+                act: /wh:down
+                cost: "free"
+                available: {_exit_one()!r}
+                when: "anytime"
+            """,
+        )
+        config = _config_for(tmp_path)
+
+        # Both load; only the one whose probe exits 0 is available.
+        assert {c.id for c in load_services(config)} == {"up", "down"}
+        assert {c.id for c in available_services(config)} == {"up"}
+
+    def test_missing_binary_is_unavailable(self, tmp_path: Path) -> None:
+        _write_user_manifest(
+            tmp_path,
+            """
+            services:
+              - id: ghost
+                provider: local
+                name: Ghost
+                description: probe binary does not exist
+                kind: local
+                act: /wh:ghost
+                cost: "free"
+                available: "this-binary-does-not-exist-wheeler-test"
+                when: "anytime"
+            """,
+        )
+        config = _config_for(tmp_path)
+        assert available_services(config) == []
+
+    def test_all_probes_passing_returns_all(self, tmp_path: Path) -> None:
+        _write_user_manifest(
+            tmp_path,
+            f"""
+            services:
+              - id: a
+                provider: local
+                name: A
+                description: ok
+                kind: local
+                act: /wh:a
+                cost: "free"
+                available: {_exit_zero()!r}
+                when: "anytime"
+              - id: b
+                provider: local
+                name: B
+                description: ok
+                kind: local
+                act: /wh:b
+                cost: "free"
+                available: {_exit_zero()!r}
+                when: "anytime"
+            """,
+        )
+        config = _config_for(tmp_path)
+        assert {c.id for c in available_services(config)} == {"a", "b"}

--- a/tests/test_scaffold_service.py
+++ b/tests/test_scaffold_service.py
@@ -1,0 +1,243 @@
+"""Unit tests for the wheeler-service-creator scaffolder.
+
+The script lives under .claude/skills/wheeler-service-creator/ (a dev-only,
+gitignored-except-negated skill), so these tests skip cleanly on a checkout that
+does not include it (mirroring tests/test_render_brief.py). The scaffolder is
+deterministic and stdlib-only; pinning it here keeps the contract-to-skeleton
+emission from drifting silently.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / ".claude/skills/wheeler-service-creator/assets/scaffold_service.py"
+
+pytestmark = pytest.mark.skipif(
+    not SCRIPT.exists(),
+    reason="wheeler-service-creator skill not present in this checkout",
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("scaffold_service", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so @dataclass can resolve cls.__module__ (its
+    # field/InitVar type resolution walks sys.modules).
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _contract(mod, **overrides):
+    base = dict(
+        provider="MyOrg",
+        tool="Paper-Finder",
+        name="Paper Finder",
+        description="literature search",
+        raw_node="dataset",
+        nodes=["Paper"],
+        cost="free",
+        when="literature search",
+        available="myorg auth status",
+        cli_invocation='myorg find "$QUERY" -o /tmp/paper-finder.json',
+    )
+    base.update(overrides)
+    return mod.ServiceContract(**base)
+
+
+# ---------------------------------------------------------------------------
+# Identity derivation
+# ---------------------------------------------------------------------------
+
+
+def test_identity_derivation_is_slug_safe():
+    mod = _load_module()
+    c = _contract(mod)
+    assert c.provider_slug == "myorg"
+    assert c.tool_slug == "paper-finder"
+    assert c.tool_ident == "paper_finder"
+    assert c.tool_camel == "PaperFinder"
+    assert c.service_id == "myorg-paper-finder"
+    assert c.service_tag == "myorg:paper-finder"
+    assert c.act_name == "wh:myorg-paper-finder"
+
+
+def test_invalid_raw_node_rejected():
+    mod = _load_module()
+    with pytest.raises(ValueError):
+        _contract(mod, raw_node="banana")
+
+
+def test_missing_provider_rejected():
+    mod = _load_module()
+    with pytest.raises(ValueError):
+        _contract(mod, provider="   ")
+
+
+# ---------------------------------------------------------------------------
+# Renderers
+# ---------------------------------------------------------------------------
+
+
+def test_services_entry_carries_contract():
+    mod = _load_module()
+    c = _contract(mod)
+    text = mod.render_services_entry(c)
+    assert "id: myorg-paper-finder" in text
+    assert "act: /wh:myorg-paper-finder" in text
+    assert "raw_node: dataset" in text
+    assert "nodes: [Paper]" in text
+    assert 'cost: "free"' in text
+    assert 'available: "myorg auth status"' in text
+
+
+def test_ingest_skeleton_has_the_load_bearing_pieces():
+    mod = _load_module()
+    c = _contract(mod)
+    text = mod.render_ingest(c)
+    # Lazy, function-local execute_tool import (the only graph-write chokepoint).
+    assert "from wheeler.tools.graph_tools import _get_backend, execute_tool" in text
+    # Input-side provenance + idempotent Execution + raw artifact registration.
+    assert "_record_used" in text
+    assert "_find_execution" in text
+    assert "register_output_artifact" in text
+    assert '_SERVICE_TAG = "myorg:paper-finder"' in text
+    assert '_RAW_NODE_TYPE = "dataset"' in text
+    # Parser + ingest fn named off the tool ident.
+    assert "def parse_paper_finder(" in text
+    assert "async def ingest_paper_finder(" in text
+    # The parser is a TODO stub returning empty, never raises.
+    assert "return [], RunMeta()" in text
+
+
+def test_act_is_a_marshal_in_prompt():
+    mod = _load_module()
+    c = _contract(mod)
+    text = mod.render_act(c)
+    assert "name: wh:myorg-paper-finder" in text
+    assert "Bash(myorg:*)" in text
+    assert "Bash(wheeler integrate:*)" in text
+    assert "search_context" in text
+    assert "--used" in text
+    assert "wheeler integrate ingest paper_finder" in text
+
+
+def test_test_stub_follows_e2e_tag_convention():
+    mod = _load_module()
+    c = _contract(mod)
+    text = mod.render_test(c)
+    # Hermetic teardown is EXACTLY the e2e_tag delete, never by service/corpus_id.
+    assert "MATCH (n) WHERE n.e2e_tag = $tag DETACH DELETE n" in text
+    assert "integrations_e2e_" in text
+    assert "_cleanup_paper_finder" in text
+    assert "class TestParsePaperFinder" in text
+    assert "class TestIngestPaperFinderE2E" in text
+    # Idempotency assertion present.
+    assert "report2.created == 0" in text
+
+
+def test_no_em_dashes_in_any_rendered_file():
+    mod = _load_module()
+    c = _contract(mod)
+    for text in (
+        mod.render_services_entry(c),
+        mod.render_ingest(c),
+        mod.render_act(c),
+        mod.render_test(c),
+    ):
+        assert "—" not in text  # no em dash
+
+
+# ---------------------------------------------------------------------------
+# Scaffold writer (filesystem, isolated tmp)
+# ---------------------------------------------------------------------------
+
+
+def test_scaffold_writes_all_four_pieces(tmp_path: Path):
+    mod = _load_module()
+    c = _contract(mod, provider="acme", tool="widget", raw_node="document")
+    notes = mod.scaffold(c, tmp_path)
+    assert any("services.yaml" in n for n in notes)
+
+    services = tmp_path / ".wheeler" / "services.yaml"
+    ingest = tmp_path / "wheeler" / "integrations" / "acme" / "widget.py"
+    act = tmp_path / ".claude" / "commands" / "wh" / "acme-widget.md"
+    test = tmp_path / "tests" / "integrations" / "acme" / "test_widget.py"
+
+    for path in (services, ingest, act, test):
+        assert path.exists(), f"missing {path}"
+
+    # Provider package __init__ files created.
+    assert (tmp_path / "wheeler" / "integrations" / "acme" / "__init__.py").exists()
+    assert (tmp_path / "tests" / "integrations" / "acme" / "__init__.py").exists()
+
+    assert "services:" in services.read_text()
+    assert "id: acme-widget" in services.read_text()
+    assert '_RAW_NODE_TYPE = "document"' in ingest.read_text()
+
+
+def test_scaffold_services_entry_is_idempotent(tmp_path: Path):
+    mod = _load_module()
+    c = _contract(mod, provider="acme", tool="widget")
+    mod.scaffold(c, tmp_path)
+    first = (tmp_path / ".wheeler" / "services.yaml").read_text()
+    # Re-scaffold: the services entry must not be duplicated.
+    notes = mod.scaffold(c, tmp_path)
+    second = (tmp_path / ".wheeler" / "services.yaml").read_text()
+    assert first == second
+    assert second.count("id: acme-widget") == 1
+    assert any("entry exists" in n for n in notes)
+
+
+def test_scaffold_appends_second_service_without_clobber(tmp_path: Path):
+    mod = _load_module()
+    mod.scaffold(_contract(mod, provider="acme", tool="widget"), tmp_path)
+    mod.scaffold(_contract(mod, provider="acme", tool="gadget"), tmp_path)
+    text = (tmp_path / ".wheeler" / "services.yaml").read_text()
+    assert "id: acme-widget" in text
+    assert "id: acme-gadget" in text
+    assert text.count("services:") == 1
+
+
+def test_dry_run_writes_nothing(tmp_path: Path):
+    mod = _load_module()
+    c = _contract(mod, provider="acme", tool="widget")
+    notes = mod.scaffold(c, tmp_path, dry_run=True)
+    assert any("would" in n for n in notes)
+    assert not (tmp_path / "wheeler" / "integrations" / "acme" / "widget.py").exists()
+    assert not (tmp_path / ".wheeler" / "services.yaml").exists()
+
+
+def test_existing_file_not_overwritten_without_flag(tmp_path: Path):
+    mod = _load_module()
+    c = _contract(mod, provider="acme", tool="widget")
+    ingest = tmp_path / "wheeler" / "integrations" / "acme" / "widget.py"
+    ingest.parent.mkdir(parents=True)
+    ingest.write_text("# hand-edited, keep me\n")
+    mod.scaffold(c, tmp_path)
+    assert ingest.read_text() == "# hand-edited, keep me\n"
+    # With overwrite the skeleton replaces it.
+    mod.scaffold(c, tmp_path, overwrite=True)
+    assert "ingest_widget" in ingest.read_text()
+
+
+def test_main_dry_run_smoke(tmp_path: Path, capsys):
+    mod = _load_module()
+    rc = mod.main(
+        [
+            "--provider", "acme",
+            "--tool", "widget",
+            "--name", "Widget",
+            "--raw-node", "dataset",
+            "--repo-root", str(tmp_path),
+            "--dry-run",
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "would" in out

--- a/wheeler/_data/commands/asta.md
+++ b/wheeler/_data/commands/asta.md
@@ -6,6 +6,10 @@ allowed-tools:
   - Read
   - AskUserQuestion
   - Skill
+  - Bash(asta auth status)
+  - Bash(wheeler graph status)
+  - Bash(./.venv/bin/python -c *)
+  - Bash(python -c *)
   - mcp__wheeler_core__graph_context
   - mcp__wheeler_core__search_context
   - mcp__wheeler_core__graph_gaps
@@ -15,57 +19,74 @@ allowed-tools:
   - mcp__wheeler_query__query_findings
 ---
 
-# Asta Router
+# Asta / Service Router
 
-Pick the right Asta service for the user's research intent and dispatch the matching
-`/wh:asta-*` act. Read the graph first, then suggest. Confirm before anything paid.
+Pick the right service for the user's research intent and dispatch the matching
+`/wh:*` act. The available services come from the registry (a declarative
+manifest), not a hardcoded table. Read the graph first, then suggest. Confirm
+before anything paid.
+
+## Read the registry first
+
+The service list is data, not prose in this file. Load the AVAILABLE services
+(those whose availability probe passes) from the registry:
+
+```bash
+./.venv/bin/python -c "from wheeler.config import load_config; from wheeler.integrations.registry import available_services; import json; print(json.dumps([{'id': c.id, 'name': c.name, 'act': c.act, 'kind': c.kind, 'cost': c.cost, 'when': c.when, 'description': c.description} for c in available_services(load_config())], indent=2))"
+```
+
+(If `./.venv/bin/python` is not present, use plain `python`.) The registry reads
+the user override at `.wheeler/services.yaml` if it exists, else the bundled
+default. It runs each service's `available` probe (for example `asta auth
+status`) and returns only the ones that pass, so an unauthenticated or
+uninstalled service simply will not appear. Do NOT maintain a service table in
+this file; trust the registry. If the list is empty, tell the user no services
+are available (likely asta is not authenticated: `asta auth status`) and stop.
 
 ## Routing procedure
 
-1. If `$ARGUMENTS` is non-empty, treat it as the intent and skip to step 3.
-2. If `$ARGUMENTS` is empty: read the graph (`graph_context`, `graph_gaps`) and propose
-   the highest-value next Asta action from the graph state (see Graph-aware suggestions),
-   then confirm with the user via AskUserQuestion (offer 2-4 concrete options).
-3. Match intent to a service:
-   - Broad literature discovery ("find papers on X", "what is known about Y") ->
-     `/wh:asta-lit` (Paper Finder). Cheap.
-   - A specific paper, its citations, or snippet evidence ("look up Z", "what cites Y",
-     "find the quote about X") -> `/wh:asta-scholar` (Semantic Scholar). Cheap. Citations
-     build the CITES citation graph.
-   - Hypothesis or theory generation ("generate theories about X", "what could explain
-     Y", "form hypotheses") -> `/wh:asta-theorize` (Theorizer). EXPENSIVE (about 7 dollars,
-     about 20 minutes): confirm with the user before dispatching.
-   - Analyze the user's own data ("analyze this CSV", "find patterns in my .mat",
-     "statistics on this dataset") -> DataVoyager. NOT YET BUILT (planned, Phase 4): say so
-     plainly and do not pretend to run it. Offer Paper Finder or Semantic Scholar instead
-     if literature would help.
-4. Before dispatching an expensive service (Theorizer, and DataVoyager once built), confirm
-   cost and time with the user. For the cheap services, dispatch directly.
-5. Invoke the chosen `/wh:asta-*` act via the Skill tool, prefixed with a one-line
-   explanation of the routing choice.
-6. If the task is not an Asta-suited research action, say so plainly and point the user to
-   `/wh:start` for general Wheeler routing.
+1. Load the available services from the registry (above).
+2. If `$ARGUMENTS` is non-empty, treat it as the intent and skip to step 4.
+3. If `$ARGUMENTS` is empty: read the graph (`graph_context`, `graph_gaps`) and
+   propose the highest-value next action from the graph state (see Graph-aware
+   suggestions), then confirm with the user via AskUserQuestion (offer 2-4
+   concrete options drawn from the available services).
+4. Match the intent to one of the AVAILABLE services using its `when` and
+   `description` fields. Do not offer a service that is not in the list.
+5. Warn on `cost`. Before dispatching any service whose `cost` is not "free" or
+   "cheap" (for example Theorizer at about 7 dollars, about 20 minutes), confirm
+   cost and time with the user. For free or cheap services, dispatch directly.
+6. Invoke the chosen service's `act` via the Skill tool, prefixed with a
+   one-line explanation of the routing choice.
+7. If the intent is not served by any available service (for example
+   "analyze my CSV" when DataVoyager is not built or not authenticated), say so
+   plainly: name the missing capability, do not pretend to run it, and offer the
+   closest available service (literature discovery often helps) or point the
+   user to `/wh:start` for general Wheeler routing.
 
 ## Graph-aware suggestions
 
-Use the graph state to suggest the highest-value next action, not just a keyword match.
-Read `graph_gaps` and `search_context`, then look for:
-- An OpenQuestion with linked Papers but no Hypotheses -> suggest Theorizer.
-- A Finding or Hypothesis with no supporting literature -> suggest Paper Finder or
-  Semantic Scholar.
-- A Paper with no CITES edges -> suggest `asta papers citations` via `/wh:asta-scholar`.
-- A Dataset with an open analysis question -> suggest DataVoyager (once built).
+Use the graph state to suggest the highest-value next action, not just a keyword
+match. Read `graph_gaps` and `search_context`, then look for these patterns and
+map each to an AVAILABLE service (skip the suggestion if the matching service is
+not in the registry list):
 
-Surface the trade-offs when you suggest:
-- Paper Finder: broad semantic discovery, relevance-ranked.
-- Semantic Scholar: precise lookup plus the citation graph plus snippet evidence.
-- Theorizer: literature-grounded theories with supporting and contradicting evidence
-  (expensive).
-- DataVoyager: code-executing analysis of your own data (paid, uploads files; not yet
-  built).
+- An OpenQuestion with linked Papers but no Hypotheses -> suggest the theory
+  service (Theorizer) if available. Warn on its cost.
+- A Finding or Hypothesis with no supporting literature -> suggest a literature
+  service (Paper Finder or Semantic Scholar) if available.
+- A Paper with no CITES edges -> suggest the citation lookup (Semantic Scholar
+  `papers citations`) if available.
+- A Dataset with an open analysis question -> suggest a data-analysis service
+  (DataVoyager) if it appears in the available list; otherwise say it is not
+  available and offer literature instead.
+
+Surface the trade-offs from each service's `description` when you suggest, and
+always state the `cost` for paid services.
 
 ## Style
 
 - Never use em dashes. Use colons, commas, periods, parentheses.
 - Be brief. The user wants to get into the right tool, not read about tools.
-- Always confirm before a paid service. Never claim to have run a service that is not built.
+- Always confirm before a paid service. Never claim to have run a service that
+  is unavailable or not built.

--- a/wheeler/_data/commands/execute.md
+++ b/wheeler/_data/commands/execute.md
@@ -71,6 +71,10 @@ When running from a registered plan (PL-xxxx):
 9. When all WHEELER tasks complete, run **Step 2.5: Honor the contract** if any contract field is set. Otherwise jump straight to checking success criteria.
 10. Call `update_node(node_id=PL-xxxx, status="completed")` (or leave as in-progress if gaps remain). Update plan file frontmatter to mirror.
 
+### External research steps (route through the service router)
+
+When a task needs external research that Wheeler does not do itself (finding literature, generating candidate theories, analyzing data with an outside agent), launch `/wh:asta`, the service router, rather than doing it inline. Do not name or hardcode any specific service: `/wh:asta` reads the service registry (`.wheeler/services.yaml`, else the bundled default) to discover what is available for the current step, suggests the right one, and warns on cost. Stay service-agnostic: the plan only knows "this step needs external work, so route it through the service router." Pass the running plan id as `--link-to PL-xxxx` so the run's Execution is anchored to the Plan (`Execution -[AROSE_FROM]-> Plan`) and its results land RELEVANT_TO it: the Plan, its Asta runs, and their outputs stay one provenance chain readable at `/wh:close`. Surface the launch as a checkpoint when it incurs cost; otherwise proceed and record the run in the SUMMARY.
+
 ### Artifact organization (canonical export directory)
 
 The archive root for a plan-based execute is `analysis_exports/<investigation_slug>_<YYYY-MM-DD>/`. Once Step 2.4 has created the directory, treat this as the source of truth for figure and dataset outputs:

--- a/wheeler/_data/commands/plan.md
+++ b/wheeler/_data/commands/plan.md
@@ -314,6 +314,9 @@ Rules:
 ## Handoff Awareness
 When the plan is clear and remaining work is mostly grinding (lit search, data wrangling, boilerplate code, graph ops), recognize the handoff moment and propose tasks inline — don't wait for the scientist to invoke `/wh:handoff`. Present each task with description, assignee (SCIENTIST/WHEELER/PAIR), model (sonnet/haiku), time estimate, and checkpoint conditions. But don't force it — only when it's natural and the question is sharp.
 
+## External research steps (offer the service router)
+When a plan step needs external research that Wheeler does not do itself (finding literature, generating candidate theories, analyzing data with an outside agent), offer to launch `/wh:asta`, the service router. Do not name or hardcode any specific service: `/wh:asta` reads the service registry (`.wheeler/services.yaml`, else the bundled default) to discover what is actually available, suggests the right service for the step, and warns on cost. Stay service-agnostic: the plan only knows "this step needs external work, so route it through the service router." Hand off with the plan context and pass the plan id as `--link-to PL-xxxx` so the run's Execution is anchored to the Plan (`Execution -[AROSE_FROM]-> Plan`) and its results land RELEVANT_TO it, keeping the Plan, its runs, and their outputs in one provenance chain. Offer this, do not auto-run it.
+
 If $ARGUMENTS names a clear research topic, call `search_context` with it and briefly summarize what the graph knows. Otherwise, ask what the scientist wants to investigate, use AskUserQuestion to clarify intent, then call `search_context` once the topic is sharp.
 
 $ARGUMENTS

--- a/wheeler/integrations/asta/_marshal.py
+++ b/wheeler/integrations/asta/_marshal.py
@@ -51,6 +51,7 @@ class ImportReport:
     linked: int = 0
     skipped: int = 0
     used: int = 0
+    plan_linked: int = 0
     execution_id: str = ""
     artifact: str = ""
     paper_ids: list[str] = field(default_factory=list)
@@ -62,6 +63,7 @@ class ImportReport:
             "linked": self.linked,
             "skipped": self.skipped,
             "used": self.used,
+            "plan_linked": self.plan_linked,
             "execution_id": self.execution_id,
             "artifact": self.artifact,
             "paper_ids": list(self.paper_ids),
@@ -252,6 +254,51 @@ async def _node_exists(backend, config: WheelerConfig, node_id: str) -> bool:
         params = {"id": node_id}
     rows = await backend.run_cypher(query, params)
     return bool(rows)
+
+
+async def _link_execution_to_plan(
+    backend, config: WheelerConfig, exec_id: str, link_to: str | None,
+) -> bool:
+    """Anchor the run Execution to a Plan: ``Execution -[AROSE_FROM]-> Plan``.
+
+    Plan/session lifecycle integration. When the marshal-in ``link_to`` is a Plan
+    id (``PL-`` prefix), the Asta run is a step OF that plan, so the run Execution
+    -[AROSE_FROM]-> the Plan: the run AROSE FROM the plan that motivated it. This
+    puts the Execution itself into the plan's provenance chain, on top of the
+    results that link RELEVANT_TO the Plan as today. With this edge a Plan, its
+    Asta Executions, and their outputs form one chain (see /wh:plan, /wh:execute,
+    /wh:close).
+
+    Direction rationale: ``AROSE_FROM`` reads as "the run arose from the plan",
+    matching the proven model already used by the Theorizer adapter (a generated
+    parent Finding -[AROSE_FROM]-> its ``link_to`` Plan/Question). ``CONTAINS``
+    (Plan CONTAINS the step) was considered but rejected: CONTAINS is the
+    structural parent/child edge (e.g. a theory Finding CONTAINS its law
+    Hypotheses); AROSE_FROM is the discovery/derivation edge, which is exactly
+    what an Asta run is relative to the plan that prompted it. Keeping the same
+    relationship the Theorizer already uses also makes the plan-side query
+    uniform across adapters.
+
+    No-op (returns False) for a non-Plan ``link_to`` (anything not ``PL-``),
+    a blank id, or a Plan id not in the graph (existence-guarded with
+    ``_node_exists``, so a stale/missing id is skipped, never fabricated).
+    Idempotent via ``_link_once``, so re-ingest does not duplicate the edge.
+    Returns True only when a NEW edge was created.
+    """
+    if not exec_id or not link_to:
+        return False
+    plan_id = link_to.strip()
+    if not plan_id.upper().startswith("PL-"):
+        return False
+    if plan_id == exec_id:
+        return False
+    if not await _node_exists(backend, config, plan_id):
+        logger.warning(
+            "link_execution_to_plan: skipping missing Plan id %r (not in graph)",
+            plan_id,
+        )
+        return False
+    return await _link_once(backend, config, exec_id, "AROSE_FROM", plan_id)
 
 
 async def _record_used(

--- a/wheeler/integrations/asta/ingest.py
+++ b/wheeler/integrations/asta/ingest.py
@@ -32,6 +32,7 @@ from ._marshal import (
     ImportReport,
     _find_execution,
     _find_paper_by_corpus_id,
+    _link_execution_to_plan,
     _link_once,
     _load_index,
     _paper_exists,
@@ -133,6 +134,13 @@ async def ingest_paper_finder(
                 )
     report.execution_id = exec_id
 
+    # Plan lifecycle: anchor the run Execution to its Plan. When link_to is a
+    # Plan id (PL-), Execution -[AROSE_FROM]-> Plan, so the run is part of the
+    # plan provenance chain (not just the result Papers RELEVANT_TO it). No-op
+    # for a non-Plan / missing link_to; link_once so re-ingest does not duplicate.
+    if exec_id and await _link_execution_to_plan(backend, config, exec_id, link_to):
+        report.plan_linked += 1
+
     # Input-side provenance: the marshal-in built this request FROM graph nodes
     # (at minimum the link target that motivated the search), so the run USED
     # them. Existence-guarded + link_once, so re-ingest dedupes and a missing id
@@ -209,9 +217,9 @@ async def ingest_paper_finder(
     _save_index(index)
     logger.info(
         "ingest_paper_finder: created=%d deduped=%d linked=%d skipped=%d "
-        "used=%d (exec=%s)",
+        "used=%d plan_linked=%d (exec=%s)",
         report.created, report.deduped, report.linked, report.skipped,
-        report.used, exec_id,
+        report.used, report.plan_linked, exec_id,
     )
     return report
 

--- a/wheeler/integrations/asta/semantic_scholar.py
+++ b/wheeler/integrations/asta/semantic_scholar.py
@@ -88,6 +88,7 @@ from wheeler.integrations.asta._marshal import (
     ImportReport,
     _find_execution,
     _find_paper_by_corpus_id,
+    _link_execution_to_plan,
     _link_once,
     _load_index,
     _paper_exists,
@@ -715,6 +716,17 @@ async def ingest_semantic_scholar(
         exec_id = exec_result.get("node_id", "")
     report.execution_id = exec_id
 
+    # Plan lifecycle: anchor the run Execution to its Plan. When link_to is a
+    # Plan id (PL-), Execution -[AROSE_FROM]-> Plan, so the run itself joins the
+    # plan provenance chain. This is an Execution-level edge (the RUN arose from
+    # the plan that prompted it) and so is recorded for EVERY sub-kind, including
+    # citations: the citing papers themselves are not RELEVANT_TO the question
+    # (link_to is withheld from them), but the run still arose from the plan.
+    # No-op for a non-Plan / missing link_to; link_once so re-ingest does not
+    # duplicate.
+    if exec_id and await _link_execution_to_plan(backend, config, exec_id, link_to):
+        report.plan_linked += 1
+
     # Input-side provenance: the marshal-in built this request FROM graph nodes
     # (at minimum the link target that motivated the query), so the run USED
     # them. Existence-guarded + link_once, so re-ingest dedupes and a missing id
@@ -831,13 +843,14 @@ async def ingest_semantic_scholar(
     _save_fallback_index(fallback_index)
     logger.info(
         "ingest_semantic_scholar: sub_kind=%s created=%d deduped=%d linked=%d "
-        "skipped=%d used=%d (exec=%s)",
+        "skipped=%d used=%d plan_linked=%d (exec=%s)",
         parsed.sub_kind,
         report.created,
         report.deduped,
         report.linked,
         report.skipped,
         report.used,
+        report.plan_linked,
         exec_id,
     )
     return report

--- a/wheeler/integrations/asta/theorizer.py
+++ b/wheeler/integrations/asta/theorizer.py
@@ -101,6 +101,7 @@ from wheeler.integrations.asta._marshal import (
     ImportReport,
     _find_execution,
     _find_paper_by_corpus_id,
+    _link_execution_to_plan,
     _link_once,
     _load_index,
     _paper_exists,
@@ -1026,6 +1027,14 @@ async def ingest_theorizer(
             await _stamp_custom(execute_tool, config, exec_id, run_meta.custom_bag())
     report.execution_id = exec_id
 
+    # Plan lifecycle: anchor the run Execution to its Plan. When link_to is a
+    # Plan id (PL-), Execution -[AROSE_FROM]-> Plan, so the run itself joins the
+    # plan provenance chain (the theory parent Findings also link AROSE_FROM the
+    # Plan, below). No-op for a non-Plan / missing link_to; link_once so re-ingest
+    # does not duplicate.
+    if exec_id and await _link_execution_to_plan(backend, config, exec_id, link_to):
+        report.plan_linked += 1
+
     # Input-side provenance: the marshal-in built this request FROM graph nodes
     # (the link target that motivated the run plus the Finding ids seeded into
     # the extraction payload), so the run USED them. This is on TOP of the
@@ -1088,12 +1097,13 @@ async def ingest_theorizer(
     _save_theory_index(theory_index)
     logger.info(
         "ingest_theorizer: created=%d deduped=%d linked=%d skipped=%d "
-        "used=%d (exec=%s)",
+        "used=%d plan_linked=%d (exec=%s)",
         report.created,
         report.deduped,
         report.linked,
         report.skipped,
         report.used,
+        report.plan_linked,
         exec_id,
     )
     return report

--- a/wheeler/integrations/registry.py
+++ b/wheeler/integrations/registry.py
@@ -1,0 +1,255 @@
+"""Light service-extension registry: a declarative manifest of services.
+
+A service is a declarative CONTRACT (one manifest entry). Commands read the
+registry instead of hardcoding providers. This module is a PURE READ: it has no
+graph dependency, imports no LLM-provider SDK, and never raises on a bad
+manifest. A missing file falls back to the bundled default; a malformed entry is
+skipped and logged; the loaders always return a list (possibly empty).
+
+Two manifests exist:
+  - the bundled DEFAULT at ``wheeler/integrations/services.default.yaml``
+    (ships with the package),
+  - an optional USER override at ``<project_root>/.wheeler/services.yaml``
+    (wins when present).
+
+``load_services`` returns every parsed contract. ``available_services`` runs each
+contract's ``available`` shell probe and returns only the ones that pass.
+"""
+
+from __future__ import annotations
+
+import logging
+import shlex
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+if TYPE_CHECKING:
+    from wheeler.config import WheelerConfig
+
+logger = logging.getLogger(__name__)
+
+# The bundled default manifest sits next to this module.
+_DEFAULT_MANIFEST = Path(__file__).resolve().parent / "services.default.yaml"
+
+# Probe wall-clock ceiling. The probe is an availability check (e.g.
+# "asta auth status"), so it should be fast; we cap it so a hung binary cannot
+# stall the router.
+_PROBE_TIMEOUT = 10
+
+
+@dataclass(frozen=True)
+class ServiceContract:
+    """One declarative service entry from the manifest.
+
+    Carries identity, the act that drives it, cost/availability hints, and the
+    free-text ``when`` trigger. It does NOT carry a field-map DSL: the heavy
+    marshalling stays tool-specific in each adapter. ``kind`` is one of
+    ``"shell-out"`` or ``"local"``.
+    """
+
+    id: str
+    provider: str
+    name: str
+    description: str
+    kind: str
+    act: str
+    cost: str
+    available: str
+    when: str
+    # Optional input ports / output shape from the manifest, kept opaque here
+    # (the registry does not interpret them; adapters do).
+    inputs: list[dict[str, Any]] = field(default_factory=list)
+    output: dict[str, Any] = field(default_factory=dict)
+
+
+# Fields required for a manifest entry to parse into a ServiceContract.
+_REQUIRED_FIELDS = (
+    "id",
+    "provider",
+    "name",
+    "description",
+    "kind",
+    "act",
+    "cost",
+    "available",
+    "when",
+)
+
+_VALID_KINDS = ("shell-out", "local")
+
+
+def _user_manifest_path(config: WheelerConfig | None) -> Path | None:
+    """Resolve the user override path ``<project_root>/.wheeler/services.yaml``.
+
+    Returns None when no config is supplied (caller then uses the default only).
+    """
+    if config is None:
+        return None
+    root = Path(config.project_root).resolve()
+    return root / ".wheeler" / "services.yaml"
+
+
+def _read_manifest(path: Path) -> list[dict[str, Any]]:
+    """Read raw service entries from a YAML manifest file.
+
+    Defensive: a missing file, unreadable file, non-mapping document, or a
+    ``services:`` key that is not a list yields an empty list (logged). Never
+    raises.
+    """
+    try:
+        raw = path.read_text()
+    except OSError as exc:
+        logger.warning("registry: could not read manifest %s: %s", path, exc)
+        return []
+
+    try:
+        doc = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        logger.warning("registry: manifest %s is not valid YAML: %s", path, exc)
+        return []
+
+    if doc is None:
+        # Empty manifest (the user file may ship empty): no services.
+        return []
+    if not isinstance(doc, dict):
+        logger.warning("registry: manifest %s is not a mapping; ignoring", path)
+        return []
+
+    services = doc.get("services")
+    if services is None:
+        return []
+    if not isinstance(services, list):
+        logger.warning(
+            "registry: 'services' in %s is not a list; ignoring", path
+        )
+        return []
+
+    return [entry for entry in services if isinstance(entry, dict)]
+
+
+def _parse_entry(entry: dict[str, Any]) -> ServiceContract | None:
+    """Parse one raw manifest entry into a ServiceContract.
+
+    Returns None (and logs) when the entry is missing a required field or has an
+    unknown ``kind``. Never raises.
+    """
+    missing = [f for f in _REQUIRED_FIELDS if not entry.get(f)]
+    if missing:
+        logger.warning(
+            "registry: skipping service entry %r; missing fields: %s",
+            entry.get("id", "<no id>"),
+            ", ".join(missing),
+        )
+        return None
+
+    kind = str(entry["kind"])
+    if kind not in _VALID_KINDS:
+        logger.warning(
+            "registry: skipping service %r; unknown kind %r (expected one of %s)",
+            entry["id"],
+            kind,
+            ", ".join(_VALID_KINDS),
+        )
+        return None
+
+    inputs_raw = entry.get("inputs")
+    inputs = (
+        [i for i in inputs_raw if isinstance(i, dict)]
+        if isinstance(inputs_raw, list)
+        else []
+    )
+    output_raw = entry.get("output")
+    output = output_raw if isinstance(output_raw, dict) else {}
+
+    return ServiceContract(
+        id=str(entry["id"]),
+        provider=str(entry["provider"]),
+        name=str(entry["name"]),
+        description=str(entry["description"]),
+        kind=kind,
+        act=str(entry["act"]),
+        cost=str(entry["cost"]),
+        available=str(entry["available"]),
+        when=str(entry["when"]),
+        inputs=inputs,
+        output=output,
+    )
+
+
+def load_services(config: WheelerConfig | None = None) -> list[ServiceContract]:
+    """Load service contracts from the user override or the bundled default.
+
+    Resolution: if ``<project_root>/.wheeler/services.yaml`` exists, it wins and
+    the default is NOT merged in; otherwise the bundled
+    ``services.default.yaml`` is used. Malformed entries are skipped (logged);
+    a missing or malformed file yields the default or an empty list. Never
+    raises.
+
+    This is a pure read: no graph access, no subprocess, no network.
+    """
+    user_path = _user_manifest_path(config)
+    if user_path is not None and user_path.is_file():
+        logger.info("registry: loading user manifest %s", user_path)
+        raw_entries = _read_manifest(user_path)
+    else:
+        logger.info("registry: loading bundled default manifest %s", _DEFAULT_MANIFEST)
+        raw_entries = _read_manifest(_DEFAULT_MANIFEST)
+
+    contracts: list[ServiceContract] = []
+    for entry in raw_entries:
+        parsed = _parse_entry(entry)
+        if parsed is not None:
+            contracts.append(parsed)
+    return contracts
+
+
+def _probe_passes(command: str) -> bool:
+    """Run an availability probe; True iff it exits 0.
+
+    A missing binary, non-zero exit, timeout, or empty command counts as
+    unavailable. Never raises.
+    """
+    command = command.strip()
+    if not command:
+        return False
+
+    try:
+        argv = shlex.split(command)
+    except ValueError as exc:
+        logger.warning("registry: probe %r is not a valid command: %s", command, exc)
+        return False
+    if not argv:
+        return False
+
+    try:
+        proc = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=_PROBE_TIMEOUT,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        logger.info("registry: probe %r timed out; treating as unavailable", argv[:2])
+        return False
+    except (FileNotFoundError, OSError) as exc:
+        logger.info("registry: probe %r could not launch: %s", argv[:1], exc)
+        return False
+
+    return proc.returncode == 0
+
+
+def available_services(
+    config: WheelerConfig | None = None,
+) -> list[ServiceContract]:
+    """Return the loaded contracts whose ``available`` probe passes.
+
+    Runs each contract's probe via subprocess; a non-zero exit or missing binary
+    filters the contract out. Pure read with respect to the graph: it shells out
+    only to the declared probes, never to an LLM provider. Never raises.
+    """
+    return [c for c in load_services(config) if _probe_passes(c.available)]

--- a/wheeler/integrations/services.default.yaml
+++ b/wheeler/integrations/services.default.yaml
@@ -1,0 +1,60 @@
+# Wheeler service-extension registry: shipped DEFAULT manifest.
+#
+# This file is bundled with the package and read by
+# wheeler.integrations.registry.load_services when the project has no user
+# override at .wheeler/services.yaml. Copy it there and edit to add or remove
+# services for a project; the user file always wins.
+#
+# Each entry is a declarative service CONTRACT (one manifest entry per tool):
+#   id          stable identifier (kebab-case)
+#   provider    the upstream provider (e.g. asta, local)
+#   name        human-readable display name
+#   description what the service does (one line)
+#   kind        shell-out | local
+#   act         the /wh:* slash command that drives the service
+#   cost        free-text cost/time hint, surfaced as a warning by the router
+#   available   shell probe; non-zero exit or missing binary => unavailable
+#   when        free-text trigger hint ("use this when ...")
+#
+# No em dashes anywhere. The router lists only AVAILABLE services.
+
+services:
+  - id: paper-finder
+    provider: asta
+    name: Paper Finder
+    description: broad semantic literature discovery, relevance-ranked
+    kind: shell-out
+    act: /wh:asta-lit
+    cost: "cheap"
+    available: "asta auth status"
+    when: "broad literature discovery (find papers on X, what is known about Y)"
+
+  - id: theorizer
+    provider: asta
+    name: Theorizer
+    description: literature-grounded theory generation with supporting and contradicting evidence
+    kind: shell-out
+    act: /wh:asta-theorize
+    cost: "expensive (~$7, ~20min)"
+    available: "asta auth status"
+    when: "hypothesis or theory generation (generate theories about X, what could explain Y)"
+
+  - id: semantic-scholar
+    provider: asta
+    name: Semantic Scholar
+    description: precise paper lookup plus the citation graph plus snippet evidence
+    kind: shell-out
+    act: /wh:asta-scholar
+    cost: "cheap"
+    available: "asta auth status"
+    when: "a specific paper, its citations, or snippet evidence (look up Z, what cites Y)"
+
+  - id: graph-status
+    provider: local
+    name: Graph Status
+    description: local read-only summary of the current Wheeler knowledge graph
+    kind: local
+    act: /wh:status
+    cost: "free"
+    available: "wheeler graph status"
+    when: "a quick local snapshot of graph health and recent activity, no external service"


### PR DESCRIPTION
Follow-up to #72 / #73. Builds three pieces of `docs/asta-engine-spec.md`, each in an isolated git worktree, merged here. No conflicts (disjoint files).

## 1. Service-extension registry (light, not a DSL)
- `wheeler/integrations/services.default.yaml`: bundled manifest of the live Asta services plus a `local` example (id, provider, description, kind, act, cost, availability probe, `when`).
- `wheeler/integrations/registry.py`: `ServiceContract` + `load_services` (a user `.wheeler/services.yaml` overrides the bundled default; defensive, never raises) + `available_services` (runs each `available` probe and filters out unauthenticated / uninstalled services). Pure read, no graph dependency.
- `/wh:asta` now READS the registry instead of a hardcoded table: lists only available services, suggests by `when`/`description`, warns on `cost`. Adding or removing a service is a manifest entry, not a command edit.

## 2. wheeler-service-creator skill (Wheeler adapter creation)
- `.claude/skills/wheeler-service-creator/`: a skill that scaffolds a new provenance-tracked adapter from a tool contract: the registry entry, the marshal-out ingest skeleton (wired to `_marshal.py` + `register_output_artifact`, the lazy `execute_tool` chokepoint, a defensive parser TODO), the marshal-in act (`/wh:<provider>-<tool>`, passes `--used` source ids), and a per-run `e2e_tag` test stub. A stdlib generator (`assets/scaffold_service.py`) emits the skeletons; 14 unit tests.

## 4. Plan / session lifecycle
- `Execution -[AROSE_FROM]-> Plan` when an Asta run is linked to a `PL-` id (existence-guarded, idempotent, wired into all three adapters), so the run is part of the plan provenance chain.
- `/wh:plan` and `/wh:execute` offer to route external-research steps through `/wh:asta` (the service router). Service-agnostic: no service names are hardcoded in the plan acts; the router plus registry own discovery and cost warnings.

## Tests
1852 passed, 2 skipped. mypy clean. `ruff check wheeler/` (the canonical pre-commit scope) clean; each new test file is clean. The 117 ruff findings under `tests/` are pre-existing on main, outside this change. Each piece self-tested in its own worktree venv; the full suite here is the integration gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)