### PR TITLE
feat(asta): scholar-qa (literature-report) adapter via the service-creator skill

### DIFF
--- a/.claude/commands/wh/asta-report.md
+++ b/.claude/commands/wh/asta-report.md
@@ -1,0 +1,84 @@
+---
+name: wh:asta-report
+description: Use when the user wants a written literature review or comprehensive multi-paper report (write a review of X, synthesize the literature on Y) via Asta, ingested into the Wheeler knowledge graph as a Document with cited papers
+argument-hint: "[review topic or question]"
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash(asta literature:*)
+  - Bash(asta papers:*)
+  - Bash(asta auth status)
+  - Bash(jq *)
+  - Bash(wheeler integrate:*)
+  - mcp__wheeler_core__search_context
+  - mcp__wheeler_query__query_papers
+  - mcp__wheeler_query__query_findings
+  - mcp__wheeler_query__query_hypotheses
+  - mcp__wheeler_query__query_open_questions
+  - mcp__wheeler_mutations__link_nodes
+
+---
+
+You are Wheeler, producing an Asta Literature Report (a written, multi-paper literature review) and marshalling it into the knowledge graph. The deliverable is a MARKDOWN document, not a single JSON artifact: you orchestrate `asta literature find` (and `asta papers`) for evidence, SYNTHESIZE the review yourself, then one deterministic `wheeler integrate` verb writes the report Document plus its cited papers into the graph with provenance.
+
+Unlike the other Asta acts (one CLI call, one JSON `-o` artifact), this act writes a markdown report and ingests THAT. The asta CLI owns its own auth and timeouts; a failed search writes nothing.
+
+## Preflight
+
+1. Confirm Asta is authenticated: `asta auth status`. If that fails, say Asta is not available and stop. Do not attempt the run.
+2. Read context so the review is shaped by the graph. Use `mcp__wheeler_core__search_context` with the topic (or the active question), `mcp__wheeler_query__query_papers` for papers already recorded, and `mcp__wheeler_query__query_open_questions` for the question this review answers. Use this only to sharpen the topic and pick a link target. Do not invent findings. Do not do the scientist's thinking.
+
+## Choose the topic and link target
+
+- The topic is `$ARGUMENTS` when provided. If empty, ask the user or derive one from the active investigation.
+- Pick at most one link target: the Question (`Q-...`) or Plan (`PL-...`) this review serves. If there is no clear target, run without one.
+
+## Gather evidence
+
+Run the paper finder, writing its results to a temp file (this JSON also enriches each cited paper's metadata at ingest):
+
+```
+asta literature find "$TOPIC" -o /tmp/find.json
+```
+
+Supplement with targeted `asta papers search` / `asta papers get` / `asta papers citations` calls as needed. If `asta literature find` exits non-zero (including a login or auth failure), report it and stop.
+
+(If the asta-plugins `literature-report` skill is installed, you may invoke it to do the search-and-synthesize loop; otherwise do the steps here directly.)
+
+## Write the report
+
+Synthesize a markdown literature review at `.asta/literature/report/<YYYY-MM-DD>-<topic-slug>.md`. SYNTHESIZE across papers (connect ideas, do not just list them); support every claim with a citation. Use the citation convention the ingest parses (this is load-bearing, the parser keys on it):
+
+- Inline + reference entries use double brackets: `[[Maes2020]]`.
+- A References section lists each cited paper: `- [[Maes2020]] Maes, E., et al. (2020). Title. Venue.`
+- Link definitions at the end of the file carry the Semantic Scholar corpus id, which is the dedupe key. Use the `/p/<corpusId>` form (read `corpusId` for each paper from `/tmp/find.json` with `jq`):
+
+```
+[Maes2020]: https://semanticscholar.org/p/91676903
+```
+
+Only papers that have BOTH a `[[Key]]` reference entry AND a `[Key]: <url>` link definition with a corpus id become cited Paper nodes, so give every cited paper both. Never use em dashes in the report.
+
+## Ingest
+
+Marshal the report (markdown) into the graph with the single integrate verb. Pass the find-results JSON so each cited paper's metadata (authors, year, venue) is enriched by a corpus_id join:
+
+```
+wheeler integrate ingest scholar-qa .asta/literature/report/<file>.md --link-to <Q- or PL- id> --used <Q- or PL- id>,<source ids> --find-results /tmp/find.json
+```
+
+This registers the report as a Document (`W-`) node WAS_GENERATED_BY the run Execution, creates a Paper node per cited corpus id (deduped across the whole graph), wires the Document `CITES` each paper and the Execution `USED` each paper (the review was derived from them). Omit `--link-to` if there is no target. Pass `--used` with the graph node ids the request was built FROM (at minimum the link target): this records `Execution -[USED]-> each input` (input-side provenance), so the report traces back to the graph context that shaped it. The verb is idempotent: re-ingesting the same report creates no duplicate Document, papers, or edges.
+
+## Wire semantics to the existing graph
+
+The ingest is STRUCTURALLY complete (the report `WAS_GENERATED_BY` the run and `USED`/`CITES` its papers). It does NOT connect the review to what was ALREADY in the graph, because that is a judgment call (compare the review's conclusions against the current graph), so it lives here in the act, not in the mechanical parser. Do this after ingest:
+
+1. Read the report Document id and the new Paper ids from the ingest summary. Read the existing graph with `mcp__wheeler_query__query_open_questions`, `mcp__wheeler_query__query_hypotheses`, and `mcp__wheeler_query__query_findings`, plus `mcp__wheeler_core__search_context` on the topic.
+2. Identify the semantic edges between the review and EXISTING nodes: the report Document `RELEVANT_TO` an open Question it answers; the report's stated conclusion `SUPPORTS` or `CONTRADICTS` an existing Hypothesis (link the Document, or a Finding you record for the conclusion, to the Hypothesis); a cited Paper `RELEVANT_TO` an open Question. Keep only edges the review's text actually warrants.
+3. Confirm each judgment call with the scientist before writing.
+4. Apply the confirmed edges via `mcp__wheeler_mutations__link_nodes` (for example `link_nodes(<report W- id>, <Q- id>, "RELEVANT_TO")` or `link_nodes(<report W- id>, <H- id>, "SUPPORTS")`). Skip any edge the scientist does not endorse.
+
+## Report
+
+Relay the printed summary (`created`, `deduped`, `linked`, `used`, the run Execution id, the report Document id, and the cited Paper ids) in one or two sentences, and give the path to the markdown report so the scientist can read it. Suggest `query_documents` / `query_papers` to browse the new nodes. Do not editorialize the science. Never use em dashes.

--- a/tests/integrations/asta/fixtures/scholar_qa_find_sample.json
+++ b/tests/integrations/asta/fixtures/scholar_qa_find_sample.json
@@ -1,0 +1,49 @@
+{
+  "query": "dopamine reward prediction error",
+  "thread_id": "fixture-thread",
+  "narrative": "Trimmed LiteratureSearchResult fixture: three of the five report-cited papers, for the corpus_id enrichment join. Schultz1997 and Cooper2011 are deliberately absent so the text-fallback path is exercised.",
+  "results": [
+    {
+      "corpusId": 91676903,
+      "title": "Causal evidence supporting the proposal that dopamine transients function as temporal difference prediction errors",
+      "year": 2020,
+      "venue": "Nature Neuroscience",
+      "url": "https://doi.org/10.1038/s41593-019-0574-1",
+      "citationCount": 142,
+      "relevanceScore": 0.94,
+      "authors": [
+        {"name": "Etienne J. P. Maes"},
+        {"name": "M. Sharpe"},
+        {"name": "Alexandra A. Usypchuk"},
+        {"name": "G. Schoenbaum"}
+      ]
+    },
+    {
+      "corpusId": 260988593,
+      "title": "Reward prediction error in learning-related behaviors",
+      "year": 2023,
+      "venue": "Frontiers in Neuroscience",
+      "url": "https://api.semanticscholar.org/CorpusId:260988593",
+      "citationCount": 7,
+      "relevanceScore": 0.88,
+      "authors": [
+        {"name": "Yujun Deng"},
+        {"name": "Da Song"},
+        {"name": "Zhenzhen Quan"}
+      ]
+    },
+    {
+      "corpusId": 53024913,
+      "title": "The timing of action determines reward prediction signals in identified midbrain dopamine neurons",
+      "year": 2018,
+      "venue": "Nature Neuroscience",
+      "url": "https://doi.org/10.1038/s41593-018-0245-7",
+      "citationCount": 61,
+      "relevanceScore": 0.9,
+      "authors": [
+        {"name": "Luke T. Coddington"},
+        {"name": "J. Dudman"}
+      ]
+    }
+  ]
+}

--- a/tests/integrations/asta/fixtures/scholar_qa_real_sample.md
+++ b/tests/integrations/asta/fixtures/scholar_qa_real_sample.md
@@ -1,0 +1,42 @@
+# Dopamine and Reward Prediction Error: A Literature Review
+
+## Executive Summary
+
+The reward prediction error (RPE) hypothesis holds that midbrain dopamine
+neurons encode the discrepancy between received and predicted reward, a signal
+formally identified with the temporal difference (TD) error of reinforcement
+learning. The foundational account was given by [[Schultz1997]], and causal
+tests have since strengthened the proposal that dopamine transients function as
+TD prediction errors [[Maes2020]]. Recent work refines the picture by showing
+that the timing of action shapes the prediction signal [[Coddington2018]] and
+by surveying RPE across learning-related behaviors [[Deng2023]].
+
+## The temporal difference account
+
+[[Schultz1997]] proposed a neural substrate of prediction and reward in which
+phasic dopamine responses track a TD error. [[Cooper2011]] summarizes the
+predictive reward signal of dopamine neurons that motivated the account.
+
+## Causal and timing evidence
+
+[[Maes2020]] provided causal evidence supporting the proposal that dopamine
+transients function as temporal difference prediction errors. [[Coddington2018]]
+showed that the timing of action determines reward prediction signals in
+identified midbrain dopamine neurons, a constraint the canonical TD model does
+not fully capture.
+
+## References
+
+- [[Maes2020]] Maes, E. J. P., et al. (2020). Causal evidence supporting the proposal that dopamine transients function as temporal difference prediction errors. Nature Neuroscience.
+- [[Deng2023]] Deng, Y., et al. (2023). Reward prediction error in learning-related behaviors. Frontiers in Neuroscience.
+- [[Coddington2018]] Coddington, L. T., & Dudman, J. (2018). The timing of action determines reward prediction signals in identified midbrain dopamine neurons. Nature Neuroscience.
+- [[Schultz1997]] Schultz, W., Dayan, P., & Montague, P. (1997). A Neural Substrate of Prediction and Reward. Science.
+- [[Cooper2011]] Cooper, A., & Pickering, A. (2011). Predictive Reward Signal of Dopamine Neurons.
+
+[Maes2020]: https://semanticscholar.org/p/91676903
+[Deng2023]: https://api.semanticscholar.org/CorpusId:260988593
+[Coddington2018]: https://www.semanticscholar.org/p/53024913
+[Schultz1997]: https://semanticscholar.org/p/220093382
+[Cooper2011]: https://semanticscholar.org/p/15402417
+
+Generated 2026-06-15.

--- a/tests/integrations/asta/test_scholar_qa.py
+++ b/tests/integrations/asta/test_scholar_qa.py
@@ -1,0 +1,673 @@
+"""Tests for the Asta Literature Reports (scholar-qa) adapter.
+
+Two layers, NEITHER making a live scholar-qa call:
+  1. parse_scholar_qa: parse a REAL report fixture (markdown with the skill's
+     [[Key]] / [Key]: <url> citation convention) plus a real find-results JSON
+     for the corpus_id enrichment join, plus shape-drift / garbage tolerance
+     (never raises).
+  2. live-Neo4j e2e: ingest a report with RUN-UNIQUE synthetic corpus_ids,
+     assert the bucketing subgraph (one report Document WAS_GENERATED_BY the run
+     Execution, each cited Paper CITES-from-doc + USED-by-run, papers carry NO
+     WAS_GENERATED_BY), then re-ingest the SAME report and assert idempotency.
+     Skipped automatically when Neo4j is not reachable.
+
+The e2e deliberately does NOT reuse the real fixture's corpus_ids: the e2e config
+runs on the SHARED default Neo4j namespace, the parse fixture cites real dopamine
+papers, and the user's own research graph is about dopamine, so a real corpus_id
+could DEDUPE to a pre-existing production Paper which _tag_all would then tag and
+the teardown would DETACH DELETE (data loss). Run-unique synthetic corpus_ids
+make every e2e Paper brand-new, so created counts are deterministic and teardown
+can only ever touch this run's nodes.
+
+Run: python -m pytest tests/integrations/asta/test_scholar_qa.py -q
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+
+import pytest
+
+from wheeler.integrations.asta.scholar_qa import (
+    ReportRecord,
+    RunMeta,
+    parse_scholar_qa,
+)
+
+# Trimmed REAL report: a markdown literature review citing five real dopamine /
+# reward-prediction-error papers, using the skill's citation convention
+# ([[Key]] inline + references, [Key]: <url> link definitions).
+FIXTURE = Path(__file__).parent / "fixtures" / "scholar_qa_real_sample.md"
+# Trimmed REAL LiteratureSearchResult: three of the five cited papers, for the
+# corpus_id enrichment join (the other two exercise the text-fallback path).
+FIND_FIXTURE = Path(__file__).parent / "fixtures" / "scholar_qa_find_sample.json"
+SERVICE_TAG = "asta:scholar-qa"
+
+# Every corpus_id cited in the report fixture (normalized to digit-strings).
+ALL_CORPUS_IDS = ["91676903", "260988593", "53024913", "220093382", "15402417"]
+# The three corpus_ids present in the find-results fixture (enriched).
+ENRICHED_CORPUS_IDS = {"91676903", "260988593", "53024913"}
+N_PAPERS = 5
+
+
+def _load_report() -> str:
+    return FIXTURE.read_text()
+
+
+def _load_find() -> dict:
+    return json.loads(FIND_FIXTURE.read_text())
+
+
+# ---------------------------------------------------------------------------
+# 1. Defensive parse against the REAL markdown shape
+# ---------------------------------------------------------------------------
+
+
+class TestParseScholarQa:
+    def test_returns_record_and_run_meta(self):
+        record, run_meta = parse_scholar_qa(_load_report(), _load_find())
+        assert isinstance(record, ReportRecord)
+        assert isinstance(run_meta, RunMeta)
+        assert record.title.startswith("Dopamine and Reward Prediction Error")
+        assert record.query == "dopamine reward prediction error"  # from find
+
+    def test_cites_every_referenced_paper_once(self):
+        record, _ = parse_scholar_qa(_load_report(), _load_find())
+        assert len(record.papers) == N_PAPERS
+        cids = {p.corpus_id for p in record.papers}
+        assert cids == set(ALL_CORPUS_IDS)
+
+    def test_corpus_ids_extracted_from_all_url_shapes(self):
+        # The fixture uses /p/<id>, www./p/<id>, and api...CorpusId:<id> urls.
+        record, _ = parse_scholar_qa(_load_report(), _load_find())
+        by_key = {p.custom["citation_key"]: p for p in record.papers}
+        assert by_key["Maes2020"].corpus_id == "91676903"  # /p/
+        assert by_key["Coddington2018"].corpus_id == "53024913"  # www./p/
+        assert by_key["Deng2023"].corpus_id == "260988593"  # CorpusId:
+
+    def test_enriched_papers_get_find_metadata(self):
+        record, _ = parse_scholar_qa(_load_report(), _load_find())
+        by_cid = {p.corpus_id: p for p in record.papers}
+        maes = by_cid["91676903"]
+        assert maes.year == 2020
+        assert "Maes" in maes.authors  # authors lifted from find-results
+        assert maes.custom.get("venue") == "Nature Neuroscience"
+        assert maes.custom.get("citation_count") == 142
+
+    def test_unenriched_papers_fall_back_to_citation_text(self):
+        # Schultz1997 and Cooper2011 are NOT in the find-results fixture, so their
+        # metadata comes from the citation text (year from parens, title parsed).
+        record, _ = parse_scholar_qa(_load_report(), _load_find())
+        by_cid = {p.corpus_id: p for p in record.papers}
+        schultz = by_cid["220093382"]
+        assert schultz.year == 1997
+        assert schultz.authors == ""  # no find-results enrichment
+        assert "Neural Substrate of Prediction and Reward" in schultz.title
+
+    def test_dedupes_inline_and_reference_mentions(self):
+        # Every key is mentioned inline AND in the References list; each must
+        # resolve to ONE paper, with the longer (references) text winning.
+        record, _ = parse_scholar_qa(_load_report(), _load_find())
+        keys = [p.custom["citation_key"] for p in record.papers]
+        assert len(keys) == len(set(keys)) == N_PAPERS
+
+    def test_citation_key_recorded_in_custom(self):
+        record, _ = parse_scholar_qa(_load_report(), _load_find())
+        keys = {p.custom["citation_key"] for p in record.papers}
+        assert keys == {
+            "Maes2020",
+            "Deng2023",
+            "Coddington2018",
+            "Schultz1997",
+            "Cooper2011",
+        }
+
+    def test_parses_without_find_results(self):
+        # No enrichment doc: still cites all five (text fallback for every paper).
+        record, _ = parse_scholar_qa(_load_report())
+        assert len(record.papers) == N_PAPERS
+        assert {p.corpus_id for p in record.papers} == set(ALL_CORPUS_IDS)
+        assert all(p.authors == "" for p in record.papers)  # no enrichment
+        assert record.query == ""  # no find-results -> no query
+
+    def test_report_with_no_references_yields_empty_paper_list(self):
+        record, _ = parse_scholar_qa("# Title only\n\nNo citations here.")
+        assert isinstance(record, ReportRecord)
+        assert record.title == "Title only"
+        assert record.papers == []
+
+    def test_link_def_not_mistaken_for_reference_entry(self):
+        # A [Key]: url line (single brackets) must NOT be parsed as a [[Key]]
+        # reference entry, and vice versa.
+        md = (
+            "# T\n\n"
+            "See [[Foo2020]] for details.\n\n"
+            "## References\n"
+            "- [[Foo2020]] Foo, B. (2020). A Title. Venue.\n\n"
+            "[Foo2020]: https://semanticscholar.org/p/777\n"
+        )
+        record, _ = parse_scholar_qa(md)
+        assert len(record.papers) == 1
+        assert record.papers[0].corpus_id == "777"
+        assert record.papers[0].custom["citation_key"] == "Foo2020"
+
+    def test_defensive_on_garbage(self):
+        assert parse_scholar_qa("") == (None, RunMeta())
+        assert parse_scholar_qa("   \n  ") == (None, RunMeta())
+        assert parse_scholar_qa(123)[0] is None  # type: ignore[arg-type]
+        assert parse_scholar_qa(None)[0] is None  # type: ignore[arg-type]
+        assert parse_scholar_qa({})[0] is None  # type: ignore[arg-type]
+        # A malformed find_results does not break markdown parsing.
+        record, _ = parse_scholar_qa(_load_report(), {"results": "nope"})
+        assert len(record.papers) == N_PAPERS
+
+    def test_corpus_id_from_url_variants(self):
+        from wheeler.integrations.asta.scholar_qa import _corpus_id_from_url
+
+        assert _corpus_id_from_url("https://semanticscholar.org/p/123") == "123"
+        assert _corpus_id_from_url("https://www.semanticscholar.org/p/456") == "456"
+        assert (
+            _corpus_id_from_url("https://api.semanticscholar.org/CorpusId:789")
+            == "789"
+        )
+        assert _corpus_id_from_url("https://doi.org/10.1/x") == ""
+        assert _corpus_id_from_url("") == ""
+
+
+# ---------------------------------------------------------------------------
+# 2. CLI verb glue (markdown read + --find-results), no Neo4j
+# ---------------------------------------------------------------------------
+
+
+class TestScholarQaCliVerb:
+    """The `wheeler integrate ingest scholar-qa <report.md>` dispatch.
+
+    scholar-qa is the first MARKDOWN-deliverable tool: the verb must read the
+    artifact as TEXT (not json.loads) and forward an optional --find-results JSON.
+    Mocks ingest_scholar_qa so the glue is exercised without a live graph.
+    """
+
+    def _run(self, args, monkeypatch):
+        from typer.testing import CliRunner
+
+        from wheeler.integrations.asta import cli as cli_mod
+
+        captured = {}
+
+        async def _fake_ingest(report_markdown, **kwargs):
+            captured["report_markdown"] = report_markdown
+            captured.update(kwargs)
+            return ImportReportStub()
+
+        class ImportReportStub:
+            created = 1
+            deduped = 0
+            linked = 2
+            skipped = 0
+            used = 1
+            execution_id = "X-stub"
+            artifact = "W-stub"
+            paper_ids = ["P-stub"]
+
+        monkeypatch.setattr(cli_mod, "load_config", lambda: object(), raising=False)
+        monkeypatch.setattr(
+            "wheeler.config.load_config", lambda: object(), raising=False
+        )
+        monkeypatch.setattr(
+            "wheeler.integrations.asta.scholar_qa.ingest_scholar_qa", _fake_ingest
+        )
+        result = CliRunner().invoke(cli_mod.integrate_app, args)
+        return result, captured
+
+    def test_reads_markdown_not_json(self, tmp_path, monkeypatch):
+        report = tmp_path / "report.md"
+        report.write_text("# Not JSON\n\n[[A]] x\n\n[A]: https://semanticscholar.org/p/1\n")
+        result, captured = self._run(
+            ["scholar-qa", str(report), "--link-to", "Q-1"], monkeypatch
+        )
+        assert result.exit_code == 0, result.output
+        # The raw markdown reached the ingest verbatim (not parsed as JSON).
+        assert captured["report_markdown"].startswith("# Not JSON")
+        assert captured["report_path"] == str(report)
+        assert captured["link_to"] == "Q-1"
+        assert captured["find_results"] is None
+        assert "report: W-stub" in result.output
+
+    def test_find_results_parsed_and_forwarded(self, tmp_path, monkeypatch):
+        report = tmp_path / "report.md"
+        report.write_text("# R\n\n[[A]] x\n\n[A]: https://semanticscholar.org/p/1\n")
+        find = tmp_path / "find.json"
+        find.write_text(json.dumps({"query": "q", "results": []}))
+        result, captured = self._run(
+            ["scholar-qa", str(report), "--find-results", str(find)],
+            monkeypatch,
+        )
+        assert result.exit_code == 0, result.output
+        assert captured["find_results"] == {"query": "q", "results": []}
+
+    def test_used_ids_split_and_forwarded(self, tmp_path, monkeypatch):
+        report = tmp_path / "report.md"
+        report.write_text("# R\n")
+        result, captured = self._run(
+            ["scholar-qa", str(report), "--used", "Q-1, , F-2"],
+            monkeypatch,
+        )
+        assert result.exit_code == 0, result.output
+        assert captured["used_inputs"] == ["Q-1", "F-2"]  # blanks dropped
+
+    def test_literature_report_alias(self, tmp_path, monkeypatch):
+        report = tmp_path / "report.md"
+        report.write_text("# R\n")
+        result, _ = self._run(
+            ["literature-report", str(report)], monkeypatch
+        )
+        assert result.exit_code == 0, result.output
+
+    def test_missing_find_results_file_errors(self, tmp_path, monkeypatch):
+        from typer.testing import CliRunner
+
+        from wheeler.integrations.asta import cli as cli_mod
+
+        report = tmp_path / "report.md"
+        report.write_text("# R\n")
+        monkeypatch.setattr(
+            "wheeler.config.load_config", lambda: object(), raising=False
+        )
+        result = CliRunner().invoke(
+            cli_mod.integrate_app,
+            ["scholar-qa", str(report), "--find-results", str(tmp_path / "nope.json")],
+        )
+        assert result.exit_code == 2
+        assert "not found" in result.output
+
+
+# ---------------------------------------------------------------------------
+# 3. Live-Neo4j e2e (per-run e2e_tag, hermetic teardown, run-unique corpus_ids)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def e2e_config():
+    from wheeler.config import Neo4jConfig, ProjectMeta, WheelerConfig
+
+    return WheelerConfig(
+        neo4j=Neo4jConfig(
+            uri="bolt://localhost:7687",
+            username="neo4j",
+            password="research-graph",
+            database="neo4j",
+        ),
+        project=ProjectMeta(name="Integrations-E2E-Test"),
+    )
+
+
+@pytest.fixture(scope="module")
+def neo4j_available(e2e_config) -> bool:
+    import asyncio
+
+    from neo4j import AsyncGraphDatabase, NotificationMinimumSeverity
+
+    async def _check():
+        driver = AsyncGraphDatabase.driver(
+            e2e_config.neo4j.uri,
+            auth=(e2e_config.neo4j.username, e2e_config.neo4j.password),
+            notifications_min_severity=NotificationMinimumSeverity.OFF,
+        )
+        try:
+            async with driver.session(database=e2e_config.neo4j.database) as s:
+                await s.run("RETURN 1")
+            return True
+        except Exception:
+            return False
+        finally:
+            await driver.close()
+
+    return asyncio.run(_check())
+
+
+@pytest.fixture(autouse=True)
+def _reset_driver_singleton():
+    import wheeler.graph.driver as drv
+
+    drv._async_driver = None
+    drv._async_driver_uri = None
+    yield
+    drv._async_driver = None
+    drv._async_driver_uri = None
+
+
+def _cleanup_scholar_qa(e2e_config, e2e_tag: str) -> None:
+    """Hermetic teardown: delete ONLY the nodes THIS run tagged.
+
+    EXACTLY ``MATCH (n) WHERE n.e2e_tag = $tag DETACH DELETE n`` and nothing
+    else. NEVER delete by ``service`` or ``corpus_id``: the e2e config runs on
+    the SHARED default namespace where production nodes carry the same service
+    tag, so a service- or corpus_id-scoped delete would wipe real user data.
+    (The e2e uses RUN-UNIQUE synthetic corpus_ids precisely so no production
+    Paper is ever deduped-into, tagged, and then deleted here.)
+    """
+    import asyncio
+
+    from neo4j import AsyncGraphDatabase, NotificationMinimumSeverity
+
+    async def _run():
+        driver = AsyncGraphDatabase.driver(
+            e2e_config.neo4j.uri,
+            auth=(e2e_config.neo4j.username, e2e_config.neo4j.password),
+            notifications_min_severity=NotificationMinimumSeverity.OFF,
+        )
+        try:
+            async with driver.session(database=e2e_config.neo4j.database) as s:
+                await s.run(
+                    "MATCH (n) WHERE n.e2e_tag = $tag DETACH DELETE n",
+                    tag=e2e_tag,
+                )
+        finally:
+            await driver.close()
+
+    asyncio.run(_run())
+
+
+def _build_report(cids: list[str]) -> tuple[str, dict]:
+    """Build a report markdown + matching find-results for RUN-UNIQUE corpus_ids.
+
+    Returns ``(markdown, find_results)``. The report cites each corpus_id once
+    (inline + in References + a link definition); the find-results enriches the
+    first three (the last two exercise the text-fallback path), mirroring the
+    real fixture's mix.
+    """
+    keys = [f"Ref{i}" for i in range(len(cids))]
+    inline = " ".join(f"[[{k}]]." for k in keys)
+    refs = "\n".join(
+        f"- [[{k}]] Author, A. ({2000 + i}). Synthetic paper {i} on the topic. Venue {i}."
+        for i, k in enumerate(keys)
+    )
+    defs = "\n".join(
+        f"[{k}]: https://semanticscholar.org/p/{cid}" for k, cid in zip(keys, cids)
+    )
+    markdown = (
+        "# E2E Synthetic Literature Report\n\n"
+        "## Executive Summary\n\n"
+        f"This synthetic review cites several works {inline}\n\n"
+        "## References\n\n"
+        f"{refs}\n\n"
+        f"{defs}\n"
+    )
+    find_results = {
+        "query": "e2e synthetic topic",
+        "results": [
+            {
+                "corpusId": int(cid),
+                "title": f"Enriched synthetic paper {i}",
+                "year": 2000 + i,
+                "venue": f"Venue {i}",
+                "citationCount": 10 + i,
+                "authors": [{"name": f"Author {i}"}, {"name": "Coauthor B."}],
+            }
+            for i, cid in enumerate(cids[:3])  # enrich only the first three
+        ],
+    }
+    return markdown, find_results
+
+
+class TestIngestScholarQaE2E:
+    @pytest.fixture(autouse=True)
+    def _skip_and_cleanup(self, neo4j_available, e2e_config, tmp_path, monkeypatch):
+        if not neo4j_available:
+            pytest.skip("Neo4j not available -- skipping integrations e2e")
+        # Temp cwd so the on-disk corpus_id index + durable raw store land in a
+        # sandbox we delete; per-run unique tag so teardown never touches another
+        # test; run-unique synthetic corpus_ids so no production Paper is deduped.
+        monkeypatch.chdir(tmp_path)
+        self._tmp = tmp_path
+        self._e2e_tag = f"integrations_e2e_{uuid.uuid4().hex}"
+        # Run-unique numeric corpus_ids derived from the per-run uuid, so they
+        # cannot collide with a production Paper or a prior interrupted run.
+        base = int(self._e2e_tag.rsplit("_", 1)[-1][:12], 16)
+        self._cids = [str(base + i) for i in range(N_PAPERS)]
+        _cleanup_scholar_qa(e2e_config, self._e2e_tag)
+        yield
+        _cleanup_scholar_qa(e2e_config, self._e2e_tag)
+
+    async def _tag_all(self, e2e_config, report):
+        """Tag ONLY the nodes THIS run created, scoped off the report ids plus
+        the run's WAS_GENERATED_BY fan-in. NEVER by service or corpus_id. Papers
+        are reference entities (no WAS_GENERATED_BY); tag them via paper_ids."""
+        from wheeler.graph.driver import get_async_driver
+
+        driver = get_async_driver(e2e_config)
+        db = e2e_config.neo4j.database
+        run_ids = [i for i in (report.execution_id, report.artifact) if i]
+        run_ids += [pid for pid in report.paper_ids if pid]
+        async with driver.session(database=db) as s:
+            if run_ids:
+                await s.run(
+                    "MATCH (n) WHERE n.id IN $ids SET n.e2e_tag = $tag",
+                    ids=run_ids,
+                    tag=self._e2e_tag,
+                )
+            if report.execution_id:
+                await s.run(
+                    "MATCH (n)-[:WAS_GENERATED_BY]->(x:Execution {id: $xid}) "
+                    "SET n.e2e_tag = $tag",
+                    xid=report.execution_id,
+                    tag=self._e2e_tag,
+                )
+
+    @pytest.mark.asyncio
+    async def test_ingest_buckets_and_is_idempotent(self, e2e_config):
+        from wheeler.graph.backend import get_backend
+        from wheeler.graph.driver import get_async_driver
+        from wheeler.integrations.asta.scholar_qa import ingest_scholar_qa
+        from wheeler.tools.graph_tools import execute_tool
+
+        markdown, find_results = _build_report(self._cids)
+        report_path = self._tmp / "report.md"
+        report_path.write_text(markdown)
+
+        # Seed a Question so the run has an input to USE and a link target.
+        q = json.loads(
+            await execute_tool(
+                "add_question",
+                {"question": "E2E: what does the synthetic review address?", "priority": 5},
+                e2e_config,
+            )
+        )
+        question_id = q["node_id"]
+        driver = get_async_driver(e2e_config)
+        db = e2e_config.neo4j.database
+        async with driver.session(database=db) as s:
+            await s.run(
+                "MATCH (n {id: $id}) SET n.e2e_tag = $tag",
+                id=question_id,
+                tag=self._e2e_tag,
+            )
+
+        # --- First ingest ---
+        report1 = await ingest_scholar_qa(
+            markdown,
+            report_path=str(report_path),
+            find_results=find_results,
+            link_to=question_id,
+            config=e2e_config,
+            used_inputs=[question_id],
+        )
+        await self._tag_all(e2e_config, report1)
+        assert report1.execution_id.startswith("X-")
+        xid = report1.execution_id
+        tag = self._e2e_tag
+        # Five cited papers created (run-unique corpus_ids -> never deduped).
+        assert report1.created == N_PAPERS
+        assert report1.deduped == 0
+        # The report Document is a W- node, NOT a Dataset.
+        assert report1.artifact.startswith("W-")
+        assert len(report1.paper_ids) == N_PAPERS
+
+        # The report Document: a Document pointing at the durable raw store with
+        # its .md extension preserved, WAS_GENERATED_BY the run Execution.
+        raw_node = await get_backend(e2e_config).get_node("Document", report1.artifact)
+        assert raw_node is not None
+        assert ".wheeler/asta/raw/asta-scholar-qa" in raw_node["path"]
+        assert raw_node["path"].endswith(".md")
+        assert Path(raw_node["path"]).exists()
+        assert raw_node["service"] == SERVICE_TAG
+
+        async with driver.session(database=db) as s:
+            # report Document WAS_GENERATED_BY the run Execution (exactly one).
+            res = await s.run(
+                "MATCH (w:Document {id: $wid})-[r:WAS_GENERATED_BY]->"
+                "(x:Execution {id: $xid}) RETURN count(r) AS c",
+                wid=report1.artifact,
+                xid=xid,
+            )
+            assert (await res.single())["c"] == 1
+            # The report Document CITES each cited Paper (5 CITES edges).
+            res = await s.run(
+                "MATCH (w:Document {id: $wid})-[r:CITES]->(p:Paper) "
+                "RETURN count(r) AS c",
+                wid=report1.artifact,
+            )
+            assert (await res.single())["c"] == N_PAPERS
+            # The report Document AROSE_FROM the seed Question.
+            res = await s.run(
+                "MATCH (w:Document {id: $wid})-[r:AROSE_FROM]->(q {id: $qid}) "
+                "RETURN count(r) AS c",
+                wid=report1.artifact,
+                qid=question_id,
+            )
+            assert (await res.single())["c"] == 1
+            # INPUT side: the run USED the seed Question AND each cited Paper.
+            res = await s.run(
+                "MATCH (x:Execution {id: $xid})-[:USED]->(q {id: $qid}) "
+                "RETURN count(q) AS c",
+                xid=xid,
+                qid=question_id,
+            )
+            assert (await res.single())["c"] == 1
+            res = await s.run(
+                "MATCH (x:Execution {id: $xid})-[r:USED]->(p:Paper) "
+                "RETURN count(r) AS c",
+                xid=xid,
+            )
+            assert (await res.single())["c"] == N_PAPERS
+            # Papers are REFERENCE ENTITIES: NO WAS_GENERATED_BY into the run.
+            res = await s.run(
+                "MATCH (p:Paper)-[r:WAS_GENERATED_BY]->(x:Execution {id: $xid}) "
+                "RETURN count(r) AS c",
+                xid=xid,
+            )
+            assert (await res.single())["c"] == 0
+            # The Execution carries the service tag and the literature-report kind.
+            res = await s.run(
+                "MATCH (x:Execution {id: $xid}) "
+                "RETURN x.kind AS kind, x.service AS svc",
+                xid=xid,
+            )
+            rec = await res.single()
+            assert rec["kind"] == "literature-report"
+            assert rec["svc"] == SERVICE_TAG
+
+        # Enriched papers carry find-results metadata; unenriched ones do not.
+        async with driver.session(database=db) as s:
+            res = await s.run(
+                "MATCH (p:Paper) WHERE p.e2e_tag = $tag AND p.corpus_id = $cid "
+                "RETURN p.year AS year, p.custom_venue AS venue",
+                tag=tag,
+                cid=self._cids[0],
+            )
+            rec = await res.single()
+            assert rec["year"] == 2000
+            assert rec["venue"] == "Venue 0"
+
+        # --- Re-ingest the SAME report: idempotent ---
+        report2 = await ingest_scholar_qa(
+            markdown,
+            report_path=str(report_path),
+            find_results=find_results,
+            link_to=question_id,
+            config=e2e_config,
+            used_inputs=[question_id],
+        )
+        await self._tag_all(e2e_config, report2)
+        assert report2.created == 0  # nothing new
+        assert report2.deduped == N_PAPERS
+        assert report2.execution_id == xid  # same Execution reused
+        assert report2.artifact == report1.artifact  # same Document (path-dedupe)
+
+        # No duplicate nodes or provenance edges on the second pass. Every
+        # structural-provenance edge stays at exactly its first-pass count
+        # (link_once guards each one): CITES, USED->Paper, USED->Question,
+        # Document WAS_GENERATED_BY Execution, Document AROSE_FROM Question.
+        async with driver.session(database=db) as s:
+            res = await s.run(
+                "MATCH (p:Paper) WHERE p.e2e_tag = $tag RETURN count(p) AS c",
+                tag=tag,
+            )
+            assert (await res.single())["c"] == N_PAPERS
+            res = await s.run(
+                "MATCH (w:Document {id: $wid})-[r:CITES]->(:Paper) "
+                "RETURN count(r) AS c",
+                wid=report1.artifact,
+            )
+            assert (await res.single())["c"] == N_PAPERS
+            res = await s.run(
+                "MATCH (x:Execution {id: $xid})-[r:USED]->(p:Paper) "
+                "RETURN count(r) AS c",
+                xid=xid,
+            )
+            assert (await res.single())["c"] == N_PAPERS
+            res = await s.run(
+                "MATCH (x:Execution {id: $xid})-[r:USED]->(q {id: $qid}) "
+                "RETURN count(r) AS c",
+                xid=xid,
+                qid=question_id,
+            )
+            assert (await res.single())["c"] == 1  # no duplicate USED->input
+            res = await s.run(
+                "MATCH (w:Document {id: $wid})-[r:WAS_GENERATED_BY]->"
+                "(x:Execution {id: $xid}) RETURN count(r) AS c",
+                wid=report1.artifact,
+                xid=xid,
+            )
+            assert (await res.single())["c"] == 1  # no duplicate WAS_GENERATED_BY
+            res = await s.run(
+                "MATCH (w:Document {id: $wid})-[r:AROSE_FROM]->(q {id: $qid}) "
+                "RETURN count(r) AS c",
+                wid=report1.artifact,
+                qid=question_id,
+            )
+            assert (await res.single())["c"] == 1  # no duplicate AROSE_FROM
+            res = await s.run(
+                "MATCH (w:Document {id: $wid}) RETURN count(w) AS c",
+                wid=report1.artifact,
+            )
+            assert (await res.single())["c"] == 1
+
+        # --- Re-ingest an EDITED report at the SAME path: still ONE Document and
+        # ONE Execution (the run key is coupled to the report path, not the
+        # content sha, so a re-synthesized report does not accrue a second
+        # Document to the run). ---
+        edited = markdown + "\n\n## Addendum\n\nA later revision adds this section.\n"
+        report_path.write_text(edited)
+        report3 = await ingest_scholar_qa(
+            edited,
+            report_path=str(report_path),
+            find_results=find_results,
+            link_to=question_id,
+            config=e2e_config,
+            used_inputs=[question_id],
+        )
+        await self._tag_all(e2e_config, report3)
+        assert report3.execution_id == xid  # same Execution despite edited text
+        assert report3.artifact == report1.artifact  # same Document, not a second
+        async with driver.session(database=db) as s:
+            # Still exactly one Document WAS_GENERATED_BY this run's Execution
+            # (the edited report did not create a second version node).
+            res = await s.run(
+                "MATCH (w:Document)-[:WAS_GENERATED_BY]->(x:Execution {id: $xid}) "
+                "RETURN count(DISTINCT w) AS c",
+                xid=xid,
+            )
+            assert (await res.single())["c"] == 1

--- a/tests/integrations/asta/test_theorizer.py
+++ b/tests/integrations/asta/test_theorizer.py
@@ -34,8 +34,11 @@ from wheeler.integrations.asta.theorizer import (
 # (run_id, cost, time). Structurally faithful, under 200KB.
 FIXTURE = Path(__file__).parent / "fixtures" / "theorizer_real_sample.json"
 
-# Service tag for every node this adapter writes. Teardown keys on it (plus the
-# fixture corpus_ids) so cleanup is hermetic regardless of a per-run e2e tag.
+# Service tag for every node this adapter writes. Teardown does NOT key on it:
+# the hermetic delete is by the per-run uuid ``e2e_tag`` only (see
+# ``_cleanup_theorizer``), never by ``service`` or ``corpus_id``, because the e2e
+# config runs on the shared default namespace where production nodes carry the
+# same service tag and corpus_ids.
 SERVICE_TAG = "asta:theorizer"
 
 # Every distinct corpus_id across supporting + contradicting papers in the

--- a/wheeler/_data/commands/asta-report.md
+++ b/wheeler/_data/commands/asta-report.md
@@ -1,0 +1,84 @@
+---
+name: wh:asta-report
+description: Use when the user wants a written literature review or comprehensive multi-paper report (write a review of X, synthesize the literature on Y) via Asta, ingested into the Wheeler knowledge graph as a Document with cited papers
+argument-hint: "[review topic or question]"
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash(asta literature:*)
+  - Bash(asta papers:*)
+  - Bash(asta auth status)
+  - Bash(jq *)
+  - Bash(wheeler integrate:*)
+  - mcp__wheeler_core__search_context
+  - mcp__wheeler_query__query_papers
+  - mcp__wheeler_query__query_findings
+  - mcp__wheeler_query__query_hypotheses
+  - mcp__wheeler_query__query_open_questions
+  - mcp__wheeler_mutations__link_nodes
+
+---
+
+You are Wheeler, producing an Asta Literature Report (a written, multi-paper literature review) and marshalling it into the knowledge graph. The deliverable is a MARKDOWN document, not a single JSON artifact: you orchestrate `asta literature find` (and `asta papers`) for evidence, SYNTHESIZE the review yourself, then one deterministic `wheeler integrate` verb writes the report Document plus its cited papers into the graph with provenance.
+
+Unlike the other Asta acts (one CLI call, one JSON `-o` artifact), this act writes a markdown report and ingests THAT. The asta CLI owns its own auth and timeouts; a failed search writes nothing.
+
+## Preflight
+
+1. Confirm Asta is authenticated: `asta auth status`. If that fails, say Asta is not available and stop. Do not attempt the run.
+2. Read context so the review is shaped by the graph. Use `mcp__wheeler_core__search_context` with the topic (or the active question), `mcp__wheeler_query__query_papers` for papers already recorded, and `mcp__wheeler_query__query_open_questions` for the question this review answers. Use this only to sharpen the topic and pick a link target. Do not invent findings. Do not do the scientist's thinking.
+
+## Choose the topic and link target
+
+- The topic is `$ARGUMENTS` when provided. If empty, ask the user or derive one from the active investigation.
+- Pick at most one link target: the Question (`Q-...`) or Plan (`PL-...`) this review serves. If there is no clear target, run without one.
+
+## Gather evidence
+
+Run the paper finder, writing its results to a temp file (this JSON also enriches each cited paper's metadata at ingest):
+
+```
+asta literature find "$TOPIC" -o /tmp/find.json
+```
+
+Supplement with targeted `asta papers search` / `asta papers get` / `asta papers citations` calls as needed. If `asta literature find` exits non-zero (including a login or auth failure), report it and stop.
+
+(If the asta-plugins `literature-report` skill is installed, you may invoke it to do the search-and-synthesize loop; otherwise do the steps here directly.)
+
+## Write the report
+
+Synthesize a markdown literature review at `.asta/literature/report/<YYYY-MM-DD>-<topic-slug>.md`. SYNTHESIZE across papers (connect ideas, do not just list them); support every claim with a citation. Use the citation convention the ingest parses (this is load-bearing, the parser keys on it):
+
+- Inline + reference entries use double brackets: `[[Maes2020]]`.
+- A References section lists each cited paper: `- [[Maes2020]] Maes, E., et al. (2020). Title. Venue.`
+- Link definitions at the end of the file carry the Semantic Scholar corpus id, which is the dedupe key. Use the `/p/<corpusId>` form (read `corpusId` for each paper from `/tmp/find.json` with `jq`):
+
+```
+[Maes2020]: https://semanticscholar.org/p/91676903
+```
+
+Only papers that have BOTH a `[[Key]]` reference entry AND a `[Key]: <url>` link definition with a corpus id become cited Paper nodes, so give every cited paper both. Never use em dashes in the report.
+
+## Ingest
+
+Marshal the report (markdown) into the graph with the single integrate verb. Pass the find-results JSON so each cited paper's metadata (authors, year, venue) is enriched by a corpus_id join:
+
+```
+wheeler integrate ingest scholar-qa .asta/literature/report/<file>.md --link-to <Q- or PL- id> --used <Q- or PL- id>,<source ids> --find-results /tmp/find.json
+```
+
+This registers the report as a Document (`W-`) node WAS_GENERATED_BY the run Execution, creates a Paper node per cited corpus id (deduped across the whole graph), wires the Document `CITES` each paper and the Execution `USED` each paper (the review was derived from them). Omit `--link-to` if there is no target. Pass `--used` with the graph node ids the request was built FROM (at minimum the link target): this records `Execution -[USED]-> each input` (input-side provenance), so the report traces back to the graph context that shaped it. The verb is idempotent: re-ingesting the same report creates no duplicate Document, papers, or edges.
+
+## Wire semantics to the existing graph
+
+The ingest is STRUCTURALLY complete (the report `WAS_GENERATED_BY` the run and `USED`/`CITES` its papers). It does NOT connect the review to what was ALREADY in the graph, because that is a judgment call (compare the review's conclusions against the current graph), so it lives here in the act, not in the mechanical parser. Do this after ingest:
+
+1. Read the report Document id and the new Paper ids from the ingest summary. Read the existing graph with `mcp__wheeler_query__query_open_questions`, `mcp__wheeler_query__query_hypotheses`, and `mcp__wheeler_query__query_findings`, plus `mcp__wheeler_core__search_context` on the topic.
+2. Identify the semantic edges between the review and EXISTING nodes: the report Document `RELEVANT_TO` an open Question it answers; the report's stated conclusion `SUPPORTS` or `CONTRADICTS` an existing Hypothesis (link the Document, or a Finding you record for the conclusion, to the Hypothesis); a cited Paper `RELEVANT_TO` an open Question. Keep only edges the review's text actually warrants.
+3. Confirm each judgment call with the scientist before writing.
+4. Apply the confirmed edges via `mcp__wheeler_mutations__link_nodes` (for example `link_nodes(<report W- id>, <Q- id>, "RELEVANT_TO")` or `link_nodes(<report W- id>, <H- id>, "SUPPORTS")`). Skip any edge the scientist does not endorse.
+
+## Report
+
+Relay the printed summary (`created`, `deduped`, `linked`, `used`, the run Execution id, the report Document id, and the cited Paper ids) in one or two sentences, and give the path to the markdown report so the scientist can read it. Suggest `query_documents` / `query_papers` to browse the new nodes. Do not editorialize the science. Never use em dashes.

--- a/wheeler/integrations/asta/CLAUDE.md
+++ b/wheeler/integrations/asta/CLAUDE.md
@@ -52,9 +52,12 @@ side plus the subprocess boundary. No workflow engine, daemon, or router.
   forwards neither `service` nor `custom`, so the service tag and the benchmark
   bag (`run_id`, `cost`, `time`, `model`) are stamped via a follow-up
   `update_node` (service is a first-class NodeBase field; benchmark scalars
-  flatten to queryable `custom_<key>` props). Best-effort: ANY failure returns
-  `None` and logs a warning, never raises, so an artifact problem cannot break
-  ingest. Returns the artifact node id.
+  flatten to queryable `custom_<key>` props). The durable-store filename
+  PRESERVES the source extension (`<key>.json` for a JSON `-o` dump, `<key>.md`
+  for a markdown literature report), so a non-JSON deliverable is not stored
+  under a misleading `.json` name; existing JSON callers are unchanged. Best-effort:
+  ANY failure returns `None` and logs a warning, never raises, so an artifact
+  problem cannot break ingest. Returns the artifact node id.
 - `theorizer.py` -- `parse_theorizer(doc) -> (list[TheoryRecord], RunMeta)` and
   `ingest_theorizer(doc, *, link_to, config, artifact_path=None) -> ImportReport`.
   A marshal-out module parsing the REAL Theorizer A2A-Task shape (artifacts
@@ -67,10 +70,34 @@ side plus the subprocess boundary. No workflow engine, daemon, or router.
   papers on `corpus_id`. Imports `execute_tool` lazily (function-local) and
   reuses `_marshal.py`'s `_link_once` / `_find_paper_by_corpus_id` /
   `_paper_exists` / `_find_execution` helpers + the shared corpus_id index.
+- `scholar_qa.py` -- `parse_scholar_qa(report_markdown, find_results=None) ->
+  (ReportRecord, RunMeta)` and `ingest_scholar_qa(report_markdown, *, report_path,
+  find_results, link_to, config, used_inputs) -> ImportReport`. The Asta Literature
+  Report (scholar-qa) adapter. UNLIKE the other three adapters (one A2A call, one
+  JSON `-o` artifact), the deliverable is a MARKDOWN literature review: the
+  `literature-report` skill orchestrates `asta literature find` + `asta papers` and
+  Claude synthesizes the report. The parser keys on the skill's citation
+  convention: `[[Key]]` reference entries paired with `[Key]: <url>` link
+  definitions, lifting the corpus_id from the `/p/<id>` or `CorpusId:<id>` url, and
+  enriching title/authors/year/venue from the optional `LiteratureSearchResult`
+  JSON by a corpus_id join (reusing `parse_paper_finder`; text fallback when
+  absent). Bucketing: the report markdown registers as a Document (`W-`, synthesized
+  writing) `WAS_GENERATED_BY` the run Execution (kind `literature-report`, service
+  `asta:scholar-qa`); each cited paper -> add_paper (dedupe by corpus_id), the
+  Document `-[CITES]-> Paper` and the Execution `-[USED]-> Paper` (the review was
+  derived from it). Papers are reference entities (NO `WAS_GENERATED_BY`, and NOT
+  `WAS_DERIVED_FROM` the report, since a cited paper predates the review). The
+  Execution `session_id` AND the durable raw-store key are BOTH the same
+  path-derived `run_key`, so one report path = one run = one Document even when the
+  report is re-synthesized with edited text (no second Document accrues).
 - `cli.py` -- `integrate_app` Typer sub-app, one verb: `ingest <tool> <artifact>
-  [--link-to ID]`. Registered in `wheeler/tools/cli.py` guarded by try/except.
-  Note: the generic `integrate` CLI currently lives here and moves up to
-  `wheeler/integrations/` when the contract engine is extracted (Phase 3).
+  [--link-to ID] [--used IDS] [--target ID] [--find-results JSON]`. Registered in
+  `wheeler/tools/cli.py` guarded by try/except. The `scholar-qa` /
+  `literature-report` tool is the first MARKDOWN deliverable: its artifact is read
+  as TEXT (not `json.loads`), and `--find-results` carries the optional
+  `LiteratureSearchResult` JSON for paper enrichment. Note: the generic `integrate`
+  CLI currently lives here and moves up to `wheeler/integrations/` when the contract
+  engine is extracted (Phase 3).
 
 ## Invariants
 

--- a/wheeler/integrations/asta/artifacts.py
+++ b/wheeler/integrations/asta/artifacts.py
@@ -102,7 +102,12 @@ def _save_raw_durably(
             key = _content_sha(src_path)
         store_dir = Path(_RAW_STORE_REL) / slug
         store_dir.mkdir(parents=True, exist_ok=True)
-        dest = store_dir / f"{key}.json"
+        # Preserve the source extension so a non-JSON deliverable (a markdown
+        # literature report, for example) is not stored under a misleading
+        # ``.json`` name. Existing JSON callers pass ``.json`` files, so their
+        # durable path is unchanged.
+        suffix = src_path.suffix or ".json"
+        dest = store_dir / f"{key}{suffix}"
         if dest.exists():
             # Same run already saved: reuse it (path-dedupe), do not re-copy.
             return dest

--- a/wheeler/integrations/asta/cli.py
+++ b/wheeler/integrations/asta/cli.py
@@ -30,7 +30,15 @@ _INGESTERS = {
     "semantic_scholar",
     "semantic-scholar",
     "s2",
+    "scholar_qa",
+    "scholar-qa",
+    "literature-report",
 }
+
+# Tools whose deliverable is a MARKDOWN document, not a JSON ``-o`` artifact. The
+# ingest verb reads these as text (not json.loads) and dispatches to the markdown
+# ingest path. Asta Literature Reports is the first such tool.
+_MARKDOWN_TOOLS = {"scholar_qa", "scholar-qa", "literature-report"}
 
 
 @integrate_app.command("ingest")
@@ -57,25 +65,28 @@ def ingest(
             "each one that exists in the graph (input-side provenance)."
         ),
     ),
+    find_results: Optional[Path] = typer.Option(
+        None,
+        "--find-results",
+        help=(
+            "For a literature report (scholar-qa): the underlying "
+            "LiteratureSearchResult JSON (asta literature find -o), used to "
+            "enrich each cited paper's metadata by corpus_id. Ignored otherwise."
+        ),
+    ),
 ) -> None:
     """Marshal an external-tool artifact into the Wheeler knowledge graph."""
     tool_key = tool.strip().lower()
     if tool_key not in _INGESTERS:
         typer.echo(
             f"Unknown tool '{tool}'. Supported: paper_finder, theorizer, "
-            "semantic_scholar (alias s2).",
+            "semantic_scholar (alias s2), scholar_qa (alias literature-report).",
             err=True,
         )
         raise typer.Exit(code=2)
 
     if not artifact.exists():
         typer.echo(f"Artifact not found: {artifact}", err=True)
-        raise typer.Exit(code=2)
-
-    try:
-        doc = json.loads(artifact.read_text())
-    except (OSError, json.JSONDecodeError) as exc:
-        typer.echo(f"Could not read artifact {artifact}: {exc}", err=True)
         raise typer.Exit(code=2)
 
     from wheeler.config import load_config
@@ -89,6 +100,59 @@ def ingest(
     # no-USED-edges path is reached identically rather than passing an empty list.
     _parsed_used = [i.strip() for i in used.split(",") if i.strip()] if used else []
     used_inputs = _parsed_used or None
+
+    # A literature report is MARKDOWN, not a JSON artifact: read it as text and
+    # dispatch to the markdown ingest path. The optional --find-results JSON is
+    # parsed for paper-metadata enrichment.
+    if tool_key in _MARKDOWN_TOOLS:
+        try:
+            report_markdown = artifact.read_text()
+        except OSError as exc:
+            typer.echo(f"Could not read report {artifact}: {exc}", err=True)
+            raise typer.Exit(code=2)
+        find_doc = None
+        if find_results is not None:
+            if not find_results.exists():
+                typer.echo(
+                    f"--find-results file not found: {find_results}", err=True
+                )
+                raise typer.Exit(code=2)
+            try:
+                find_doc = json.loads(find_results.read_text())
+            except (OSError, json.JSONDecodeError) as exc:
+                typer.echo(
+                    f"Could not read --find-results {find_results}: {exc}", err=True
+                )
+                raise typer.Exit(code=2)
+
+        from wheeler.integrations.asta.scholar_qa import ingest_scholar_qa
+
+        report = asyncio.run(
+            ingest_scholar_qa(
+                report_markdown,
+                report_path=str(artifact),
+                find_results=find_doc,
+                link_to=link_to,
+                config=config,
+                used_inputs=used_inputs,
+            )
+        )
+        typer.echo(
+            f"created={report.created} deduped={report.deduped} "
+            f"linked={report.linked} skipped={report.skipped} used={report.used} "
+            f"execution={report.execution_id or '-'}"
+        )
+        if report.artifact:
+            typer.echo(f"report: {report.artifact}")
+        if report.paper_ids:
+            typer.echo("papers: " + ", ".join(report.paper_ids))
+        return
+
+    try:
+        doc = json.loads(artifact.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        typer.echo(f"Could not read artifact {artifact}: {exc}", err=True)
+        raise typer.Exit(code=2)
 
     if tool_key == "theorizer":
         from wheeler.integrations.asta.theorizer import ingest_theorizer

--- a/wheeler/integrations/asta/scholar_qa.py
+++ b/wheeler/integrations/asta/scholar_qa.py
@@ -1,0 +1,591 @@
+"""Marshal-out (deterministic): ingest an Asta Literature Report.
+
+A marshal-out module mirroring ``theorizer.py``: it imports ``execute_tool``
+lazily (function-local), so every graph write routes through the triple-write +
+write-receipt + trace-id + embedding wiring, and reuses the shared helpers in
+``_marshal.py`` (``_link_once`` / ``_find_paper_by_corpus_id`` / ``_paper_exists``
+/ ``_find_execution`` / ``_record_used`` + the persisted corpus_id index) plus
+``register_output_artifact`` in ``artifacts.py``.
+
+REAL output shape: UNLIKE the other three Asta adapters (each one A2A call that
+dumps a single JSON ``-o`` artifact), the Asta Literature Report deliverable is a
+MARKDOWN document. The ``literature-report`` skill orchestrates ``asta literature
+find`` + ``asta papers`` lookups and Claude SYNTHESIZES a written review at
+``.asta/literature/report/<topic>.md``. So this ingest takes the report MARKDOWN
+(primary) plus the optional underlying ``LiteratureSearchResult`` JSON for paper
+metadata enrichment, not a single service JSON.
+
+The report uses the skill's citation convention, which carries the machine-
+readable parts the parser keys on:
+
+    Inline:      This was demonstrated by [[Maes2020]].
+    References:  - [[Maes2020]] Maes, E., et al. (2020). Causal evidence ... Nature Neuroscience.
+    Link defs:   [Maes2020]: https://semanticscholar.org/p/91676903
+
+The link definition's URL carries the Semantic Scholar corpus id (``/p/<id>`` or
+``CorpusId:<id>``), the stable dedupe key. The parser pairs each reference entry
+(``[[Key]]``) with its link definition (``[Key]: <url>``) by citation key, lifts
+the corpus id from the url, and enriches title/authors/year/venue from the
+optional find-results JSON by a corpus_id join (text fallback when absent).
+
+Bucketing (the report becomes a small synthesis subgraph):
+  - One Execution per RUN (kind ``literature-report``, service
+    ``asta:scholar-qa``), keyed on the report path so re-ingest is idempotent.
+  - The report MARKDOWN is saved durably (see artifacts.py, extension-preserving)
+    and registered as a Document (``W-``) node: a literature review is
+    synthesized WRITING, not data. The Document is the run's primary produced
+    node, ``WAS_GENERATED_BY`` the Execution.
+  - Each cited paper -> add_paper (dedupe by corpus_id). The report Document
+    ``-[CITES]-> Paper`` (the bibliographic edge), and the run Execution
+    ``-[USED]-> Paper`` (the report was DERIVED from it, so the paper is a
+    genuine INPUT, mirroring Theorizer evidence). Papers are REFERENCE ENTITIES
+    (NO ``WAS_GENERATED_BY``; NOT ``WAS_DERIVED_FROM`` the report either, since a
+    cited paper predates the review that cites it).
+  - If ``link_to`` is given, the report Document ``-[AROSE_FROM]-> link_to`` and,
+    when ``link_to`` is a Plan, the Execution ``-[AROSE_FROM]-> Plan``.
+
+Semantic wiring to the EXISTING graph (the report's claims SUPPORTS/CONTRADICTS
+prior Hypotheses, RELEVANT_TO open Questions) is JUDGMENT, so it lives in the
+``/wh:asta-report`` act post-ingest, NOT in this parser (see the three-part model
+in docs/asta-engine-spec.md).
+
+Invariants:
+  - Defensive: every step tolerates missing pieces, counts and skips, never
+    raises. A malformed or reference-less report never aborts ingest.
+  - Sequential writes only. Never ``asyncio.gather``: ``execute_tool`` reuses
+    one cached backend singleton and Neo4j forbids concurrent queries.
+  - link_once: every edge is existence-guarded because the backend's
+    ``create_relationship`` is a bare CREATE that duplicates on re-run.
+  - One Execution per RUN, tagged service ``asta:scholar-qa``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from wheeler.config import WheelerConfig
+from wheeler.integrations.asta._marshal import (
+    ImportReport,
+    _find_execution,
+    _find_paper_by_corpus_id,
+    _link_execution_to_plan,
+    _link_once,
+    _load_index,
+    _paper_exists,
+    _record_used,
+    _save_index,
+)
+from wheeler.integrations.asta.schemas import (
+    _normalize_corpus_id,
+    parse_paper_finder,
+)
+
+logger = logging.getLogger(__name__)
+
+_SERVICE_TAG = "asta:scholar-qa"
+
+# A literature review is synthesized WRITING, so its raw node is a Document (W-),
+# NOT a Dataset. Reserve Dataset for genuine data.
+_RAW_NODE_TYPE = "document"
+
+# Citation-key reference entry: a line carrying ``[[Key]]`` (the skill's
+# double-bracket inline/reference form) followed by the citation text.
+_REF_ENTRY_RE = re.compile(r"\[\[([^\]\[]+)\]\]\s*(.*)")
+
+# Link definition: ``[Key]: <url>`` at the start of a line (single brackets, NOT
+# followed by another ``[`` so a ``[[Key]]`` reference entry is not mistaken for
+# a link def). The url runs to end-of-line / whitespace.
+_LINK_DEF_RE = re.compile(r"^\[([^\]\[]+)\]:\s*(\S+)", re.MULTILINE)
+
+# Corpus id inside a Semantic Scholar url: ``/p/<digits>`` or ``CorpusId:<digits>``
+# (case-insensitive on the CorpusId token; the real find urls use both shapes).
+_CORPUS_ID_RE = re.compile(r"(?:/p/|corpusid:)(\d+)", re.IGNORECASE)
+
+# Year inside a citation text, e.g. ``(2020)``.
+_YEAR_RE = re.compile(r"\((\d{4})\)")
+
+
+# ---------------------------------------------------------------------------
+# Parse records (intermediate, shape-drift tolerant, never raises)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CitedPaper:
+    """One paper cited by the report (becomes a Paper node, CITES from the doc)."""
+
+    corpus_id: str
+    title: str
+    authors: str = ""
+    year: int = 0
+    custom: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ReportRecord:
+    """A parsed literature report: its identity + the papers it cites."""
+
+    title: str
+    query: str
+    papers: list[CitedPaper] = field(default_factory=list)
+
+
+@dataclass
+class RunMeta:
+    """Benchmark fields for the run.
+
+    A report has no service run_id (Claude synthesizes it), so these are usually
+    empty; kept for shape-parity with the other adapters and future enrichment.
+    """
+
+    run_id: str = ""
+    cost: float | None = None
+    time: float | None = None
+    model: str = ""
+
+    def custom_bag(self) -> dict[str, Any]:
+        bag: dict[str, Any] = {"service": _SERVICE_TAG}
+        if self.run_id:
+            bag["run_id"] = self.run_id
+        if self.cost is not None:
+            bag["cost"] = self.cost
+        if self.time is not None:
+            bag["time"] = self.time
+        if self.model:
+            bag["model"] = self.model
+        return bag
+
+
+def _as_str(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    return str(value)
+
+
+def _corpus_id_from_url(url: str) -> str:
+    """Lift a corpus id from a Semantic Scholar url, normalized, or ""."""
+    match = _CORPUS_ID_RE.search(url or "")
+    return _normalize_corpus_id(match.group(1)) if match else ""
+
+
+def _report_title(markdown: str) -> str:
+    """First level-1 ATX heading (``# ...``) as the report title, or ""."""
+    for line in markdown.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("# "):
+            return stripped[2:].strip()
+    return ""
+
+
+def _link_defs(markdown: str) -> dict[str, str]:
+    """Map citation key -> corpus_id from every ``[Key]: <url>`` link def.
+
+    A key with no extractable corpus id is kept with "" so the reference entry
+    is still recognized (its metadata then comes from the text / find-results).
+    """
+    out: dict[str, str] = {}
+    for key, url in _LINK_DEF_RE.findall(markdown):
+        ckey = key.strip()
+        if ckey and ckey not in out:
+            out[ckey] = _corpus_id_from_url(url)
+    return out
+
+
+def _ref_entries(markdown: str) -> dict[str, str]:
+    """Map citation key -> citation text from every ``[[Key]] <text>`` entry.
+
+    Inline mentions and the References list both use ``[[Key]]``; the References
+    entry carries the fuller text (authors, year, title), so prefer the LONGEST
+    text seen for a key. This is the set of papers the report actually cites.
+    """
+    out: dict[str, str] = {}
+    for raw_line in markdown.splitlines():
+        match = _REF_ENTRY_RE.search(raw_line)
+        if not match:
+            continue
+        key = match.group(1).strip()
+        text = match.group(2).strip()
+        if not key:
+            continue
+        if key not in out or len(text) > len(out[key]):
+            out[key] = text
+    return out
+
+
+def _title_from_citation(text: str) -> str:
+    """Best-effort title from a citation text ``Authors (Year). Title. Venue.``
+
+    Take the clause after the ``(Year).`` marker up to the next sentence period.
+    Falls back to the whole text when no year marker is present. Defensive: never
+    raises, returns "" only for empty input.
+    """
+    text = text.strip()
+    if not text:
+        return ""
+    match = _YEAR_RE.search(text)
+    after = text[match.end() :].strip(" .") if match else text
+    # Title is the first sentence after the year; venues follow another period.
+    title = after.split(". ", 1)[0].strip(" .")
+    return title or after or text
+
+
+def _find_results_index(find_results: dict[str, Any] | None) -> dict[str, Any]:
+    """Build a corpus_id -> PaperRecord map from a LiteratureSearchResult.
+
+    Reuses the battle-tested ``parse_paper_finder`` (same shape) so enrichment
+    metadata (clean title, authors, year, venue, url, abstract) is lifted by a
+    deterministic corpus_id join. Defensive: a missing / malformed doc yields {}.
+    """
+    if not isinstance(find_results, dict):
+        return {}
+    index: dict[str, Any] = {}
+    for record in parse_paper_finder(find_results):
+        if record.corpus_id:
+            index[record.corpus_id] = record
+    return index
+
+
+def parse_scholar_qa(
+    report_markdown: Any, find_results: dict[str, Any] | None = None
+) -> tuple[ReportRecord | None, RunMeta]:
+    """Parse an Asta Literature Report markdown into a ReportRecord + run meta.
+
+    Pairs each ``[[Key]]`` reference entry with its ``[Key]: <url>`` link
+    definition by citation key, lifts the corpus id from the url, and enriches
+    title/authors/year/venue from the optional find-results JSON (corpus_id
+    join, text fallback). Defensive throughout: a non-string, empty, or
+    reference-less report yields ``(None, RunMeta())`` so a partial artifact
+    never aborts ingest.
+    """
+    if not isinstance(report_markdown, str) or not report_markdown.strip():
+        logger.warning(
+            "parse_scholar_qa: report is not a non-empty string, got %s",
+            type(report_markdown).__name__,
+        )
+        return None, RunMeta()
+
+    title = _report_title(report_markdown)
+    link_defs = _link_defs(report_markdown)
+    ref_entries = _ref_entries(report_markdown)
+    enrich = _find_results_index(find_results)
+
+    papers: list[CitedPaper] = []
+    seen: set[str] = set()
+    for key, text in ref_entries.items():
+        corpus_id = link_defs.get(key, "")
+        record = enrich.get(corpus_id) if corpus_id else None
+
+        if record is not None:
+            paper_title = record.title or _title_from_citation(text)
+            authors = record.authors
+            year = record.year
+            custom = dict(record.custom)
+        else:
+            paper_title = _title_from_citation(text)
+            authors = ""
+            year_match = _YEAR_RE.search(text)
+            year = int(year_match.group(1)) if year_match else 0
+            custom = {}
+
+        if not corpus_id and not paper_title:
+            # Nothing to dedupe or name this reference by: skip it.
+            continue
+        # Dedupe within one report: a key cited inline and in References resolves
+        # once; corpus-id-less refs dedupe on title.
+        dedupe_key = corpus_id or f"title:{paper_title.lower()}"
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+        custom["citation_key"] = key
+        papers.append(
+            CitedPaper(
+                corpus_id=corpus_id,
+                title=paper_title,
+                authors=authors,
+                year=year,
+                custom=custom,
+            )
+        )
+
+    query = _as_str((find_results or {}).get("query")) if find_results else ""
+    record = ReportRecord(title=title, query=query, papers=papers)
+    return record, RunMeta()
+
+
+# ---------------------------------------------------------------------------
+# Ingest
+# ---------------------------------------------------------------------------
+
+
+async def ingest_scholar_qa(
+    report_markdown: str,
+    *,
+    report_path: str | None = None,
+    find_results: dict[str, Any] | None = None,
+    link_to: str | None = None,
+    config: WheelerConfig,
+    used_inputs: list[str] | None = None,
+) -> ImportReport:
+    """Ingest an Asta Literature Report into the knowledge graph.
+
+    Args:
+        report_markdown: The report's markdown text (the deliverable).
+        report_path: Optional path to the report file. Registered as the Document
+            (raw node, synthesized writing) WAS_GENERATED_BY the run Execution,
+            and the stable run key so re-ingest is idempotent. The durable
+            raw-store snapshot is first-write-wins: re-ingesting an EDITED report
+            at the same path reuses the one Document node (correct provenance
+            identity) but does NOT re-copy the new bytes into the store, so the
+            snapshot keeps the first-seen version.
+        find_results: Optional underlying ``LiteratureSearchResult`` dict, used to
+            enrich each cited paper's metadata by a corpus_id join (best-effort).
+        link_to: Optional node id (Question/Plan) the report Document AROSE_FROM.
+        config: Active Wheeler config.
+        used_inputs: Optional graph node ids the marshal-in consumed to build the
+            request (the link target plus any seeded source ids). The run
+            Execution -[USED]-> each one that exists (input-side provenance,
+            existence-guarded, link_once, never fabricated).
+
+    Returns:
+        An ImportReport with created / deduped / linked / skipped / used counts.
+        ``artifact`` is the report Document id; ``paper_ids`` the cited papers.
+    """
+    from wheeler.tools.graph_tools import _get_backend, execute_tool
+
+    report = ImportReport()
+    record, run_meta = parse_scholar_qa(report_markdown, find_results)
+    if record is None:
+        logger.warning("ingest_scholar_qa: report not parseable")
+        return report
+
+    backend = await _get_backend(config)
+    paper_index = _load_index()
+
+    # One stable run key from the report's IDENTITY (its path), used for BOTH the
+    # Execution session_id AND the durable raw-store key, so the two dedupe on the
+    # SAME identity. A literature report has no service run_id (Claude synthesizes
+    # it), so without this coupling the Execution would key on the path (stable)
+    # while the Document keyed on a content sha (changes on every edit): re-running
+    # the act at the same path with re-synthesized text would then accrue a SECOND
+    # Document to the same run. Coupling to the path makes one report path = one
+    # run = one Document, even across edits. Falls back to a content hash when no
+    # path is given (a directly-passed string has no stable identity).
+    run_key = run_meta.run_id or (
+        "sqa-" + hashlib.sha256(
+            (report_path or report_markdown[:512]).encode()
+        ).hexdigest()[:16]
+    )
+    session_id = run_key
+    exec_id = await _find_execution(
+        backend, config, service=_SERVICE_TAG, session_id=session_id
+    )
+    if not exec_id:
+        import json
+
+        exec_result = json.loads(
+            await execute_tool(
+                "add_execution",
+                {
+                    "kind": "literature-report",
+                    "description": (
+                        f"Asta Literature Report: {record.title or record.query}"
+                    )[:200],
+                    "agent_id": "asta",
+                    "status": "completed",
+                    "session_id": session_id,
+                    "service": _SERVICE_TAG,
+                },
+                config,
+            )
+        )
+        exec_id = exec_result.get("node_id", "")
+    report.execution_id = exec_id
+
+    # Plan lifecycle: anchor the run Execution to its Plan (Execution -[AROSE_FROM]
+    # -> Plan) when link_to is a PL- id. No-op otherwise; link_once.
+    if exec_id and await _link_execution_to_plan(backend, config, exec_id, link_to):
+        report.plan_linked += 1
+
+    # Input-side provenance: the marshal-in built the request FROM graph nodes, so
+    # the run USED them. Existence-guarded, never fabricated, re-ingest dedupes.
+    if exec_id and used_inputs:
+        report.used += await _record_used(backend, config, exec_id, used_inputs)
+
+    # The report markdown is synthesized WRITING, so it registers as a Document
+    # (W-) node, the run's PRIMARY produced node, WAS_GENERATED_BY the Execution.
+    # Best-effort: returns None on any failure and never raises.
+    doc_id: str | None = None
+    try:
+        from wheeler.integrations.asta.artifacts import register_output_artifact
+
+        doc_id = await register_output_artifact(
+            report_path,
+            execution_id=exec_id,
+            service=_SERVICE_TAG,
+            config=config,
+            node_type=_RAW_NODE_TYPE,
+            # Key the durable store on the SAME run_key as the Execution (above),
+            # not a content sha, so one report path resolves to one Document.
+            run_id=run_key,
+            benchmark=run_meta.custom_bag(),
+            description=(
+                f"Literature report: {record.title or record.query}"
+            )[:200],
+        )
+    except Exception:
+        logger.warning(
+            "ingest_scholar_qa: artifact registration raised (best-effort)",
+            exc_info=True,
+        )
+    if doc_id:
+        report.artifact = doc_id
+        # The report Document AROSE_FROM its link target (the Question/Plan that
+        # prompted it), mirroring a Theorizer theory parent.
+        if link_to and await _link_once(
+            backend, config, doc_id, "AROSE_FROM", link_to
+        ):
+            report.linked += 1
+
+    # corpus_id -> P-id for papers touched this run (a paper cited by two keys is
+    # resolved once).
+    seen_papers: dict[str, str] = {}
+    for paper in record.papers:
+        await _ingest_cited_paper(
+            backend=backend,
+            execute_tool=execute_tool,
+            config=config,
+            paper=paper,
+            doc_id=doc_id,
+            exec_id=exec_id,
+            session_id=session_id,
+            paper_index=paper_index,
+            seen_papers=seen_papers,
+            report=report,
+        )
+
+    _save_index(paper_index)
+    logger.info(
+        "ingest_scholar_qa: created=%d deduped=%d linked=%d skipped=%d "
+        "used=%d plan_linked=%d (exec=%s)",
+        report.created,
+        report.deduped,
+        report.linked,
+        report.skipped,
+        report.used,
+        report.plan_linked,
+        exec_id,
+    )
+    return report
+
+
+async def _ingest_cited_paper(
+    *,
+    backend,
+    execute_tool,
+    config: WheelerConfig,
+    paper: CitedPaper,
+    doc_id: str | None,
+    exec_id: str,
+    session_id: str,
+    paper_index: dict[str, str],
+    seen_papers: dict[str, str],
+    report: ImportReport,
+) -> None:
+    """Dedupe-or-create one cited paper, then wire its edges.
+
+    The report Document -[CITES]-> the paper (bibliographic edge), and the run
+    Execution -[USED]-> the paper: the review was DERIVED from the paper, so it is
+    a genuine INPUT (mirroring Theorizer evidence). Papers are reference entities
+    (NO WAS_GENERATED_BY; NOT WAS_DERIVED_FROM the report, since a cited paper
+    predates the review). Both edges link_once-guarded.
+    """
+    paper_id = await _resolve_paper(
+        backend=backend,
+        execute_tool=execute_tool,
+        config=config,
+        paper=paper,
+        session_id=session_id,
+        paper_index=paper_index,
+        seen_papers=seen_papers,
+        report=report,
+    )
+    if paper_id is None:
+        return
+    # The report Document CITES the paper (bibliographic edge).
+    if doc_id and await _link_once(backend, config, doc_id, "CITES", paper_id):
+        report.linked += 1
+    # Execution -[USED]-> the cited paper: the report was derived from it.
+    if exec_id and await _link_once(backend, config, exec_id, "USED", paper_id):
+        report.linked += 1
+
+
+async def _resolve_paper(
+    *,
+    backend,
+    execute_tool,
+    config: WheelerConfig,
+    paper: CitedPaper,
+    session_id: str,
+    paper_index: dict[str, str],
+    seen_papers: dict[str, str],
+    report: ImportReport,
+) -> str | None:
+    """Return a Paper node id for ``paper``, deduping by corpus_id where possible."""
+    cid = paper.corpus_id
+    # 1. Already created this run.
+    if cid and cid in seen_papers:
+        return seen_papers[cid]
+    # 2. Persisted cross-tool corpus_id index. Only trust the hit if the node
+    # still lives in the graph; a stale id would make link_once target a missing
+    # node and silently drop the CITES edge. Drop the dead entry and fall through.
+    existing = paper_index.get(cid) if cid else None
+    if existing and not await _paper_exists(backend, config, existing):
+        existing = None
+        if cid:
+            paper_index.pop(cid, None)
+    # 3. Project-aware graph read.
+    if not existing and cid:
+        existing = await _find_paper_by_corpus_id(backend, config, cid)
+    if existing:
+        report.deduped += 1
+        if existing not in report.paper_ids:
+            report.paper_ids.append(existing)
+        if cid:
+            paper_index[cid] = existing
+            seen_papers[cid] = existing
+        return existing
+
+    # 4. Create. A paper with no corpus_id and no title was dropped at parse time,
+    # so title is guaranteed here when corpus_id is absent.
+    import json
+
+    add_args: dict[str, Any] = {
+        "title": paper.title or f"Paper {cid}",
+        "corpus_id": cid,
+        "authors": paper.authors,
+        "year": paper.year,
+        "custom": paper.custom,
+        "session_id": session_id,
+        "service": _SERVICE_TAG,
+    }
+    result = json.loads(await execute_tool("add_paper", add_args, config))
+    paper_id = result.get("node_id")
+    if not paper_id or "error" in result:
+        logger.warning("ingest_scholar_qa: add_paper failed for corpus_id=%s", cid)
+        report.skipped += 1
+        return None
+    report.created += 1
+    report.paper_ids.append(paper_id)
+    if cid:
+        paper_index[cid] = paper_id
+        seen_papers[cid] = paper_id
+    # Papers are REFERENCE ENTITIES (per /wh:close, /wh:graph-link): no
+    # WAS_GENERATED_BY. The semantic edges (CITES from the doc, USED by the run)
+    # are added by the caller.
+    return paper_id

--- a/wheeler/integrations/services.default.yaml
+++ b/wheeler/integrations/services.default.yaml
@@ -56,6 +56,22 @@ services:
     available: "asta auth status"
     when: "a specific paper, its citations, or snippet evidence (look up Z, what cites Y)"
 
+  - id: scholar-qa
+    provider: asta
+    name: Asta Literature Reports
+    description: long-form literature review report synthesizing many papers into a written document with citations
+    kind: shell-out
+    act: /wh:asta-report
+    cost: "cheap (literature find + papers lookups)"
+    available: "asta auth status"
+    when: "a written literature review or comprehensive multi-paper report (write a review of X, synthesize the literature on Y)"
+    inputs:
+      - { name: query, source: query, required: true }
+    output:
+      raw_node: document
+      nodes: [Document, Paper]
+    # implemented by wheeler/integrations/asta/scholar_qa.py
+
   - id: graph-status
     provider: local
     name: Graph Status


### PR DESCRIPTION
## What

The fourth Asta adapter, and the first **markdown-deliverable** service. ScholarQA's `literature-report` is not a single A2A JSON artifact: the `literature-report` skill orchestrates `asta literature find` + `asta papers` and Claude synthesizes a written review at `.asta/literature/report/<topic>.md`. This adapter marshals that markdown into the graph.

Built by running the `wheeler-service-creator` scaffolder (**its first real test**), then adapting the JSON-shaped skeleton to the markdown reality. The divergences found are themselves the skill-creator feedback (see below).

## The three-part provenance model, end to end

1. **Structural input**: `Execution -[USED]->` the marshalled-in question/plan AND each cited paper (the review was derived from it).
2. **Structural output**: the report markdown registers as a **Document (`W-`)** node `WAS_GENERATED_BY` the run Execution. Papers are reference entities (no `WAS_GENERATED_BY`, and not `WAS_DERIVED_FROM` the report since a cited paper predates the review); the Document `-[CITES]->` each paper.
3. **Semantic wiring** lives in the `/wh:asta-report` act (post-ingest, `link_nodes`).

Parser keys on the skill's citation convention: `[[Key]]` reference entries paired with `[Key]: <url>` link defs, lifting the corpus_id from the `/p/<id>` or `CorpusId:<id>` url, enriching title/authors/year/venue from the optional `LiteratureSearchResult` JSON by a corpus_id join (reuses `parse_paper_finder`; text fallback when absent).

**Idempotency**: the Execution `session_id` AND the durable raw-store key are the same path-derived `run_key`, so one report path = one run = one Document, even when re-synthesized with edited text.

## Skill-creator feedback (divergences from the scaffold)

- The scaffolder assumes one JSON `-o` artifact; a report-style service is markdown, so `cli.py` reads it as text and the registry entry / module needed a Document-CITES-papers shape rather than the generic record loop.
- The scaffolder writes the registry entry to `.wheeler/services.yaml` (which would shadow the bundled catalog); a shipped service belongs in `services.default.yaml`.
- The mechanical act name `/wh:asta-scholar-qa` collides confusingly with `/wh:asta-scholar` (semantic-scholar); renamed to `/wh:asta-report`.

## Tests

- 12 parse-unit (real dopamine-paper fixture, all three corpus_id URL shapes, enrichment + text fallback, dedupe, defensive).
- 5 CLI-glue (markdown-not-json, `--find-results`, aliases).
- 1 live-Neo4j e2e: uses **run-unique synthetic corpus_ids** so it can never dedupe-into and then delete a production Paper, asserts the full provenance topology, and re-ingests an *edited* report to prove one-path-one-Document.

Adversarially reviewed across three lenses (provenance, data-safety with a live test re-run, conventions). The one blocker found (Execution/Document dedupe-key asymmetry) was fixed and re-confirmed PASS. `ruff` + `mypy` clean, **1894 passed, 2 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)