### PR TITLE
Service enable/disable: .wheeler/services/ folder + wheeler services CLI

### DIFF
--- a/.claude/commands/wh/asta.md
+++ b/.claude/commands/wh/asta.md
@@ -35,13 +35,16 @@ The service list is data, not prose in this file. Load the AVAILABLE services
 ./.venv/bin/python -c "from wheeler.config import load_config; from wheeler.integrations.registry import available_services; import json; print(json.dumps([{'id': c.id, 'name': c.name, 'act': c.act, 'kind': c.kind, 'cost': c.cost, 'when': c.when, 'description': c.description} for c in available_services(load_config())], indent=2))"
 ```
 
-(If `./.venv/bin/python` is not present, use plain `python`.) The registry reads
-the user override at `.wheeler/services.yaml` if it exists, else the bundled
-default. It runs each service's `available` probe (for example `asta auth
-status`) and returns only the ones that pass, so an unauthenticated or
-uninstalled service simply will not appear. Do NOT maintain a service table in
-this file; trust the registry. If the list is empty, tell the user no services
-are available (likely asta is not authenticated: `asta auth status`) and stop.
+(If `./.venv/bin/python` is not present, use plain `python`.) The registry
+returns only ENABLED services. The enabled set is the folder
+`.wheeler/services/` when it exists (each `<id>.yaml` is one enabled contract,
+curated via `wheeler services enable/disable`), else the bundled catalog
+(every default enabled until the user starts curating). It then runs each
+service's `available` probe (for example `asta auth status`) and returns only
+the ones that pass, so a disabled, unauthenticated, or uninstalled service
+simply will not appear. Do NOT maintain a service table in this file; trust the
+registry. If the list is empty, tell the user no services are available (either
+none are enabled, or asta is not authenticated: `asta auth status`) and stop.
 
 ## Routing procedure
 

--- a/tests/integrations/test_registry.py
+++ b/tests/integrations/test_registry.py
@@ -11,12 +11,17 @@ import sys
 import textwrap
 from pathlib import Path
 
+import pytest
+from typer.testing import CliRunner
+
 from wheeler.config import WheelerConfig
 from wheeler.integrations.registry import (
     ServiceContract,
     available_services,
+    catalog_services,
     load_services,
 )
+from wheeler.integrations.services_cli import services_app
 
 
 def _config_for(project_root: Path) -> WheelerConfig:
@@ -271,3 +276,322 @@ class TestAvailability:
         )
         config = _config_for(tmp_path)
         assert {c.id for c in available_services(config)} == {"a", "b"}
+
+
+# ---------------------------------------------------------------------------
+# catalog_services + the enabled-services FOLDER (the ENABLE/DISABLE layer)
+# ---------------------------------------------------------------------------
+
+
+def _services_dir(project_root: Path) -> Path:
+    return project_root / ".wheeler" / "services"
+
+
+def _write_enabled_file(project_root: Path, service_id: str, body: str) -> Path:
+    folder = _services_dir(project_root)
+    folder.mkdir(parents=True, exist_ok=True)
+    path = folder / f"{service_id}.yaml"
+    path.write_text(textwrap.dedent(body))
+    return path
+
+
+class TestCatalog:
+    def test_catalog_is_the_bundled_default(self) -> None:
+        # catalog_services is always the bundled default regardless of config.
+        catalog = catalog_services(None)
+        ids = {c.id for c in catalog}
+        assert {"paper-finder", "theorizer", "semantic-scholar"} <= ids
+
+    def test_catalog_ignores_enabled_folder(self, tmp_path: Path) -> None:
+        # Even when a curated folder exists, the catalog stays the full default.
+        _write_enabled_file(
+            tmp_path,
+            "paper-finder",
+            """
+            id: paper-finder
+            provider: asta
+            name: Paper Finder
+            description: only this one enabled
+            kind: shell-out
+            act: /wh:asta-lit
+            cost: "cheap"
+            available: "asta auth status"
+            when: "broad literature discovery"
+            """,
+        )
+        config = _config_for(tmp_path)
+        catalog = catalog_services(config)
+        # Catalog still has everything; only load_services is filtered.
+        assert {"paper-finder", "theorizer", "semantic-scholar"} <= {
+            c.id for c in catalog
+        }
+
+
+class TestEnabledFolder:
+    def test_folder_absent_falls_back_to_catalog(self, tmp_path: Path) -> None:
+        # No .wheeler/services/ folder -> backward-compat: all defaults enabled.
+        config = _config_for(tmp_path)
+        ids = {c.id for c in load_services(config)}
+        assert {"paper-finder", "theorizer", "semantic-scholar"} <= ids
+
+    def test_folder_is_source_of_truth(self, tmp_path: Path) -> None:
+        # A folder with one file -> only that contract is enabled.
+        _write_enabled_file(
+            tmp_path,
+            "paper-finder",
+            """
+            id: paper-finder
+            provider: asta
+            name: Paper Finder
+            description: enabled
+            kind: shell-out
+            act: /wh:asta-lit
+            cost: "cheap"
+            available: "asta auth status"
+            when: "broad literature discovery"
+            """,
+        )
+        config = _config_for(tmp_path)
+        ids = {c.id for c in load_services(config)}
+        assert ids == {"paper-finder"}
+
+    def test_empty_folder_yields_no_enabled_services(self, tmp_path: Path) -> None:
+        # An existing-but-empty folder means "nothing enabled", not "fall back".
+        _services_dir(tmp_path).mkdir(parents=True)
+        config = _config_for(tmp_path)
+        assert load_services(config) == []
+
+    def test_folder_accepts_services_wrapper_shape(self, tmp_path: Path) -> None:
+        # A file may also use the catalog-style ``services:`` list wrapper.
+        _write_enabled_file(
+            tmp_path,
+            "theorizer",
+            """
+            services:
+              - id: theorizer
+                provider: asta
+                name: Theorizer
+                description: enabled via wrapper
+                kind: shell-out
+                act: /wh:asta-theorize
+                cost: "expensive"
+                available: "asta auth status"
+                when: "theory generation"
+            """,
+        )
+        config = _config_for(tmp_path)
+        assert {c.id for c in load_services(config)} == {"theorizer"}
+
+    def test_folder_wins_over_legacy_single_file(self, tmp_path: Path) -> None:
+        # When BOTH the folder and the legacy services.yaml exist, folder wins.
+        _write_user_manifest(
+            tmp_path,
+            """
+            services:
+              - id: legacy-only
+                provider: local
+                name: Legacy
+                description: from the single-file override
+                kind: local
+                act: /wh:legacy
+                cost: "free"
+                available: "true"
+                when: "anytime"
+            """,
+        )
+        _write_enabled_file(
+            tmp_path,
+            "paper-finder",
+            """
+            id: paper-finder
+            provider: asta
+            name: Paper Finder
+            description: enabled via folder
+            kind: shell-out
+            act: /wh:asta-lit
+            cost: "cheap"
+            available: "asta auth status"
+            when: "broad literature discovery"
+            """,
+        )
+        config = _config_for(tmp_path)
+        assert {c.id for c in load_services(config)} == {"paper-finder"}
+
+    def test_garbage_file_in_folder_is_skipped(self, tmp_path: Path) -> None:
+        _write_enabled_file(tmp_path, "broken", "::: not valid yaml :::\n[\n")
+        _write_enabled_file(
+            tmp_path,
+            "paper-finder",
+            """
+            id: paper-finder
+            provider: asta
+            name: Paper Finder
+            description: enabled
+            kind: shell-out
+            act: /wh:asta-lit
+            cost: "cheap"
+            available: "asta auth status"
+            when: "broad literature discovery"
+            """,
+        )
+        config = _config_for(tmp_path)
+        # The garbage file is skipped, not raised; the good one survives.
+        assert {c.id for c in load_services(config)} == {"paper-finder"}
+
+    def test_missing_required_field_in_folder_is_skipped(self, tmp_path: Path) -> None:
+        _write_enabled_file(
+            tmp_path,
+            "incomplete",
+            """
+            id: incomplete
+            provider: local
+            """,
+        )
+        config = _config_for(tmp_path)
+        assert load_services(config) == []
+
+
+# ---------------------------------------------------------------------------
+# `wheeler services` CLI: enable / disable / list (seed-on-first-curate)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def _cli_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Run the CLI inside tmp_path so load_config() resolves project_root there.
+
+    project_root defaults to "." (cwd) and there is no wheeler.yaml, so chdir
+    into tmp_path makes .wheeler/services/ land under the temp project.
+    """
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    return runner, tmp_path
+
+
+class TestServicesCli:
+    def test_enable_seeds_then_creates_file_and_loads(self, _cli_project) -> None:
+        runner, root = _cli_project
+        # paper-finder is already a default; enable a different one to prove the
+        # file is written and seed kept the others.
+        result = runner.invoke(services_app, ["enable", "paper-finder"])
+        assert result.exit_code == 0, result.output
+
+        folder = _services_dir(root)
+        assert folder.is_dir(), "folder should be seeded on first curate"
+        assert (folder / "paper-finder.yaml").is_file()
+        # Seed-on-first-curate keeps the OTHER defaults enabled too.
+        assert (folder / "theorizer.yaml").is_file()
+        assert (folder / "semantic-scholar.yaml").is_file()
+
+        config = _config_for(root)
+        ids = {c.id for c in load_services(config)}
+        assert "paper-finder" in ids
+        # All defaults still enabled after first enable (seed preserved them).
+        assert {"theorizer", "semantic-scholar"} <= ids
+
+    def test_disable_seeds_then_removes_file_and_excludes(self, _cli_project) -> None:
+        runner, root = _cli_project
+        result = runner.invoke(services_app, ["disable", "theorizer"])
+        assert result.exit_code == 0, result.output
+
+        folder = _services_dir(root)
+        assert folder.is_dir(), "folder should be seeded on first curate"
+        # Disable from the default state: theorizer file is gone, others remain.
+        assert not (folder / "theorizer.yaml").exists()
+        assert (folder / "paper-finder.yaml").is_file()
+        assert (folder / "semantic-scholar.yaml").is_file()
+
+        config = _config_for(root)
+        ids = {c.id for c in load_services(config)}
+        assert "theorizer" not in ids
+        # The other defaults stay enabled (seed-on-first-curate decision).
+        assert {"paper-finder", "semantic-scholar"} <= ids
+
+    def test_enable_then_disable_roundtrip(self, _cli_project) -> None:
+        runner, root = _cli_project
+        runner.invoke(services_app, ["disable", "paper-finder"])
+        config = _config_for(root)
+        assert "paper-finder" not in {c.id for c in load_services(config)}
+
+        # Re-enable: the file reappears and load_services includes it again.
+        result = runner.invoke(services_app, ["enable", "paper-finder"])
+        assert result.exit_code == 0, result.output
+        assert (_services_dir(root) / "paper-finder.yaml").is_file()
+        assert "paper-finder" in {c.id for c in load_services(config)}
+
+    def test_enable_unknown_id_errors(self, _cli_project) -> None:
+        runner, root = _cli_project
+        result = runner.invoke(services_app, ["enable", "does-not-exist"])
+        assert result.exit_code == 1
+        # No folder created on a rejected enable (validation happens first).
+        assert not _services_dir(root).exists()
+
+    def test_disable_unknown_id_errors_without_side_effects(self, _cli_project) -> None:
+        # A typo'd / unknown id must NOT silently materialise the whole folder.
+        # It is validated against the catalog first (mirroring enable) and
+        # rejected with exit 1 before any seeding.
+        runner, root = _cli_project
+        result = runner.invoke(services_app, ["disable", "does-not-exist"])
+        assert result.exit_code == 1, result.output
+        # No folder created on a rejected disable (validation happens first).
+        assert not _services_dir(root).exists()
+        # Defaults remain enabled via fallback (the project is untouched).
+        config = _config_for(root)
+        ids = {c.id for c in load_services(config)}
+        assert {"paper-finder", "theorizer", "semantic-scholar"} <= ids
+
+    def test_disable_known_id_twice_is_a_clean_noop(self, _cli_project) -> None:
+        # Disabling a real catalog id that is already disabled is a friendly
+        # exit-0 no-op (it must NOT be confused with the unknown-id error).
+        runner, root = _cli_project
+        first = runner.invoke(services_app, ["disable", "theorizer"])
+        assert first.exit_code == 0, first.output
+        second = runner.invoke(services_app, ["disable", "theorizer"])
+        assert second.exit_code == 0, second.output
+        assert "already disabled" in second.output
+        config = _config_for(root)
+        ids = {c.id for c in load_services(config)}
+        assert "theorizer" not in ids
+        assert {"paper-finder", "semantic-scholar"} <= ids
+
+    def test_disable_handles_hand_added_non_catalog_id(self, _cli_project) -> None:
+        # A contract added by hand beyond the catalog can still be disabled,
+        # because validation also accepts an already-enabled file on disk.
+        runner, root = _cli_project
+        _write_enabled_file(
+            root,
+            "my-custom-tool",
+            """
+            id: my-custom-tool
+            provider: local
+            name: Custom Tool
+            description: a hand-added contract beyond the catalog
+            kind: local
+            act: /wh:custom
+            cost: "free"
+            available: "true"
+            when: "anytime"
+            """,
+        )
+        config = _config_for(root)
+        assert "my-custom-tool" in {c.id for c in load_services(config)}
+        result = runner.invoke(services_app, ["disable", "my-custom-tool"])
+        assert result.exit_code == 0, result.output
+        assert not (_services_dir(root) / "my-custom-tool.yaml").exists()
+        assert "my-custom-tool" not in {c.id for c in load_services(config)}
+
+    def test_list_shows_loaded_and_available(self, _cli_project) -> None:
+        runner, root = _cli_project
+        # Curate: enable only paper-finder by disabling the rest.
+        runner.invoke(services_app, ["disable", "theorizer"])
+        runner.invoke(services_app, ["disable", "semantic-scholar"])
+        runner.invoke(services_app, ["disable", "graph-status"])
+
+        result = runner.invoke(services_app, ["list"])
+        assert result.exit_code == 0, result.output
+        out = result.output
+        # Loaded section shows paper-finder; available section shows a disabled one.
+        assert "paper-finder" in out
+        assert "Loaded services" in out
+        assert "Available to enable" in out
+        assert "theorizer" in out

--- a/wheeler/_data/commands/asta.md
+++ b/wheeler/_data/commands/asta.md
@@ -35,13 +35,16 @@ The service list is data, not prose in this file. Load the AVAILABLE services
 ./.venv/bin/python -c "from wheeler.config import load_config; from wheeler.integrations.registry import available_services; import json; print(json.dumps([{'id': c.id, 'name': c.name, 'act': c.act, 'kind': c.kind, 'cost': c.cost, 'when': c.when, 'description': c.description} for c in available_services(load_config())], indent=2))"
 ```
 
-(If `./.venv/bin/python` is not present, use plain `python`.) The registry reads
-the user override at `.wheeler/services.yaml` if it exists, else the bundled
-default. It runs each service's `available` probe (for example `asta auth
-status`) and returns only the ones that pass, so an unauthenticated or
-uninstalled service simply will not appear. Do NOT maintain a service table in
-this file; trust the registry. If the list is empty, tell the user no services
-are available (likely asta is not authenticated: `asta auth status`) and stop.
+(If `./.venv/bin/python` is not present, use plain `python`.) The registry
+returns only ENABLED services. The enabled set is the folder
+`.wheeler/services/` when it exists (each `<id>.yaml` is one enabled contract,
+curated via `wheeler services enable/disable`), else the bundled catalog
+(every default enabled until the user starts curating). It then runs each
+service's `available` probe (for example `asta auth status`) and returns only
+the ones that pass, so a disabled, unauthenticated, or uninstalled service
+simply will not appear. Do NOT maintain a service table in this file; trust the
+registry. If the list is empty, tell the user no services are available (either
+none are enabled, or asta is not authenticated: `asta auth status`) and stop.
 
 ## Routing procedure
 

--- a/wheeler/integrations/registry.py
+++ b/wheeler/integrations/registry.py
@@ -3,17 +3,39 @@
 A service is a declarative CONTRACT (one manifest entry). Commands read the
 registry instead of hardcoding providers. This module is a PURE READ: it has no
 graph dependency, imports no LLM-provider SDK, and never raises on a bad
-manifest. A missing file falls back to the bundled default; a malformed entry is
-skipped and logged; the loaders always return a list (possibly empty).
+manifest. A missing folder/file falls back to the bundled default; a malformed
+entry is skipped and logged; the loaders always return a list (possibly empty).
 
-Two manifests exist:
-  - the bundled DEFAULT at ``wheeler/integrations/services.default.yaml``
-    (ships with the package),
-  - an optional USER override at ``<project_root>/.wheeler/services.yaml``
-    (wins when present).
+Two distinct ideas, do not conflate them:
 
-``load_services`` returns every parsed contract. ``available_services`` runs each
-contract's ``available`` shell probe and returns only the ones that pass.
+  - the bundled CATALOG at ``wheeler/integrations/services.default.yaml``
+    (ships with the package): everything that is AVAILABLE to enable.
+  - the ENABLED set: what is actually LOADED and visible to the router and to
+    plan suggestions.
+
+The ENABLE/DISABLE layer is a FOLDER, not a single override file. The folder
+``<project_root>/.wheeler/services/`` is the source of truth for ENABLED
+services: each ``<id>.yaml`` file in it is one enabled contract (same schema as
+a ``services.default.yaml`` entry, either a single mapping or wrapped under a
+``services:`` list, both accepted).
+
+Load precedence (the rule the CLI and the router both rely on):
+
+  - if ``<project_root>/.wheeler/services/`` EXISTS, the folder is truth and
+    ``load_services`` returns only the contracts parsed from its ``*.yaml``
+    files (an empty or all-garbage folder yields an empty enabled set);
+  - if the folder does NOT exist, ``load_services`` falls back to the bundled
+    CATALOG so every default stays enabled until the user starts curating
+    (backward-compat).
+
+``load_services`` returns the ENABLED set. ``catalog_services`` returns the
+bundled catalog (everything available to enable), used by the ``list`` command.
+``available_services`` filters the ENABLED set by each contract's ``available``
+shell probe and returns only the ones that pass.
+
+A legacy single-file override at ``<project_root>/.wheeler/services.yaml`` is
+still honoured for backward-compat, but ONLY when the new
+``.wheeler/services/`` folder is absent: the folder always wins.
 """
 
 from __future__ import annotations
@@ -82,10 +104,23 @@ _REQUIRED_FIELDS = (
 _VALID_KINDS = ("shell-out", "local")
 
 
-def _user_manifest_path(config: WheelerConfig | None) -> Path | None:
-    """Resolve the user override path ``<project_root>/.wheeler/services.yaml``.
+def services_dir(config: WheelerConfig | None) -> Path | None:
+    """Resolve the enabled-services folder ``<project_root>/.wheeler/services/``.
 
-    Returns None when no config is supplied (caller then uses the default only).
+    This folder is the source of truth for ENABLED services. Returns None when no
+    config is supplied (caller then uses the bundled catalog only).
+    """
+    if config is None:
+        return None
+    root = Path(config.project_root).resolve()
+    return root / ".wheeler" / "services"
+
+
+def _user_manifest_path(config: WheelerConfig | None) -> Path | None:
+    """Resolve the legacy single-file override ``.wheeler/services.yaml``.
+
+    Honoured only when the ``.wheeler/services/`` folder is absent. Returns None
+    when no config is supplied (caller then uses the bundled catalog only).
     """
     if config is None:
         return None
@@ -129,6 +164,81 @@ def _read_manifest(path: Path) -> list[dict[str, Any]]:
         return []
 
     return [entry for entry in services if isinstance(entry, dict)]
+
+
+def _read_service_file(path: Path) -> list[dict[str, Any]]:
+    """Read raw service entries from one ``.wheeler/services/<id>.yaml`` file.
+
+    Each enabled-service file holds ONE contract, accepted in either shape:
+      - a bare mapping (the contract fields at the top level), or
+      - the same ``services:`` list shape as the catalog (in which case every
+        list entry is read, so a hand-merged file still works).
+
+    Defensive: a missing/unreadable file, invalid YAML, or a non-mapping
+    top-level document yields an empty list (logged). Never raises.
+    """
+    try:
+        raw = path.read_text()
+    except OSError as exc:
+        logger.warning("registry: could not read service file %s: %s", path, exc)
+        return []
+
+    try:
+        doc = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        logger.warning("registry: service file %s is not valid YAML: %s", path, exc)
+        return []
+
+    if doc is None:
+        return []
+    if not isinstance(doc, dict):
+        logger.warning("registry: service file %s is not a mapping; ignoring", path)
+        return []
+
+    # Allow the catalog-style ``services:`` wrapper as well as a bare mapping.
+    if "services" in doc:
+        services = doc.get("services")
+        if not isinstance(services, list):
+            logger.warning(
+                "registry: 'services' in %s is not a list; ignoring", path
+            )
+            return []
+        return [entry for entry in services if isinstance(entry, dict)]
+
+    return [doc]
+
+
+def _load_enabled_dir(folder: Path) -> list[ServiceContract]:
+    """Parse every ``*.yaml`` in the enabled-services folder into contracts.
+
+    The folder is the source of truth for ENABLED services. Files are read in
+    sorted order for deterministic output; a malformed file is skipped (logged)
+    and never aborts the load. Duplicate ids (same contract id from two files)
+    keep the first seen. Never raises.
+    """
+    contracts: list[ServiceContract] = []
+    seen: set[str] = set()
+    try:
+        files = sorted(folder.glob("*.yaml"))
+    except OSError as exc:
+        logger.warning("registry: could not list %s: %s", folder, exc)
+        return []
+
+    for path in files:
+        for entry in _read_service_file(path):
+            parsed = _parse_entry(entry)
+            if parsed is None:
+                continue
+            if parsed.id in seen:
+                logger.warning(
+                    "registry: duplicate enabled service id %r (%s); keeping first",
+                    parsed.id,
+                    path,
+                )
+                continue
+            seen.add(parsed.id)
+            contracts.append(parsed)
+    return contracts
 
 
 def _parse_entry(entry: dict[str, Any]) -> ServiceContract | None:
@@ -180,23 +290,78 @@ def _parse_entry(entry: dict[str, Any]) -> ServiceContract | None:
     )
 
 
-def load_services(config: WheelerConfig | None = None) -> list[ServiceContract]:
-    """Load service contracts from the user override or the bundled default.
+def contract_to_entry(contract: ServiceContract) -> dict[str, Any]:
+    """Render a ServiceContract back to a plain YAML-serialisable mapping.
 
-    Resolution: if ``<project_root>/.wheeler/services.yaml`` exists, it wins and
-    the default is NOT merged in; otherwise the bundled
-    ``services.default.yaml`` is used. Malformed entries are skipped (logged);
-    a missing or malformed file yields the default or an empty list. Never
-    raises.
+    Used by the ``enable`` CLI to write a faithful ``.wheeler/services/<id>.yaml``
+    entry. The shape round-trips through ``_parse_entry`` unchanged. ``inputs``
+    and ``output`` are only emitted when non-empty to keep files terse.
+    """
+    entry: dict[str, Any] = {
+        "id": contract.id,
+        "provider": contract.provider,
+        "name": contract.name,
+        "description": contract.description,
+        "kind": contract.kind,
+        "act": contract.act,
+        "cost": contract.cost,
+        "available": contract.available,
+        "when": contract.when,
+    }
+    if contract.inputs:
+        entry["inputs"] = contract.inputs
+    if contract.output:
+        entry["output"] = contract.output
+    return entry
+
+
+def catalog_services(
+    config: WheelerConfig | None = None,
+) -> list[ServiceContract]:
+    """Return the bundled CATALOG: every service AVAILABLE to enable.
+
+    This is always the shipped ``services.default.yaml``, independent of what is
+    enabled in ``.wheeler/services/``. The ``list`` command uses it to show what
+    can be enabled. ``config`` is accepted for signature symmetry but is not
+    consulted (the catalog is bundled, not per-project). Never raises.
+
+    Pure read: no graph access, no subprocess, no network.
+    """
+    contracts: list[ServiceContract] = []
+    for entry in _read_manifest(_DEFAULT_MANIFEST):
+        parsed = _parse_entry(entry)
+        if parsed is not None:
+            contracts.append(parsed)
+    return contracts
+
+
+def load_services(config: WheelerConfig | None = None) -> list[ServiceContract]:
+    """Load the ENABLED service contracts (what the router/plan acts see).
+
+    Load precedence:
+      1. If ``<project_root>/.wheeler/services/`` EXISTS, the folder is the
+         source of truth: return only the contracts parsed from its ``*.yaml``
+         files (an empty or all-garbage folder yields an empty enabled set).
+      2. Else if the legacy single-file ``.wheeler/services.yaml`` exists, it
+         wins (backward-compat) and the catalog is NOT merged in.
+      3. Else fall back to the bundled CATALOG so every default stays enabled
+         until the user starts curating (backward-compat).
+
+    Malformed entries/files are skipped (logged); nothing here ever raises.
 
     This is a pure read: no graph access, no subprocess, no network.
     """
+    folder = services_dir(config)
+    if folder is not None and folder.is_dir():
+        logger.info("registry: loading enabled services from folder %s", folder)
+        return _load_enabled_dir(folder)
+
     user_path = _user_manifest_path(config)
     if user_path is not None and user_path.is_file():
-        logger.info("registry: loading user manifest %s", user_path)
+        logger.info("registry: loading legacy user manifest %s", user_path)
         raw_entries = _read_manifest(user_path)
     else:
-        logger.info("registry: loading bundled default manifest %s", _DEFAULT_MANIFEST)
+        logger.info("registry: loading bundled catalog %s", _DEFAULT_MANIFEST)
         raw_entries = _read_manifest(_DEFAULT_MANIFEST)
 
     contracts: list[ServiceContract] = []

--- a/wheeler/integrations/services.default.yaml
+++ b/wheeler/integrations/services.default.yaml
@@ -1,9 +1,16 @@
-# Wheeler service-extension registry: shipped DEFAULT manifest.
+# Wheeler service-extension registry: shipped CATALOG of services.
 #
-# This file is bundled with the package and read by
-# wheeler.integrations.registry.load_services when the project has no user
-# override at .wheeler/services.yaml. Copy it there and edit to add or remove
-# services for a project; the user file always wins.
+# This file is bundled with the package and is the CATALOG: every service that
+# is AVAILABLE to enable. It does NOT directly decide what is loaded.
+#
+# The ENABLED set (what the router and plan acts actually see) is curated in the
+# folder .wheeler/services/ : each <id>.yaml file there is one enabled contract.
+# Curate it with `wheeler services enable/disable` (or by editing the folder by
+# hand). load_services precedence:
+#   1. if .wheeler/services/ exists, that folder is the source of truth;
+#   2. else the legacy single-file override .wheeler/services.yaml, if present;
+#   3. else this bundled catalog (every default enabled until you start curating).
+# The folder always wins over the single-file override.
 #
 # Each entry is a declarative service CONTRACT (one manifest entry per tool):
 #   id          stable identifier (kebab-case)

--- a/wheeler/integrations/services_cli.py
+++ b/wheeler/integrations/services_cli.py
@@ -1,0 +1,239 @@
+"""Typer sub-app: ``wheeler services``.
+
+Curate which service contracts are ENABLED (loaded, visible to the router and
+to plan suggestions) via the folder ``<project_root>/.wheeler/services/``. That
+folder is the source of truth for the enabled set; the bundled
+``services.default.yaml`` is the CATALOG of what is available to enable.
+
+Three verbs:
+  - ``list``    show loaded/enabled services AND catalog services not enabled.
+  - ``enable``  add a catalog entry to ``.wheeler/services/<id>.yaml``.
+  - ``disable`` remove ``.wheeler/services/<id>.yaml``.
+
+Seed-on-first-curate: ``enable`` and ``disable`` operate relative to a concrete
+folder state. If the folder does not exist yet, the first curate SEEDS it with
+all current catalog entries (so existing defaults stay enabled), THEN applies
+the enable/disable. This makes a single disable meaningful from the default
+state instead of silently dropping every other default.
+
+This CLI WRITES only under ``.wheeler/services/``. It never touches the graph,
+the network, or any LLM provider. It never raises on a curating no-op (already
+enabled / not enabled).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import typer
+import yaml
+from rich.console import Console
+from rich.table import Table
+
+from wheeler.config import load_config
+from wheeler.integrations.registry import (
+    ServiceContract,
+    catalog_services,
+    contract_to_entry,
+    load_services,
+    services_dir,
+)
+
+logger = logging.getLogger(__name__)
+console = Console()
+
+services_app = typer.Typer(
+    help="Enable/disable which service contracts are loaded (the .wheeler/services/ folder)."
+)
+
+
+def _resolve_dir() -> Path:
+    """Resolve the enabled-services folder for the current project."""
+    config = load_config()
+    folder = services_dir(config)
+    if folder is None:
+        # load_config always yields a config, so services_dir is non-None;
+        # guard anyway so mypy and a hand-built config never crash the CLI.
+        folder = Path(config.project_root).resolve() / ".wheeler" / "services"
+    return folder
+
+
+def _write_contract(folder: Path, contract: ServiceContract) -> Path:
+    """Write one enabled-service file ``<folder>/<id>.yaml``. Returns its path."""
+    folder.mkdir(parents=True, exist_ok=True)
+    path = folder / f"{contract.id}.yaml"
+    body = yaml.safe_dump(
+        contract_to_entry(contract),
+        sort_keys=False,
+        default_flow_style=False,
+    )
+    path.write_text(body)
+    return path
+
+
+def _seed_if_absent(folder: Path) -> bool:
+    """Seed the folder with the full catalog if it does not exist yet.
+
+    Returns True when seeding happened. After seeding, enable/disable act on a
+    concrete folder state, so the other defaults stay enabled. Idempotent: an
+    existing folder is left untouched.
+    """
+    if folder.is_dir():
+        return False
+    for contract in catalog_services():
+        _write_contract(folder, contract)
+    logger.info("services: seeded %s with the full catalog", folder)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# services list
+# ---------------------------------------------------------------------------
+
+
+@services_app.command("list")
+def services_list() -> None:
+    """Show LOADED/ENABLED services and catalog services not yet enabled."""
+    config = load_config()
+    enabled = load_services(config)
+    catalog = catalog_services(config)
+
+    enabled_ids = {c.id for c in enabled}
+    folder = services_dir(config)
+    curating = folder is not None and folder.is_dir()
+
+    loaded_table = Table(title="Loaded services (enabled)")
+    loaded_table.add_column("id", style="cyan")
+    loaded_table.add_column("provider")
+    loaded_table.add_column("act")
+    loaded_table.add_column("cost")
+    if enabled:
+        for c in sorted(enabled, key=lambda c: c.id):
+            loaded_table.add_row(c.id, c.provider, c.act, c.cost)
+    else:
+        loaded_table.add_row("[dim](none)[/dim]", "", "", "")
+    console.print(loaded_table)
+
+    if curating:
+        console.print(
+            f"[dim]Source of truth: {folder} (folder = enabled set).[/dim]"
+        )
+    else:
+        console.print(
+            "[dim]No .wheeler/services/ folder yet: every catalog default is "
+            "enabled. Run 'wheeler services enable/disable' to start curating.[/dim]"
+        )
+
+    not_enabled = [c for c in catalog if c.id not in enabled_ids]
+    avail_table = Table(title="Available to enable (catalog, not currently loaded)")
+    avail_table.add_column("id", style="green")
+    avail_table.add_column("provider")
+    avail_table.add_column("description")
+    if not_enabled:
+        for c in sorted(not_enabled, key=lambda c: c.id):
+            avail_table.add_row(c.id, c.provider, c.description)
+    else:
+        avail_table.add_row("[dim](all catalog services enabled)[/dim]", "", "")
+    console.print(avail_table)
+
+
+# ---------------------------------------------------------------------------
+# services enable
+# ---------------------------------------------------------------------------
+
+
+@services_app.command("enable")
+def services_enable(
+    service_id: str = typer.Argument(..., help="Catalog service id to enable."),
+) -> None:
+    """Enable a service: copy its catalog entry into .wheeler/services/<id>.yaml.
+
+    Seeds the folder with the full catalog first when it does not exist, so the
+    other defaults stay enabled.
+    """
+    catalog = {c.id: c for c in catalog_services()}
+    if service_id not in catalog:
+        console.print(
+            f"[red]Unknown service id[/red] {service_id!r}. "
+            "Run 'wheeler services list' to see the catalog."
+        )
+        raise typer.Exit(1)
+
+    folder = _resolve_dir()
+    # Record whether the file already existed BEFORE any seed, so the message
+    # distinguishes "already enabled" from "seeded in as a catalog default".
+    pre_existing = (folder / f"{service_id}.yaml").is_file()
+    seeded = _seed_if_absent(folder)
+
+    path = folder / f"{service_id}.yaml"
+    _write_contract(folder, catalog[service_id])
+
+    if seeded:
+        console.print(
+            f"[green]Seeded {folder} with the catalog and enabled[/green] {service_id}."
+        )
+    elif pre_existing:
+        console.print(f"[yellow]{service_id} was already enabled.[/yellow] Rewrote {path}.")
+    else:
+        console.print(f"[green]Enabled[/green] {service_id} -> {path}")
+
+    _print_state()
+
+
+# ---------------------------------------------------------------------------
+# services disable
+# ---------------------------------------------------------------------------
+
+
+@services_app.command("disable")
+def services_disable(
+    service_id: str = typer.Argument(..., help="Service id to disable."),
+) -> None:
+    """Disable a service: remove .wheeler/services/<id>.yaml.
+
+    Validates the id first (mirroring ``enable``): an id that is neither a
+    catalog service nor an already-enabled file on disk is rejected with exit 1
+    BEFORE any seeding, so a typo never silently materialises the whole folder.
+
+    For a real id, seeds the folder with the full catalog when it does not exist
+    yet, so the disable is meaningful from the default state (the other defaults
+    stay enabled instead of all being dropped).
+    """
+    folder = _resolve_dir()
+    catalog_ids = {c.id for c in catalog_services()}
+    # An id is legitimate to disable if it is a catalog service OR an already
+    # enabled file on disk (a hand-added contract beyond the catalog).
+    on_disk = (folder / f"{service_id}.yaml").is_file()
+    if service_id not in catalog_ids and not on_disk:
+        console.print(
+            f"[red]Unknown service id[/red] {service_id!r}. "
+            "Run 'wheeler services list' to see enabled and catalog services."
+        )
+        raise typer.Exit(1)
+
+    seeded = _seed_if_absent(folder)
+
+    path = folder / f"{service_id}.yaml"
+    if path.is_file():
+        path.unlink()
+        if seeded:
+            console.print(
+                f"[green]Seeded {folder} with the catalog and disabled[/green] "
+                f"{service_id} (removed {path})."
+            )
+        else:
+            console.print(f"[green]Disabled[/green] {service_id} (removed {path}).")
+    else:
+        # Known catalog id but no file present after the (possible) seed: a clean
+        # no-op. This is reached only for a real id, never a typo.
+        console.print(f"[yellow]{service_id} is already disabled.[/yellow]")
+
+    _print_state()
+
+
+def _print_state() -> None:
+    """Print the resulting enabled set after a curate operation."""
+    enabled = load_services(load_config())
+    ids = ", ".join(sorted(c.id for c in enabled)) or "(none)"
+    console.print(f"[bold]Enabled now:[/bold] {ids}")

--- a/wheeler/tools/cli.py
+++ b/wheeler/tools/cli.py
@@ -50,6 +50,15 @@ try:
 except ImportError:
     pass
 
+# Service enable/disable curation (the .wheeler/services/ folder). Guarded the
+# same way so a missing integrations package never breaks the rest of the CLI.
+try:
+    from wheeler.integrations.services_cli import services_app
+
+    app.add_typer(services_app, name="services")
+except ImportError:
+    pass
+
 
 
 # Re-export for backward compatibility and convenience


### PR DESCRIPTION
Adds an explicit ENABLE/DISABLE layer on top of the service registry (#74/#75), so you control which services the router AND plans see, distinct from the availability probe.

- `.wheeler/services/` folder is the source of truth for ENABLED services (each `.yaml` is one enabled contract). The bundled `services.default.yaml` is the CATALOG of what is available to enable.
- Load precedence: folder (when present) > legacy single-file `.wheeler/services.yaml` > bundled catalog (so defaults stay on until you curate).
- `wheeler services list` (loaded vs available), `enable <id>`, `disable <id>`. First curate seeds the folder with the full catalog so a single enable/disable does not silently flip everything else.
- Because `/wh:asta` and the plan acts read the registry, disabling a service removes it from both immediately.

Adversarial review caught and fixed a real ergonomics bug: a typo'd `disable` on a fresh project would silently seed the whole folder as a side effect; `disable` now validates the id and exits cleanly with zero side effects on an unknown id.

Full suite 1869 passed, 2 skipped. ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)