### PR TITLE
feat(asta): external-call failsafe (honest Execution status, no fabricated outputs)

### DIFF
--- a/.claude/commands/wh/asta-lit.md
+++ b/.claude/commands/wh/asta-lit.md
@@ -34,7 +34,13 @@ Run the CLI, writing the artifact to a temp file:
 asta literature find "$QUERY" -o /tmp/asta-paper-finder.json
 ```
 
-If the command exits non-zero, report the failure and stop. A failed run writes nothing to the graph by design.
+If the command exits non-zero, FIRST record the failed attempt so it is not silently lost (the failsafe: the external job is an Execution, and a failed one must be visible, not absent):
+
+```
+wheeler integrate record-failure paper_finder --reason "<short stderr>" --link-to <Q- or PL- id> --used <Q- or PL- id>
+```
+
+This writes a failed Execution (status "failed", the reason in custom_error) wired to its inputs (USED) and Plan (AROSE_FROM). Then report the failure and stop. A failed run fabricates NO Paper nodes by design.
 
 ## Ingest
 

--- a/.claude/commands/wh/asta-report.md
+++ b/.claude/commands/wh/asta-report.md
@@ -42,7 +42,13 @@ Run the paper finder, writing its results to a temp file (this JSON also enriche
 asta literature find "$TOPIC" -o /tmp/find.json
 ```
 
-Supplement with targeted `asta papers search` / `asta papers get` / `asta papers citations` calls as needed. If `asta literature find` exits non-zero (including a login or auth failure), report it and stop.
+Supplement with targeted `asta papers search` / `asta papers get` / `asta papers citations` calls as needed. If `asta literature find` exits non-zero (including a login or auth failure), FIRST record the failed attempt so it is not silently lost (the failsafe: the external job is an Execution, and a failed one must be visible, not absent):
+
+```
+wheeler integrate record-failure scholar-qa --reason "<short stderr>" --link-to <Q- or PL- id> --used <Q- or PL- id>
+```
+
+This writes a failed Execution (status "failed", the reason in custom_error) wired to its inputs (USED) and Plan (AROSE_FROM). Then report it and stop. A failed search fabricates NO report or papers by design.
 
 (If the asta-plugins `literature-report` skill is installed, you may invoke it to do the search-and-synthesize loop; otherwise do the steps here directly.)
 

--- a/.claude/commands/wh/asta-scholar.md
+++ b/.claude/commands/wh/asta-scholar.md
@@ -66,7 +66,13 @@ asta papers snippet "<query>" --fields corpusId,title,authors --limit <N> > /tmp
 wheeler integrate ingest semantic_scholar /tmp/asta-s2.json --link-to <Q- or PL- id> --used <Q- or PL- id>
 ```
 
-If any CLI command exits non-zero, report the failure and stop. A failed run writes nothing to the graph by design. The short alias `s2` works in place of `semantic_scholar`.
+If any CLI command exits non-zero, FIRST record the failed attempt so it is not silently lost (the failsafe: the external job is an Execution, and a failed one must be visible, not absent):
+
+```
+wheeler integrate record-failure semantic_scholar --reason "<short stderr>" --link-to <Q- or PL- id> --used <Q- or PL- id>
+```
+
+This writes a failed Execution (status "failed", the reason in custom_error) wired to its inputs (USED) and Plan (AROSE_FROM). Then report the failure and stop. A failed run fabricates NO nodes by design. The short alias `s2` works in place of `semantic_scholar`.
 
 ## Wire semantics to the existing graph
 

--- a/.claude/commands/wh/asta-theorize.md
+++ b/.claude/commands/wh/asta-theorize.md
@@ -35,7 +35,15 @@ Run the CLI, writing the artifact to a temp file. This requires an Asta login:
 asta generate-theories literature-theory-generation "$QUESTION" -o /tmp/asta-theorizer.json
 ```
 
-If the command exits non-zero (including a login or auth failure), report it and stop. A failed run writes nothing to the graph by design.
+If the command exits non-zero (including a login or auth failure), FIRST record the failed attempt so the expensive run is not silently lost (the failsafe: the external job is an Execution, and a failed one must be visible, not absent):
+
+```
+wheeler integrate record-failure theorizer --reason "<short stderr>" --link-to <Q- or PL- id> --used <Q- or PL- id>,<seeded Finding ids>
+```
+
+This writes a failed Execution (status "failed", the reason in custom_error) wired to its inputs (USED) and Plan (AROSE_FROM). Then report it and stop. A failed run fabricates NO theories or hypotheses by design.
+
+The ingest applies the same gate even when an artifact IS returned: a Theorizer Task whose `status.state` is not "completed" is marshalled as a failed Execution with no fabricated theories, so a partial or failed remote job never masquerades as a clean one.
 
 ## Ingest
 

--- a/tests/integrations/asta/test_failsafe.py
+++ b/tests/integrations/asta/test_failsafe.py
@@ -1,0 +1,426 @@
+"""Tests for the external-call failsafe (job lifecycle + honest Execution status).
+
+Every external-service call is an Execution that must TRUTHFULLY record whether
+the job actually completed. A failed / canceled / incomplete job must not have
+its (partial or empty) output ingested as if real: the ingest records a FAILED
+Execution so the attempt is visible, but fabricates NO Findings / Hypotheses /
+Papers. Two layers:
+  1. job_outcome: pure unit cases (A2A Task states, non-Task dicts, garbage).
+  2. live-Neo4j e2e: a FAILED Theorizer Task whose artifacts WOULD parse to a
+     theory still ingests zero theory nodes, leaving only a failed Execution.
+
+Run: python -m pytest tests/integrations/asta/test_failsafe.py -q
+The e2e class is skipped automatically when Neo4j is not reachable.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+
+from wheeler.integrations.asta._marshal import job_outcome
+
+# A minimal theory artifact that parse_theorizer DOES turn into one theory with
+# one law. Wrapping it in a failed-status Task lets the e2e prove the failsafe
+# GATE (not an empty parse) is what suppresses the output.
+_THEORY_ARTIFACT = {
+    "artifactId": "theory-1",
+    "metadata": {"type": "theory"},
+    "parts": [
+        {
+            "kind": "data",
+            "data": {
+                "id": "theory-1",
+                "name": "Failsafe Test Theory",
+                "description": "A theory that must NOT be ingested from a failed run.",
+                "entities": {},
+                "annotations": {},
+                "content": [
+                    {
+                        "id": "c1",
+                        "type": "SECTIONS",
+                        "title": "Theory Statements",
+                        "childIds": ["c2"],
+                    },
+                    {
+                        "id": "c2",
+                        "type": "SECTION",
+                        "title": "The law that should never be stored",
+                        "childIds": ["c3"],
+                    },
+                    {"id": "c3", "type": "MARKDOWN", "text": "Body of the law."},
+                ],
+            },
+        }
+    ],
+}
+
+
+def _failed_task() -> dict:
+    return {
+        "kind": "task",
+        "id": "task-failed-1",
+        "status": {
+            "state": "failed",
+            "message": {"parts": [{"text": "the upstream model timed out"}]},
+        },
+        "metadata": {"run_id": "gen-failsafe-failed-01"},
+        "artifacts": [_THEORY_ARTIFACT],
+    }
+
+
+def _completed_task() -> dict:
+    doc = _failed_task()
+    doc["status"]["state"] = "completed"
+    doc["metadata"]["run_id"] = "gen-failsafe-ok-01"
+    return doc
+
+
+# ---------------------------------------------------------------------------
+# 1. job_outcome (pure)
+# ---------------------------------------------------------------------------
+
+
+class TestJobOutcome:
+    def test_completed_a2a_task_is_ok(self):
+        out = job_outcome(_completed_task())
+        assert out.ok is True
+        assert out.state == "completed"
+
+    @pytest.mark.parametrize("state", ["failed", "canceled", "rejected", "working", "input-required"])
+    def test_non_completed_a2a_state_is_not_ok(self, state):
+        doc = _failed_task()
+        doc["status"]["state"] = state
+        out = job_outcome(doc)
+        assert out.ok is False
+        assert out.state == state
+        assert out.detail  # a human reason is surfaced
+
+    def test_failed_task_surfaces_status_message(self):
+        out = job_outcome(_failed_task())
+        assert out.ok is False
+        assert "timed out" in out.detail
+
+    def test_none_is_missing(self):
+        out = job_outcome(None)
+        assert out.ok is False
+        assert out.state == "missing"
+
+    def test_non_dict_is_invalid(self):
+        out = job_outcome("not a dict")
+        assert out.ok is False
+        assert out.state == "invalid"
+
+    def test_plain_result_dict_is_ok(self):
+        # A LiteratureSearchResult / S2 response / report envelope has no A2A
+        # status block: a present dict is a usable artifact (the transport already
+        # rejected the empty / missing cases).
+        out = job_outcome({"query": "x", "results": []})
+        assert out.ok is True
+        assert out.state == "completed"
+
+    def test_uppercase_state_normalized(self):
+        doc = _failed_task()
+        doc["status"]["state"] = "COMPLETED"
+        assert job_outcome(doc).ok is True
+
+
+# ---------------------------------------------------------------------------
+# 2. Live-Neo4j e2e: a FAILED job ingests no outputs, only a failed Execution
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def e2e_config():
+    from wheeler.config import Neo4jConfig, ProjectMeta, WheelerConfig
+
+    return WheelerConfig(
+        neo4j=Neo4jConfig(
+            uri="bolt://localhost:7687",
+            username="neo4j",
+            password="research-graph",
+            database="neo4j",
+        ),
+        project=ProjectMeta(name="Integrations-E2E-Test"),
+    )
+
+
+@pytest.fixture(scope="module")
+def neo4j_available(e2e_config) -> bool:
+    import asyncio
+
+    from neo4j import AsyncGraphDatabase, NotificationMinimumSeverity
+
+    async def _check():
+        driver = AsyncGraphDatabase.driver(
+            e2e_config.neo4j.uri,
+            auth=(e2e_config.neo4j.username, e2e_config.neo4j.password),
+            notifications_min_severity=NotificationMinimumSeverity.OFF,
+        )
+        try:
+            async with driver.session(database=e2e_config.neo4j.database) as s:
+                await s.run("RETURN 1")
+            return True
+        except Exception:
+            return False
+        finally:
+            await driver.close()
+
+    return asyncio.run(_check())
+
+
+@pytest.fixture(autouse=True)
+def _reset_driver_singleton():
+    import wheeler.graph.driver as drv
+
+    drv._async_driver = None
+    drv._async_driver_uri = None
+    yield
+    drv._async_driver = None
+    drv._async_driver_uri = None
+
+
+def _cleanup(e2e_config, e2e_tag: str) -> None:
+    """Hermetic teardown: delete ONLY the nodes THIS run tagged (per-run uuid),
+    never by service or corpus_id (the e2e config is the shared namespace)."""
+    import asyncio
+
+    from neo4j import AsyncGraphDatabase, NotificationMinimumSeverity
+
+    async def _run():
+        driver = AsyncGraphDatabase.driver(
+            e2e_config.neo4j.uri,
+            auth=(e2e_config.neo4j.username, e2e_config.neo4j.password),
+            notifications_min_severity=NotificationMinimumSeverity.OFF,
+        )
+        try:
+            async with driver.session(database=e2e_config.neo4j.database) as s:
+                await s.run(
+                    "MATCH (n) WHERE n.e2e_tag = $tag DETACH DELETE n", tag=e2e_tag
+                )
+        finally:
+            await driver.close()
+
+    asyncio.run(_run())
+
+
+class TestFailsafeE2E:
+    @pytest.fixture(autouse=True)
+    def _skip_and_cleanup(self, neo4j_available, e2e_config, tmp_path, monkeypatch):
+        if not neo4j_available:
+            pytest.skip("Neo4j not available -- skipping integrations e2e")
+        monkeypatch.chdir(tmp_path)
+        self._tmp = tmp_path
+        self._e2e_tag = f"integrations_e2e_{uuid.uuid4().hex}"
+        _cleanup(e2e_config, self._e2e_tag)
+        yield
+        _cleanup(e2e_config, self._e2e_tag)
+
+    @pytest.mark.asyncio
+    async def test_failed_theorizer_job_ingests_no_outputs(self, e2e_config):
+        from wheeler.graph.driver import get_async_driver
+        from wheeler.integrations.asta.theorizer import (
+            ingest_theorizer,
+            parse_theorizer,
+        )
+
+        doc = _failed_task()
+        # Sanity: the artifacts WOULD parse to a theory if the run had completed,
+        # so a zero-output ingest proves the GATE suppressed it, not an empty parse.
+        theories, _ = parse_theorizer(doc)
+        assert len(theories) == 1
+
+        artifact_path = self._tmp / "failed_theorizer.json"
+        artifact_path.write_text(json.dumps(doc))
+
+        report = await ingest_theorizer(
+            doc, link_to=None, config=e2e_config, artifact_path=str(artifact_path)
+        )
+        # Tag this run's nodes (Execution + artifact) for hermetic teardown.
+        driver = get_async_driver(e2e_config)
+        db = e2e_config.neo4j.database
+        run_ids = [i for i in (report.execution_id, report.artifact) if i]
+        async with driver.session(database=db) as s:
+            if run_ids:
+                await s.run(
+                    "MATCH (n) WHERE n.id IN $ids SET n.e2e_tag = $tag",
+                    ids=run_ids,
+                    tag=self._e2e_tag,
+                )
+
+        # The run is reported failed, with the job's own state.
+        assert report.failed is True
+        assert report.job_state == "failed"
+        assert report.created == 0  # NO theories / hypotheses / papers fabricated
+        assert report.execution_id  # but the attempt IS recorded
+
+        async with driver.session(database=db) as s:
+            # The Execution exists and is honestly marked failed, carrying the
+            # job's state + reason in its queryable custom bag.
+            res = await s.run(
+                "MATCH (x:Execution {id: $xid}) "
+                "RETURN x.status AS status, x.custom_job_state AS job_state, "
+                "x.custom_error AS err",
+                xid=report.execution_id,
+            )
+            rec = await res.single()
+            assert rec["status"] == "failed"
+            assert rec["job_state"] == "failed"
+            assert rec["err"]  # the status message was stamped
+            # ZERO theory Findings / Hypotheses were generated by this run.
+            res = await s.run(
+                "MATCH (n)-[:WAS_GENERATED_BY]->(x:Execution {id: $xid}) "
+                "WHERE n:Finding OR n:Hypothesis RETURN count(n) AS c",
+                xid=report.execution_id,
+            )
+            assert (await res.single())["c"] == 0
+
+    @pytest.mark.asyncio
+    async def test_failed_then_successful_retry_flips_status_to_completed(
+        self, e2e_config
+    ):
+        """A successful retry that REUSES a prior failed Execution (same
+        service+session_id) must flip status back to completed, not inherit the
+        stale "failed" (regression: status was only set at creation time)."""
+        from wheeler.graph.driver import get_async_driver
+        from wheeler.integrations.asta.theorizer import ingest_theorizer
+
+        driver = get_async_driver(e2e_config)
+        db = e2e_config.neo4j.database
+
+        async def _tag(report):
+            ids = [i for i in (report.execution_id, report.artifact) if i]
+            async with driver.session(database=db) as s:
+                if ids:
+                    await s.run(
+                        "MATCH (n) WHERE n.id IN $ids SET n.e2e_tag = $tag",
+                        ids=ids,
+                        tag=self._e2e_tag,
+                    )
+                if report.execution_id:
+                    await s.run(
+                        "MATCH (n)-[:WAS_GENERATED_BY]->(x:Execution {id: $xid}) "
+                        "SET n.e2e_tag = $tag",
+                        xid=report.execution_id,
+                        tag=self._e2e_tag,
+                    )
+
+        # Same run_id on both -> same session_id -> the SAME Execution is reused.
+        failed = _failed_task()
+        completed = json.loads(json.dumps(failed))  # deep copy
+        completed["status"]["state"] = "completed"  # same run_id, now successful
+
+        artifact_path = self._tmp / "retry.json"
+
+        # 1. Failed run: failed Execution, zero outputs.
+        artifact_path.write_text(json.dumps(failed))
+        r1 = await ingest_theorizer(
+            failed, link_to=None, config=e2e_config, artifact_path=str(artifact_path)
+        )
+        await _tag(r1)
+        assert r1.failed is True
+        assert r1.created == 0
+
+        # 2. Successful retry with the same run_id: reuses the Execution, flips it
+        # to completed, and now ingests the theory.
+        artifact_path.write_text(json.dumps(completed))
+        r2 = await ingest_theorizer(
+            completed,
+            link_to=None,
+            config=e2e_config,
+            artifact_path=str(artifact_path),
+        )
+        await _tag(r2)
+        assert r2.execution_id == r1.execution_id  # same Execution reused
+        assert r2.failed is False
+        assert r2.created >= 1  # the theory IS now ingested
+
+        async with driver.session(database=db) as s:
+            res = await s.run(
+                "MATCH (x:Execution {id: $xid}) "
+                "RETURN x.status AS status, x.custom_job_state AS job_state",
+                xid=r2.execution_id,
+            )
+            rec = await res.single()
+            # The graph no longer lies that the (now successful) run failed.
+            assert rec["status"] == "completed"
+            assert rec["job_state"] != "failed"
+
+    @pytest.mark.asyncio
+    async def test_record_failed_execution_when_no_artifact(self, e2e_config):
+        """The visibility half: a never-returned-artifact attempt (the CLI failed)
+        still leaves a queryable failed Execution wired to its inputs."""
+        from wheeler.graph.driver import get_async_driver
+        from wheeler.integrations.asta._marshal import record_failed_execution
+        from wheeler.tools.graph_tools import _get_backend, execute_tool
+
+        driver = get_async_driver(e2e_config)
+        db = e2e_config.neo4j.database
+
+        # Seed a Question the failed run was supposed to address (its USED input).
+        q = json.loads(
+            await execute_tool(
+                "add_question",
+                {"question": "E2E: failed-run input question", "priority": 5},
+                e2e_config,
+            )
+        )
+        qid = q["node_id"]
+        async with driver.session(database=db) as s:
+            await s.run(
+                "MATCH (n {id: $id}) SET n.e2e_tag = $tag", id=qid, tag=self._e2e_tag
+            )
+
+        backend = await _get_backend(e2e_config)
+        sid = f"failsafe-rec-{uuid.uuid4().hex[:10]}"
+        report = await record_failed_execution(
+            backend,
+            e2e_config,
+            service="asta:theorizer",
+            session_id=sid,
+            kind="theory-generation",
+            description="Asta Theorizer FAILED: auth expired",
+            reason="auth expired (exit 1)",
+            used_inputs=[qid],
+        )
+        async with driver.session(database=db) as s:
+            await s.run(
+                "MATCH (n {id: $id}) SET n.e2e_tag = $tag",
+                id=report.execution_id,
+                tag=self._e2e_tag,
+            )
+
+        assert report.failed is True
+        assert report.execution_id.startswith("X-")
+        assert report.used == 1  # the USED edge to the seeded question
+        async with driver.session(database=db) as s:
+            res = await s.run(
+                "MATCH (x:Execution {id: $xid}) "
+                "RETURN x.status AS status, x.custom_error AS err",
+                xid=report.execution_id,
+            )
+            rec = await res.single()
+            assert rec["status"] == "failed"
+            assert "auth expired" in (rec["err"] or "")
+            res = await s.run(
+                "MATCH (x:Execution {id: $xid})-[:USED]->(q {id: $qid}) "
+                "RETURN count(q) AS c",
+                xid=report.execution_id,
+                qid=qid,
+            )
+            assert (await res.single())["c"] == 1
+
+        # Idempotent: a "retry" with the same (service, session_id) reuses it.
+        report2 = await record_failed_execution(
+            backend,
+            e2e_config,
+            service="asta:theorizer",
+            session_id=sid,
+            kind="theory-generation",
+            description="retry",
+            reason="auth expired again",
+            used_inputs=[qid],
+        )
+        assert report2.execution_id == report.execution_id

--- a/tests/integrations/asta/test_scholar_qa.py
+++ b/tests/integrations/asta/test_scholar_qa.py
@@ -210,6 +210,8 @@ class TestScholarQaCliVerb:
             execution_id = "X-stub"
             artifact = "W-stub"
             paper_ids = ["P-stub"]
+            failed = False
+            job_state = ""
 
         monkeypatch.setattr(cli_mod, "load_config", lambda: object(), raising=False)
         monkeypatch.setattr(
@@ -225,7 +227,7 @@ class TestScholarQaCliVerb:
         report = tmp_path / "report.md"
         report.write_text("# Not JSON\n\n[[A]] x\n\n[A]: https://semanticscholar.org/p/1\n")
         result, captured = self._run(
-            ["scholar-qa", str(report), "--link-to", "Q-1"], monkeypatch
+            ["ingest", "scholar-qa", str(report), "--link-to", "Q-1"], monkeypatch
         )
         assert result.exit_code == 0, result.output
         # The raw markdown reached the ingest verbatim (not parsed as JSON).
@@ -233,7 +235,7 @@ class TestScholarQaCliVerb:
         assert captured["report_path"] == str(report)
         assert captured["link_to"] == "Q-1"
         assert captured["find_results"] is None
-        assert "report: W-stub" in result.output
+        assert "artifact: W-stub" in result.output
 
     def test_find_results_parsed_and_forwarded(self, tmp_path, monkeypatch):
         report = tmp_path / "report.md"
@@ -241,7 +243,7 @@ class TestScholarQaCliVerb:
         find = tmp_path / "find.json"
         find.write_text(json.dumps({"query": "q", "results": []}))
         result, captured = self._run(
-            ["scholar-qa", str(report), "--find-results", str(find)],
+            ["ingest", "scholar-qa", str(report), "--find-results", str(find)],
             monkeypatch,
         )
         assert result.exit_code == 0, result.output
@@ -251,7 +253,7 @@ class TestScholarQaCliVerb:
         report = tmp_path / "report.md"
         report.write_text("# R\n")
         result, captured = self._run(
-            ["scholar-qa", str(report), "--used", "Q-1, , F-2"],
+            ["ingest", "scholar-qa", str(report), "--used", "Q-1, , F-2"],
             monkeypatch,
         )
         assert result.exit_code == 0, result.output
@@ -261,7 +263,7 @@ class TestScholarQaCliVerb:
         report = tmp_path / "report.md"
         report.write_text("# R\n")
         result, _ = self._run(
-            ["literature-report", str(report)], monkeypatch
+            ["ingest", "literature-report", str(report)], monkeypatch
         )
         assert result.exit_code == 0, result.output
 
@@ -277,7 +279,7 @@ class TestScholarQaCliVerb:
         )
         result = CliRunner().invoke(
             cli_mod.integrate_app,
-            ["scholar-qa", str(report), "--find-results", str(tmp_path / "nope.json")],
+            ["ingest", "scholar-qa", str(report), "--find-results", str(tmp_path / "nope.json")],
         )
         assert result.exit_code == 2
         assert "not found" in result.output

--- a/wheeler/_data/commands/asta-lit.md
+++ b/wheeler/_data/commands/asta-lit.md
@@ -34,7 +34,13 @@ Run the CLI, writing the artifact to a temp file:
 asta literature find "$QUERY" -o /tmp/asta-paper-finder.json
 ```
 
-If the command exits non-zero, report the failure and stop. A failed run writes nothing to the graph by design.
+If the command exits non-zero, FIRST record the failed attempt so it is not silently lost (the failsafe: the external job is an Execution, and a failed one must be visible, not absent):
+
+```
+wheeler integrate record-failure paper_finder --reason "<short stderr>" --link-to <Q- or PL- id> --used <Q- or PL- id>
+```
+
+This writes a failed Execution (status "failed", the reason in custom_error) wired to its inputs (USED) and Plan (AROSE_FROM). Then report the failure and stop. A failed run fabricates NO Paper nodes by design.
 
 ## Ingest
 

--- a/wheeler/_data/commands/asta-report.md
+++ b/wheeler/_data/commands/asta-report.md
@@ -42,7 +42,13 @@ Run the paper finder, writing its results to a temp file (this JSON also enriche
 asta literature find "$TOPIC" -o /tmp/find.json
 ```
 
-Supplement with targeted `asta papers search` / `asta papers get` / `asta papers citations` calls as needed. If `asta literature find` exits non-zero (including a login or auth failure), report it and stop.
+Supplement with targeted `asta papers search` / `asta papers get` / `asta papers citations` calls as needed. If `asta literature find` exits non-zero (including a login or auth failure), FIRST record the failed attempt so it is not silently lost (the failsafe: the external job is an Execution, and a failed one must be visible, not absent):
+
+```
+wheeler integrate record-failure scholar-qa --reason "<short stderr>" --link-to <Q- or PL- id> --used <Q- or PL- id>
+```
+
+This writes a failed Execution (status "failed", the reason in custom_error) wired to its inputs (USED) and Plan (AROSE_FROM). Then report it and stop. A failed search fabricates NO report or papers by design.
 
 (If the asta-plugins `literature-report` skill is installed, you may invoke it to do the search-and-synthesize loop; otherwise do the steps here directly.)
 

--- a/wheeler/_data/commands/asta-scholar.md
+++ b/wheeler/_data/commands/asta-scholar.md
@@ -66,7 +66,13 @@ asta papers snippet "<query>" --fields corpusId,title,authors --limit <N> > /tmp
 wheeler integrate ingest semantic_scholar /tmp/asta-s2.json --link-to <Q- or PL- id> --used <Q- or PL- id>
 ```
 
-If any CLI command exits non-zero, report the failure and stop. A failed run writes nothing to the graph by design. The short alias `s2` works in place of `semantic_scholar`.
+If any CLI command exits non-zero, FIRST record the failed attempt so it is not silently lost (the failsafe: the external job is an Execution, and a failed one must be visible, not absent):
+
+```
+wheeler integrate record-failure semantic_scholar --reason "<short stderr>" --link-to <Q- or PL- id> --used <Q- or PL- id>
+```
+
+This writes a failed Execution (status "failed", the reason in custom_error) wired to its inputs (USED) and Plan (AROSE_FROM). Then report the failure and stop. A failed run fabricates NO nodes by design. The short alias `s2` works in place of `semantic_scholar`.
 
 ## Wire semantics to the existing graph
 

--- a/wheeler/_data/commands/asta-theorize.md
+++ b/wheeler/_data/commands/asta-theorize.md
@@ -35,7 +35,15 @@ Run the CLI, writing the artifact to a temp file. This requires an Asta login:
 asta generate-theories literature-theory-generation "$QUESTION" -o /tmp/asta-theorizer.json
 ```
 
-If the command exits non-zero (including a login or auth failure), report it and stop. A failed run writes nothing to the graph by design.
+If the command exits non-zero (including a login or auth failure), FIRST record the failed attempt so the expensive run is not silently lost (the failsafe: the external job is an Execution, and a failed one must be visible, not absent):
+
+```
+wheeler integrate record-failure theorizer --reason "<short stderr>" --link-to <Q- or PL- id> --used <Q- or PL- id>,<seeded Finding ids>
+```
+
+This writes a failed Execution (status "failed", the reason in custom_error) wired to its inputs (USED) and Plan (AROSE_FROM). Then report it and stop. A failed run fabricates NO theories or hypotheses by design.
+
+The ingest applies the same gate even when an artifact IS returned: a Theorizer Task whose `status.state` is not "completed" is marshalled as a failed Execution with no fabricated theories, so a partial or failed remote job never masquerades as a clean one.
 
 ## Ingest
 

--- a/wheeler/integrations/asta/CLAUDE.md
+++ b/wheeler/integrations/asta/CLAUDE.md
@@ -200,6 +200,28 @@ side plus the subprocess boundary. No workflow engine, daemon, or router.
   (`to_dict` + the printed summary).
 - **Failure isolation.** A failed or canceled CLI run writes nothing. Retries,
   auth, and timeouts stay inside the asta CLI.
+- **External-call failsafe (honest Execution status, no fabricated outputs).**
+  Every external-service call is one Execution that must TRUTHFULLY record whether
+  the job ran. `job_outcome(doc)` in `_marshal.py` is the gate: it trusts an A2A
+  Task's own `status.state` (only "completed" is success; failed / canceled /
+  rejected / working / input-required are NOT), and treats any non-Task result
+  dict (LiteratureSearchResult, S2 response, report) as ok (the transport already
+  rejected the missing / empty / unparseable cases). Each ingest creates the run
+  Execution with `status="completed"` ONLY when `job_outcome().ok`, else `"failed"`,
+  and on a failed job it stamps the job state + reason into the queryable custom
+  bag (`custom_job_state` / `custom_error` via `mark_execution_failed`), registers
+  the raw artifact for debugging, records USED inputs, and RETURNS EARLY: a failed
+  or partial remote job NEVER has fabricated Findings / Hypotheses / Papers, so it
+  cannot masquerade as a clean run (`ImportReport.failed` / `job_state` surface it;
+  the CLI prints a FAILED line). The output-bucketing loop is wrapped so a
+  partial-ingest exception marks the Execution failed too. There is NO destructive
+  rollback (provenance must stay reachable, per /wh:close); nodes already written
+  stay, and `graph_consistency_check` reconciles any triple-write drift. When the
+  CLI produces NO artifact at all (non-zero exit, the transport returns None and
+  the ingest is never reached), the marshal-in act calls
+  `wheeler integrate record-failure <tool> --reason ... --link-to ... --used ...`
+  (-> `record_failed_execution`) so the attempt is still a visible, queryable
+  failed Execution wired to its inputs, rather than leaving no trace.
 
 ## Conventions
 

--- a/wheeler/integrations/asta/_marshal.py
+++ b/wheeler/integrations/asta/_marshal.py
@@ -44,7 +44,15 @@ _INDEX_REL_PATH = ".wheeler/integrations/paper_finder_index.json"
 
 @dataclass
 class ImportReport:
-    """Outcome of one ingest run."""
+    """Outcome of one ingest run.
+
+    ``failed`` / ``job_state`` carry the external-job lifecycle outcome: an
+    ingest only fabricates output nodes when the job VERIFIABLY succeeded. A
+    failed or incomplete job still leaves a (failed) Execution so the attempt is
+    visible (``failed=True``, ``job_state`` = the job's own state), but no
+    fabricated Findings/Hypotheses/Papers, so a failed run never masquerades as a
+    clean completed one.
+    """
 
     created: int = 0
     deduped: int = 0
@@ -55,6 +63,8 @@ class ImportReport:
     execution_id: str = ""
     artifact: str = ""
     paper_ids: list[str] = field(default_factory=list)
+    failed: bool = False
+    job_state: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -67,6 +77,8 @@ class ImportReport:
             "execution_id": self.execution_id,
             "artifact": self.artifact,
             "paper_ids": list(self.paper_ids),
+            "failed": self.failed,
+            "job_state": self.job_state,
         }
 
 
@@ -337,3 +349,207 @@ async def _record_used(
         if await _link_once(backend, config, exec_id, "USED", node_id):
             linked += 1
     return linked
+
+
+# ---------------------------------------------------------------------------
+# External-job lifecycle: did the job actually run, and the Execution status
+# ---------------------------------------------------------------------------
+
+
+# A2A Task.status.state values that mean the job did NOT finish successfully.
+# Anything other than "completed" means the outputs (if any) are partial or
+# absent, so we must not ingest them as if real. "completed" is the only success.
+_A2A_TERMINAL_OK = "completed"
+
+
+@dataclass
+class JobOutcome:
+    """Whether an external-service job VERIFIABLY produced a usable artifact.
+
+    ``ok`` gates whether the ingest fabricates output nodes. ``state`` is the
+    job's own reported state (an A2A Task ``status.state``, or a synthetic token
+    for non-Task shapes), surfaced onto the Execution so a failed run is visible
+    and queryable. ``detail`` is a short human reason for a failure.
+    """
+
+    ok: bool
+    state: str
+    detail: str = ""
+
+
+def _a2a_status_message(doc: dict[str, Any]) -> str:
+    """Best-effort human text from an A2A Task status.message.parts[0].text."""
+    status = doc.get("status")
+    if not isinstance(status, dict):
+        return ""
+    msg = status.get("message")
+    if not isinstance(msg, dict):
+        return ""
+    parts = msg.get("parts")
+    if isinstance(parts, list) and parts and isinstance(parts[0], dict):
+        text = parts[0].get("text")
+        if isinstance(text, str):
+            return text.strip()[:300]
+    return ""
+
+
+def job_outcome(doc: Any) -> JobOutcome:
+    """Decide whether an external job's artifact represents a SUCCESSFUL run.
+
+    The failsafe gate before any output is ingested. We do NOT trust the mere
+    presence of an artifact: an A2A Task can come back ``status.state="failed"``
+    (or canceled / rejected / input-required / working) with a partial or empty
+    artifacts list, and ingesting that as if real would forge a record. So:
+
+      - ``None`` (the transport returned nothing: non-zero exit, timeout, missing
+        / empty / unparseable artifact) -> NOT ok, state "missing".
+      - a non-dict -> NOT ok, state "invalid".
+      - an A2A Task (has a ``status`` dict with a ``state``): ok IFF
+        ``state == "completed"``; otherwise NOT ok, state = the reported state.
+      - any other dict (a LiteratureSearchResult, a report envelope: no A2A
+        status block): ok (the transport already rejected the empty / unparseable
+        cases, so a present dict is a usable artifact). state "completed".
+
+    Defensive: never raises.
+    """
+    if doc is None:
+        return JobOutcome(ok=False, state="missing", detail="no artifact returned")
+    if not isinstance(doc, dict):
+        return JobOutcome(
+            ok=False, state="invalid", detail=f"artifact is {type(doc).__name__}, not an object"
+        )
+    status = doc.get("status")
+    if isinstance(status, dict) and status.get("state") is not None:
+        state = str(status.get("state")).strip().lower()
+        if state == _A2A_TERMINAL_OK:
+            return JobOutcome(ok=True, state=state)
+        return JobOutcome(
+            ok=False,
+            state=state or "unknown",
+            detail=_a2a_status_message(doc) or f"job state was {state!r}, not completed",
+        )
+    # No A2A status block: a plain result dict. The transport already guarantees
+    # it is a non-empty parseable object, so the job produced a usable artifact.
+    return JobOutcome(ok=True, state="completed")
+
+
+async def mark_execution_failed(
+    config: WheelerConfig, exec_id: str, outcome: JobOutcome
+) -> None:
+    """Mark a run Execution as failed and stamp the job-failure diagnostic.
+
+    The failsafe write: set ``status="failed"`` (so nothing downstream reads the
+    run as clean) and park the job's own state + reason in the queryable custom
+    bag (``custom_job_state`` / ``custom_error``). Best-effort: a failure here
+    never raises, so the surrounding ingest's early-return is unaffected.
+    """
+    if not exec_id:
+        return
+    from wheeler.tools.graph_tools import execute_tool
+
+    custom: dict[str, Any] = {"job_state": outcome.state}
+    if outcome.detail:
+        custom["error"] = outcome.detail
+    try:
+        await execute_tool(
+            "update_node",
+            {"node_id": exec_id, "status": "failed", "custom": custom},
+            config,
+        )
+    except Exception:
+        logger.warning(
+            "mark_execution_failed: could not mark %s failed (best-effort)",
+            exec_id,
+            exc_info=True,
+        )
+
+
+async def mark_execution_completed(config: WheelerConfig, exec_id: str) -> None:
+    """Reset a REUSED Execution to completed, clearing any prior failure marks.
+
+    The mirror of ``mark_execution_failed``. The run Execution dedupes on
+    (service, session_id), so a retry REUSES the node a prior attempt created. If
+    that prior attempt left it ``status="failed"`` (a failed remote job, or a
+    partial-ingest error), a now-SUCCESSFUL retry must not inherit the stale
+    "failed" status, or the graph would lie that a successful run failed. Sets
+    ``status="completed"`` and clears ``custom_job_state`` / ``custom_error``.
+    Only call on the success path for a REUSED Execution (a freshly created one is
+    already stamped with the right status). Best-effort: never raises.
+    """
+    if not exec_id:
+        return
+    from wheeler.tools.graph_tools import execute_tool
+
+    try:
+        await execute_tool(
+            "update_node",
+            {
+                "node_id": exec_id,
+                "status": "completed",
+                "custom": {"job_state": "completed", "error": ""},
+            },
+            config,
+        )
+    except Exception:
+        logger.warning(
+            "mark_execution_completed: could not reset %s to completed "
+            "(best-effort)",
+            exec_id,
+            exc_info=True,
+        )
+
+
+async def record_failed_execution(
+    backend,
+    config: WheelerConfig,
+    *,
+    service: str,
+    session_id: str,
+    kind: str,
+    description: str,
+    reason: str,
+    link_to: str | None = None,
+    used_inputs: list[str] | None = None,
+) -> ImportReport:
+    """Create (or reuse) a FAILED Execution for a job that produced no artifact.
+
+    The visibility half of the failsafe: when the external CLI exits non-zero or
+    returns no usable artifact, the transport returns None and the ingest is never
+    called, so without this the attempt would leave NO trace ("you would not know
+    it ran"). The marshal-in act calls this on a non-zero exit so the failed
+    attempt is a queryable Execution (``status="failed"``, service-tagged, with
+    the reason in ``custom_error``), wired to its inputs (USED) and Plan
+    (AROSE_FROM) just like a successful run. Idempotent on (service, session_id).
+    """
+    from wheeler.tools.graph_tools import execute_tool
+
+    report = ImportReport(failed=True, job_state="missing")
+    exec_id = await _find_execution(
+        backend, config, service=service, session_id=session_id
+    )
+    if not exec_id:
+        result = json.loads(
+            await execute_tool(
+                "add_execution",
+                {
+                    "kind": kind,
+                    "description": description[:200],
+                    "agent_id": service.split(":", 1)[0] if service else "",
+                    "status": "failed",
+                    "session_id": session_id,
+                    "service": service,
+                },
+                config,
+            )
+        )
+        exec_id = result.get("node_id", "")
+    report.execution_id = exec_id
+    if exec_id:
+        await mark_execution_failed(
+            config, exec_id, JobOutcome(ok=False, state="missing", detail=reason)
+        )
+        if await _link_execution_to_plan(backend, config, exec_id, link_to):
+            report.plan_linked += 1
+        if used_inputs:
+            report.used += await _record_used(backend, config, exec_id, used_inputs)
+    return report

--- a/wheeler/integrations/asta/cli.py
+++ b/wheeler/integrations/asta/cli.py
@@ -40,6 +40,110 @@ _INGESTERS = {
 # ingest path. Asta Literature Reports is the first such tool.
 _MARKDOWN_TOOLS = {"scholar_qa", "scholar-qa", "literature-report"}
 
+# The kind + service tag recorded for a FAILED attempt of each tool (the
+# record-failure verb writes a failed Execution when the external CLI produced no
+# usable artifact). Keyed on the normalized tool name.
+_FAILURE_META = {
+    "paper_finder": ("paper-search", "asta:paper-finder"),
+    "paper-finder": ("paper-search", "asta:paper-finder"),
+    "theorizer": ("theory-generation", "asta:theorizer"),
+    "semantic_scholar": ("paper-lookup", "asta:semantic-scholar"),
+    "semantic-scholar": ("paper-lookup", "asta:semantic-scholar"),
+    "s2": ("paper-lookup", "asta:semantic-scholar"),
+    "scholar_qa": ("literature-report", "asta:scholar-qa"),
+    "scholar-qa": ("literature-report", "asta:scholar-qa"),
+    "literature-report": ("literature-report", "asta:scholar-qa"),
+}
+
+
+def _echo_report(report) -> None:
+    """Print an ingest summary, surfacing a failed / partial run honestly."""
+    typer.echo(
+        f"created={report.created} deduped={report.deduped} "
+        f"linked={report.linked} skipped={report.skipped} used={report.used} "
+        f"execution={report.execution_id or '-'}"
+    )
+    if report.failed:
+        # Honest signal: the job did not complete; no outputs were fabricated.
+        typer.echo(
+            f"FAILED: job did not complete (state={report.job_state or 'unknown'}). "
+            "The Execution is recorded as failed; no outputs were ingested."
+        )
+    if report.artifact:
+        typer.echo(f"artifact: {report.artifact}")
+    if report.paper_ids:
+        typer.echo("papers: " + ", ".join(report.paper_ids))
+
+
+@integrate_app.command("record-failure")
+def record_failure(
+    tool: str = typer.Argument(..., help="Tool name whose run failed."),
+    reason: str = typer.Option(
+        "external service call failed",
+        "--reason",
+        help="Short reason (e.g. the CLI stderr) stamped on the failed Execution.",
+    ),
+    link_to: Optional[str] = typer.Option(
+        None, "--link-to", help="Node id (Plan/Question) the failed run AROSE_FROM."
+    ),
+    used: Optional[str] = typer.Option(
+        None, "--used", help="Comma-separated graph node ids the request was built FROM."
+    ),
+    session_id: Optional[str] = typer.Option(
+        None,
+        "--session-id",
+        help="Stable run key so the failed Execution dedupes with a later retry.",
+    ),
+) -> None:
+    """Record a FAILED external-service attempt that produced no artifact.
+
+    The marshal-in act calls this when the external CLI exits non-zero or returns
+    no usable artifact: the transport returns nothing, so the ingest is never
+    reached and the attempt would otherwise leave NO trace. This writes a visible,
+    queryable failed Execution (status="failed", service-tagged, reason in
+    custom_error), wired to its inputs (USED) and Plan (AROSE_FROM). Idempotent on
+    (service, session_id), so a retry of the same logical run reuses it.
+    """
+    tool_key = tool.strip().lower()
+    if tool_key not in _FAILURE_META:
+        typer.echo(
+            f"Unknown tool '{tool}'. Supported: {', '.join(sorted(_INGESTERS))}.",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+    kind, service = _FAILURE_META[tool_key]
+
+    from wheeler.config import load_config
+
+    config = load_config()
+    parsed_used = [i.strip() for i in used.split(",") if i.strip()] if used else []
+    sid = (session_id or "").strip() or f"failed-{abs(hash(reason)) & 0xffffffff:08x}"
+
+    async def _do():
+        # One event loop: get the backend and write the failed Execution together
+        # (a nested asyncio.run would bind the backend to a closed loop).
+        from wheeler.integrations.asta._marshal import record_failed_execution
+        from wheeler.tools.graph_tools import _get_backend
+
+        backend = await _get_backend(config)
+        return await record_failed_execution(
+            backend=backend,
+            config=config,
+            service=service,
+            session_id=sid,
+            kind=kind,
+            description=f"{service} FAILED: {reason}",
+            reason=reason,
+            link_to=link_to,
+            used_inputs=parsed_used or None,
+        )
+
+    report = asyncio.run(_do())
+    typer.echo(
+        f"recorded failed execution={report.execution_id or '-'} "
+        f"(state={report.job_state}, used={report.used})"
+    )
+
 
 @integrate_app.command("ingest")
 def ingest(
@@ -137,15 +241,7 @@ def ingest(
                 used_inputs=used_inputs,
             )
         )
-        typer.echo(
-            f"created={report.created} deduped={report.deduped} "
-            f"linked={report.linked} skipped={report.skipped} used={report.used} "
-            f"execution={report.execution_id or '-'}"
-        )
-        if report.artifact:
-            typer.echo(f"report: {report.artifact}")
-        if report.paper_ids:
-            typer.echo("papers: " + ", ".join(report.paper_ids))
+        _echo_report(report)
         return
 
     try:
@@ -192,10 +288,4 @@ def ingest(
             )
         )
 
-    typer.echo(
-        f"created={report.created} deduped={report.deduped} "
-        f"linked={report.linked} skipped={report.skipped} used={report.used} "
-        f"execution={report.execution_id or '-'}"
-    )
-    if report.paper_ids:
-        typer.echo("papers: " + ", ".join(report.paper_ids))
+    _echo_report(report)

--- a/wheeler/integrations/asta/ingest.py
+++ b/wheeler/integrations/asta/ingest.py
@@ -30,6 +30,7 @@ from wheeler.config import WheelerConfig
 
 from ._marshal import (
     ImportReport,
+    JobOutcome,
     _find_execution,
     _find_paper_by_corpus_id,
     _link_execution_to_plan,
@@ -38,6 +39,9 @@ from ._marshal import (
     _paper_exists,
     _record_used,
     _save_index,
+    job_outcome,
+    mark_execution_completed,
+    mark_execution_failed,
 )
 from .schemas import PaperRecord, parse_paper_finder
 
@@ -85,9 +89,12 @@ async def ingest_paper_finder(
 
     report = ImportReport()
     records: list[PaperRecord] = parse_paper_finder(doc)
-    if not records:
-        logger.warning("ingest_paper_finder: no parseable papers in artifact")
-        return report
+    # Failsafe gate: did the external search job actually return a usable
+    # artifact? A LiteratureSearchResult has no A2A status block, so this is ok
+    # for any present result dict (the transport already rejected the non-zero /
+    # missing / empty cases); the gate is uniform across adapters and the empty /
+    # partial-ingest handling below still applies.
+    outcome = job_outcome(doc)
 
     backend = await _get_backend(config)
     index = _load_index()
@@ -103,6 +110,7 @@ async def ingest_paper_finder(
     exec_id = await _find_execution(
         backend, config, service=_SERVICE_TAG, session_id=session_id
     )
+    reused = bool(exec_id)
     if not exec_id:
         exec_result_str = await execute_tool(
             "add_execution",
@@ -110,7 +118,7 @@ async def ingest_paper_finder(
                 "kind": "paper-search",
                 "description": f"Asta Paper Finder: {query_text}",
                 "agent_id": "asta",
-                "status": "completed",
+                "status": "completed" if outcome.ok else "failed",
                 "session_id": session_id,
                 "service": _SERVICE_TAG,
             },
@@ -170,49 +178,93 @@ async def ingest_paper_finder(
     if artifact_id:
         report.artifact = artifact_id
 
-    # corpus_id -> P-id for papers seen this run (so a citing paper can be
-    # linked to a cited paper that was just created in the same run).
-    seen_this_run: dict[str, str] = {}
-
-    for record in records:
-        paper_id = await _ingest_one_paper(
-            backend, execute_tool, config, record, index, session_id, report,
+    # Failsafe gate: if the search job did not return a usable artifact, STOP
+    # here. The Execution exists (status="failed", reason in its custom bag) and
+    # the raw artifact is saved, so the attempt is visible, but no Paper nodes are
+    # fabricated. (Reachable only for a malformed artifact: the transport gates
+    # the rest.)
+    if not outcome.ok:
+        await mark_execution_failed(config, exec_id, outcome)
+        report.failed = True
+        report.job_state = outcome.state
+        logger.warning(
+            "ingest_paper_finder: job did not complete (state=%s): %s",
+            outcome.state,
+            outcome.detail,
         )
-        if paper_id is None:
-            report.skipped += 1
-            continue
-        if record.corpus_id:
-            seen_this_run[record.corpus_id] = paper_id
+        return report
+    # Reused Execution from a PRIOR failed attempt: a now-successful retry must
+    # not inherit the stale "failed" status. Reset before any output is written.
+    if reused:
+        await mark_execution_completed(config, exec_id)
+    # A completed search with zero results is a legitimate empty result: the
+    # Execution stays completed and visible, there is just nothing to bucket.
+    if not records:
+        logger.warning("ingest_paper_finder: no parseable papers in completed artifact")
+        _save_index(index)
+        return report
 
-        # Paper WAS_DERIVED_FROM the raw output artifact (link_once-guarded),
-        # so every paper chains back through the artifact to the service run.
-        if artifact_id:
-            if await _link_once(
-                backend, config, paper_id, "WAS_DERIVED_FROM", artifact_id,
-            ):
-                report.linked += 1
+    try:
+        # corpus_id -> P-id for papers seen this run (so a citing paper can be
+        # linked to a cited paper that was just created in the same run).
+        seen_this_run: dict[str, str] = {}
 
-        # Paper RELEVANT_TO the link target (e.g. the Question/Plan that
-        # prompted the search).
-        if link_to:
-            if await _link_once(backend, config, paper_id, "RELEVANT_TO", link_to):
-                report.linked += 1
-
-    # Second pass: citation contexts -> CITES edges. Done after all papers
-    # exist so a cited corpus_id created this run is resolvable.
-    for record in records:
-        if not record.cited_corpus_ids:
-            continue
-        src_paper_id = seen_this_run.get(record.corpus_id) or index.get(record.corpus_id)
-        if not src_paper_id:
-            continue
-        for cited_corpus in record.cited_corpus_ids:
-            tgt_paper_id = seen_this_run.get(cited_corpus) or index.get(cited_corpus)
-            if not tgt_paper_id:
-                # Cited paper not in our graph; skip (no orphan stub creation).
+        for record in records:
+            paper_id = await _ingest_one_paper(
+                backend, execute_tool, config, record, index, session_id, report,
+            )
+            if paper_id is None:
+                report.skipped += 1
                 continue
-            if await _link_once(backend, config, src_paper_id, "CITES", tgt_paper_id):
-                report.linked += 1
+            if record.corpus_id:
+                seen_this_run[record.corpus_id] = paper_id
+
+            # Paper WAS_DERIVED_FROM the raw output artifact (link_once-guarded),
+            # so every paper chains back through the artifact to the service run.
+            if artifact_id:
+                if await _link_once(
+                    backend, config, paper_id, "WAS_DERIVED_FROM", artifact_id,
+                ):
+                    report.linked += 1
+
+            # Paper RELEVANT_TO the link target (e.g. the Question/Plan that
+            # prompted the search).
+            if link_to:
+                if await _link_once(backend, config, paper_id, "RELEVANT_TO", link_to):
+                    report.linked += 1
+
+        # Second pass: citation contexts -> CITES edges. Done after all papers
+        # exist so a cited corpus_id created this run is resolvable.
+        for record in records:
+            if not record.cited_corpus_ids:
+                continue
+            src_paper_id = seen_this_run.get(record.corpus_id) or index.get(record.corpus_id)
+            if not src_paper_id:
+                continue
+            for cited_corpus in record.cited_corpus_ids:
+                tgt_paper_id = seen_this_run.get(cited_corpus) or index.get(cited_corpus)
+                if not tgt_paper_id:
+                    # Cited paper not in our graph; skip (no orphan stub creation).
+                    continue
+                if await _link_once(backend, config, src_paper_id, "CITES", tgt_paper_id):
+                    report.linked += 1
+    except Exception:
+        # Partial-ingest failsafe: bucketing raised partway. Mark the run failed
+        # (no destructive rollback: provenance stays reachable; consistency_check
+        # reconciles). Persist the index so created papers keep their dedupe key.
+        logger.error(
+            "ingest_paper_finder: output bucketing raised partway; marking run failed",
+            exc_info=True,
+        )
+        await mark_execution_failed(
+            config,
+            exec_id,
+            JobOutcome(ok=False, state="ingest-error", detail="output bucketing raised"),
+        )
+        report.failed = True
+        report.job_state = "ingest-error"
+        _save_index(index)
+        return report
 
     _save_index(index)
     logger.info(

--- a/wheeler/integrations/asta/scholar_qa.py
+++ b/wheeler/integrations/asta/scholar_qa.py
@@ -70,6 +70,7 @@ from typing import Any
 from wheeler.config import WheelerConfig
 from wheeler.integrations.asta._marshal import (
     ImportReport,
+    JobOutcome,
     _find_execution,
     _find_paper_by_corpus_id,
     _link_execution_to_plan,
@@ -78,6 +79,8 @@ from wheeler.integrations.asta._marshal import (
     _paper_exists,
     _record_used,
     _save_index,
+    mark_execution_completed,
+    mark_execution_failed,
 )
 from wheeler.integrations.asta.schemas import (
     _normalize_corpus_id,
@@ -385,6 +388,7 @@ async def ingest_scholar_qa(
     exec_id = await _find_execution(
         backend, config, service=_SERVICE_TAG, session_id=session_id
     )
+    reused = bool(exec_id)
     if not exec_id:
         import json
 
@@ -452,22 +456,47 @@ async def ingest_scholar_qa(
         ):
             report.linked += 1
 
+    # Reused Execution from a PRIOR failed attempt (e.g. an earlier partial-ingest
+    # error at the same report path): a now-successful retry must not inherit the
+    # stale "failed" status. Reset before any output is written.
+    if reused:
+        await mark_execution_completed(config, exec_id)
+
     # corpus_id -> P-id for papers touched this run (a paper cited by two keys is
     # resolved once).
     seen_papers: dict[str, str] = {}
-    for paper in record.papers:
-        await _ingest_cited_paper(
-            backend=backend,
-            execute_tool=execute_tool,
-            config=config,
-            paper=paper,
-            doc_id=doc_id,
-            exec_id=exec_id,
-            session_id=session_id,
-            paper_index=paper_index,
-            seen_papers=seen_papers,
-            report=report,
+    try:
+        for paper in record.papers:
+            await _ingest_cited_paper(
+                backend=backend,
+                execute_tool=execute_tool,
+                config=config,
+                paper=paper,
+                doc_id=doc_id,
+                exec_id=exec_id,
+                session_id=session_id,
+                paper_index=paper_index,
+                seen_papers=seen_papers,
+                report=report,
+            )
+    except Exception:
+        # Partial-ingest failsafe: bucketing raised partway. Mark the run failed
+        # so it does not read as clean (no destructive rollback: provenance stays
+        # reachable; consistency_check reconciles). Persist the index so created
+        # papers keep their dedupe key.
+        logger.error(
+            "ingest_scholar_qa: output bucketing raised partway; marking run failed",
+            exc_info=True,
         )
+        await mark_execution_failed(
+            config,
+            exec_id,
+            JobOutcome(ok=False, state="ingest-error", detail="output bucketing raised"),
+        )
+        report.failed = True
+        report.job_state = "ingest-error"
+        _save_index(paper_index)
+        return report
 
     _save_index(paper_index)
     logger.info(

--- a/wheeler/integrations/asta/semantic_scholar.py
+++ b/wheeler/integrations/asta/semantic_scholar.py
@@ -86,6 +86,7 @@ from typing import Any
 from wheeler.config import WheelerConfig
 from wheeler.integrations.asta._marshal import (
     ImportReport,
+    JobOutcome,
     _find_execution,
     _find_paper_by_corpus_id,
     _link_execution_to_plan,
@@ -94,6 +95,9 @@ from wheeler.integrations.asta._marshal import (
     _paper_exists,
     _record_used,
     _save_index,
+    job_outcome,
+    mark_execution_completed,
+    mark_execution_failed,
 )
 from wheeler.integrations.asta.schemas import _normalize_corpus_id
 
@@ -677,14 +681,13 @@ async def ingest_semantic_scholar(
 
     report = ImportReport()
     parsed = parse_semantic_scholar(doc)
-    if parsed.sub_kind == "unknown" or not (
-        parsed.papers or parsed.citations or parsed.snippets
-    ):
-        logger.warning(
-            "ingest_semantic_scholar: nothing parseable (sub_kind=%s)",
-            parsed.sub_kind,
-        )
-        return report
+    # Failsafe gate: did the external job return a usable artifact? An S2 REST
+    # response has no A2A status block, so this is ok for any present dict (the
+    # transport already gated the non-zero / missing / empty cases). The
+    # parse-quality check (unknown sub_kind / nothing parseable) is handled after
+    # the Execution is created, so even an undetectable artifact leaves a visible
+    # run record.
+    outcome = job_outcome(doc)
 
     backend = await _get_backend(config)
     paper_index = _load_index()
@@ -698,6 +701,7 @@ async def ingest_semantic_scholar(
     exec_id = await _find_execution(
         backend, config, service=_SERVICE_TAG, session_id=session_id
     )
+    reused = bool(exec_id)
     if not exec_id:
         exec_result = json.loads(
             await execute_tool(
@@ -706,7 +710,7 @@ async def ingest_semantic_scholar(
                     "kind": _kind_for_sub(parsed.sub_kind),
                     "description": f"Asta Semantic Scholar: {parsed.sub_kind}",
                     "agent_id": "asta",
-                    "status": "completed",
+                    "status": "completed" if outcome.ok else "failed",
                     "session_id": session_id,
                     "service": _SERVICE_TAG,
                 },
@@ -761,82 +765,134 @@ async def ingest_semantic_scholar(
     if artifact_id:
         report.artifact = artifact_id
 
-    # corpus_id (or fallback key) -> P-id for papers touched this run, so the
-    # same paper appearing twice in one artifact is created once.
-    seen_papers: dict[str, str] = {}
+    # Failsafe gate: if the job did not return a usable artifact, STOP here. The
+    # Execution exists (status="failed", reason in its custom bag) and the raw
+    # artifact is saved, so the attempt is visible, but no nodes are fabricated.
+    if not outcome.ok:
+        await mark_execution_failed(config, exec_id, outcome)
+        report.failed = True
+        report.job_state = outcome.state
+        logger.warning(
+            "ingest_semantic_scholar: job did not complete (state=%s): %s",
+            outcome.state,
+            outcome.detail,
+        )
+        return report
+    # Reused Execution from a PRIOR failed attempt: a now-successful retry must
+    # not inherit the stale "failed" status. Reset before any output is written.
+    if reused:
+        await mark_execution_completed(config, exec_id)
+    # A completed job whose shape we could not detect (or which had no records) is
+    # a visible empty run: the Execution stays completed, there is nothing to
+    # bucket. (An undetectable shape is a parse limitation, not a remote-job
+    # failure, so the run is honestly "completed", not "failed".)
+    if parsed.sub_kind == "unknown" or not (
+        parsed.papers or parsed.citations or parsed.snippets
+    ):
+        logger.warning(
+            "ingest_semantic_scholar: nothing parseable in completed artifact "
+            "(sub_kind=%s)",
+            parsed.sub_kind,
+        )
+        return report
 
-    if parsed.sub_kind in ("get", "search"):
-        for record in parsed.papers:
-            await _ingest_paper(
-                backend=backend,
-                execute_tool=execute_tool,
-                config=config,
-                record=record,
-                session_id=session_id,
-                artifact_id=artifact_id,
-                link_to=link_to,
-                paper_index=paper_index,
-                fallback_index=fallback_index,
-                seen_papers=seen_papers,
-                report=report,
-            )
+    try:
+        # corpus_id (or fallback key) -> P-id for papers touched this run, so the
+        # same paper appearing twice in one artifact is created once.
+        seen_papers: dict[str, str] = {}
 
-    elif parsed.sub_kind == "citations":
-        # Resolve the cited target (the CLI argument, NOT in the artifact). A
-        # P-id is used directly; a corpus_id (digit string) is mapped to its
-        # Paper. If the target cannot be resolved, the papers are still created
-        # but no CITES edge is built (counted via report; logged once).
-        target_id = await _resolve_target(backend, config, target)
-        if target is not None and target_id is None:
-            logger.warning(
-                "ingest_semantic_scholar: citation target %r did not resolve to a "
-                "node; citing papers will be created without CITES edges",
-                target,
-            )
-        for citation in parsed.citations:
-            # CRITICAL: citing papers are NOT relevant to the question. A citation
-            # links via citingPaper -[CITES]-> target plus WAS_DERIVED_FROM the
-            # raw node; it is never RELEVANT_TO the question and never
-            # WAS_GENERATED_BY (papers are reference entities, not produced by
-            # Wheeler). So link_to is forced to None here. See /wh:close and
-            # /wh:graph-link: "Papers are never orphans. They are reference
-            # entities, not produced by Wheeler."
-            paper_id = await _ingest_paper(
-                backend=backend,
-                execute_tool=execute_tool,
-                config=config,
-                record=citation.citing,
-                session_id=session_id,
-                artifact_id=artifact_id,
-                link_to=None,
-                paper_index=paper_index,
-                fallback_index=fallback_index,
-                seen_papers=seen_papers,
-                report=report,
-            )
-            # citingPaper -[CITES]-> target (the cited paper). Builds the
-            # citation graph. link_once-guarded so re-ingest never duplicates.
-            if paper_id and target_id:
-                if await _link_once(backend, config, paper_id, "CITES", target_id):
-                    report.linked += 1
+        if parsed.sub_kind in ("get", "search"):
+            for record in parsed.papers:
+                await _ingest_paper(
+                    backend=backend,
+                    execute_tool=execute_tool,
+                    config=config,
+                    record=record,
+                    session_id=session_id,
+                    artifact_id=artifact_id,
+                    link_to=link_to,
+                    paper_index=paper_index,
+                    fallback_index=fallback_index,
+                    seen_papers=seen_papers,
+                    report=report,
+                )
 
-    elif parsed.sub_kind == "snippet":
-        for snippet in parsed.snippets:
-            await _ingest_snippet(
-                backend=backend,
-                execute_tool=execute_tool,
-                config=config,
-                snippet=snippet,
-                session_id=session_id,
-                exec_id=exec_id,
-                artifact_id=artifact_id,
-                link_to=link_to,
-                paper_index=paper_index,
-                fallback_index=fallback_index,
-                snippet_index=snippet_index,
-                seen_papers=seen_papers,
-                report=report,
-            )
+        elif parsed.sub_kind == "citations":
+            # Resolve the cited target (the CLI argument, NOT in the artifact). A
+            # P-id is used directly; a corpus_id (digit string) is mapped to its
+            # Paper. If the target cannot be resolved, the papers are still created
+            # but no CITES edge is built (counted via report; logged once).
+            target_id = await _resolve_target(backend, config, target)
+            if target is not None and target_id is None:
+                logger.warning(
+                    "ingest_semantic_scholar: citation target %r did not resolve to a "
+                    "node; citing papers will be created without CITES edges",
+                    target,
+                )
+            for citation in parsed.citations:
+                # CRITICAL: citing papers are NOT relevant to the question. A
+                # citation links via citingPaper -[CITES]-> target plus
+                # WAS_DERIVED_FROM the raw node; it is never RELEVANT_TO the
+                # question and never WAS_GENERATED_BY (papers are reference
+                # entities, not produced by Wheeler). So link_to is forced to None
+                # here. See /wh:close and /wh:graph-link: "Papers are never
+                # orphans. They are reference entities, not produced by Wheeler."
+                paper_id = await _ingest_paper(
+                    backend=backend,
+                    execute_tool=execute_tool,
+                    config=config,
+                    record=citation.citing,
+                    session_id=session_id,
+                    artifact_id=artifact_id,
+                    link_to=None,
+                    paper_index=paper_index,
+                    fallback_index=fallback_index,
+                    seen_papers=seen_papers,
+                    report=report,
+                )
+                # citingPaper -[CITES]-> target (the cited paper). Builds the
+                # citation graph. link_once-guarded so re-ingest never duplicates.
+                if paper_id and target_id:
+                    if await _link_once(backend, config, paper_id, "CITES", target_id):
+                        report.linked += 1
+
+        elif parsed.sub_kind == "snippet":
+            for snippet in parsed.snippets:
+                await _ingest_snippet(
+                    backend=backend,
+                    execute_tool=execute_tool,
+                    config=config,
+                    snippet=snippet,
+                    session_id=session_id,
+                    exec_id=exec_id,
+                    artifact_id=artifact_id,
+                    link_to=link_to,
+                    paper_index=paper_index,
+                    fallback_index=fallback_index,
+                    snippet_index=snippet_index,
+                    seen_papers=seen_papers,
+                    report=report,
+                )
+    except Exception:
+        # Partial-ingest failsafe: bucketing raised partway. Mark the run failed
+        # (no destructive rollback: provenance stays reachable; consistency_check
+        # reconciles). Persist the indices so created nodes keep their dedupe keys.
+        logger.error(
+            "ingest_semantic_scholar: output bucketing raised partway; marking "
+            "run failed",
+            exc_info=True,
+        )
+        await mark_execution_failed(
+            config,
+            exec_id,
+            JobOutcome(ok=False, state="ingest-error", detail="output bucketing raised"),
+        )
+        report.failed = True
+        report.job_state = "ingest-error"
+        _save_index(paper_index)
+        _save_snippet_index(snippet_index)
+        _save_fallback_index(fallback_index)
+        return report
 
     _save_index(paper_index)
     _save_snippet_index(snippet_index)

--- a/wheeler/integrations/asta/theorizer.py
+++ b/wheeler/integrations/asta/theorizer.py
@@ -99,6 +99,7 @@ from typing import Any
 from wheeler.config import WheelerConfig
 from wheeler.integrations.asta._marshal import (
     ImportReport,
+    JobOutcome,
     _find_execution,
     _find_paper_by_corpus_id,
     _link_execution_to_plan,
@@ -107,6 +108,9 @@ from wheeler.integrations.asta._marshal import (
     _paper_exists,
     _record_used,
     _save_index,
+    job_outcome,
+    mark_execution_completed,
+    mark_execution_failed,
 )
 from wheeler.integrations.asta.schemas import _normalize_corpus_id
 
@@ -976,9 +980,11 @@ async def ingest_theorizer(
 
     report = ImportReport()
     theories, run_meta = parse_theorizer(doc)
-    if not theories:
-        logger.warning("ingest_theorizer: no parseable theories in artifact")
-        return report
+    # Failsafe gate: did the external Theorizer job actually complete? A failed /
+    # canceled A2A Task (or a missing artifact) must NOT have its partial output
+    # ingested as if real. We still record a (failed) Execution below so the
+    # attempt is visible; we just never fabricate theories/hypotheses for it.
+    outcome = job_outcome(doc)
 
     backend = await _get_backend(config)
     paper_index = _load_index()
@@ -1005,6 +1011,7 @@ async def ingest_theorizer(
     exec_id = await _find_execution(
         backend, config, service=_SERVICE_TAG, session_id=session_id
     )
+    reused = bool(exec_id)
     if not exec_id:
         exec_result = json.loads(
             await execute_tool(
@@ -1013,7 +1020,10 @@ async def ingest_theorizer(
                     "kind": "theory-generation",
                     "description": f"Asta Theorizer: {state_msg or run_meta.run_id}",
                     "agent_id": "asta",
-                    "status": "completed",
+                    # Honest status: only "completed" when the job verifiably
+                    # completed (job_outcome), else "failed" (the gate below stops
+                    # before any theory is fabricated).
+                    "status": "completed" if outcome.ok else "failed",
                     "session_id": session_id,
                     "service": _SERVICE_TAG,
                 },
@@ -1071,26 +1081,78 @@ async def ingest_theorizer(
     if artifact_id:
         report.artifact = artifact_id
 
+    # Failsafe gate: if the Theorizer job did not complete, STOP here. The
+    # Execution exists (status="failed", with the job's state + reason in its
+    # custom bag) and the raw artifact is saved for debugging, so the failed
+    # attempt is visible and queryable, but we fabricate NO theories/hypotheses
+    # for it (a failed run must never masquerade as a clean completed one).
+    if not outcome.ok:
+        await mark_execution_failed(config, exec_id, outcome)
+        report.failed = True
+        report.job_state = outcome.state
+        logger.warning(
+            "ingest_theorizer: job did not complete (state=%s): %s",
+            outcome.state,
+            outcome.detail,
+        )
+        return report
+    # Reused Execution from a PRIOR failed attempt: a now-successful retry must
+    # not inherit the stale "failed" status (the dedupe keys on service+session_id,
+    # not status). Reset it before any output is written.
+    if reused:
+        await mark_execution_completed(config, exec_id)
+    # A completed job with no parseable theories is a legitimate empty result:
+    # the Execution stays completed and visible, there is just nothing to bucket.
+    if not theories:
+        logger.warning(
+            "ingest_theorizer: no parseable theories in completed artifact"
+        )
+        return report
+
     # corpus_id -> P-id for papers touched this run, so a paper cited by two
     # laws is created once and reused across both.
     seen_papers: dict[str, str] = {}
 
-    for theory in theories:
-        await _ingest_one_theory(
-            backend=backend,
-            execute_tool=execute_tool,
-            config=config,
-            theory=theory,
-            link_to=link_to,
-            session_id=session_id,
-            exec_id=exec_id,
-            artifact_id=artifact_id,
-            paper_index=paper_index,
-            hyp_index=hyp_index,
-            theory_index=theory_index,
-            seen_papers=seen_papers,
-            report=report,
+    try:
+        for theory in theories:
+            await _ingest_one_theory(
+                backend=backend,
+                execute_tool=execute_tool,
+                config=config,
+                theory=theory,
+                link_to=link_to,
+                session_id=session_id,
+                exec_id=exec_id,
+                artifact_id=artifact_id,
+                paper_index=paper_index,
+                hyp_index=hyp_index,
+                theory_index=theory_index,
+                seen_papers=seen_papers,
+                report=report,
+            )
+    except Exception:
+        # Partial-ingest failsafe: bucketing raised partway. Mark the run failed
+        # so it does not read as clean. The nodes already written stay reachable
+        # (no destructive rollback: provenance must stay reachable, per /wh:close),
+        # and graph_consistency_check reconciles any triple-write drift. Persist
+        # the indices we have so created nodes are not orphaned from dedupe.
+        logger.error(
+            "ingest_theorizer: output bucketing raised partway; marking run failed",
+            exc_info=True,
         )
+        await mark_execution_failed(
+            config,
+            exec_id,
+            JobOutcome(
+                ok=False, state="ingest-error", detail="output bucketing raised"
+            ),
+        )
+        report.failed = True
+        report.job_state = "ingest-error"
+        _save_index(paper_index)
+        _save_hyp_index(hyp_index)
+        _save_theory_index(theory_index)
+        return report
 
     _save_index(paper_index)
     _save_hyp_index(hyp_index)


### PR DESCRIPTION
## Why

Every external-service call is one Execution that must **truthfully** record whether the job ran. Before: the status was hardcoded `completed`, a failed CLI left no trace (the transport returns None, so the ingest was never reached), and a failed A2A Task that still returned a partial artifact could have its output ingested as if real. The Execution could lie.

## What

- **`job_outcome(doc)`** (`_marshal.py`) is the gate: an A2A Task is success **only** when `status.state == "completed"` (failed/canceled/rejected/working/input-required are not); a non-Task result dict (LiteratureSearchResult, S2, report) is ok (the transport already rejected missing/empty). `None` → missing, non-dict → invalid.
- Each of the **4 adapters** creates the run Execution with honest status, and on a not-ok job marks it `failed` (`custom_job_state`/`custom_error`), saves the raw artifact for debugging, records USED inputs, and **returns early with no fabricated Findings/Hypotheses/Papers**. The Execution is created *before* the empty-result early returns, so even a zero-output run is visible. The bucketing loop is wrapped so a partial-ingest exception also marks the run failed.
- A successful retry that **reuses** a prior failed Execution resets it to `completed` (`mark_execution_completed`), so a now-successful run never inherits a stale `failed`.
- **`wheeler integrate record-failure`** (+ `record_failed_execution`) writes a visible failed Execution when the CLI produced no artifact at all, wired to its USED inputs + Plan. The marshal-in acts call it on a non-zero exit, so the attempt is never silently lost.
- `ImportReport.failed`/`job_state` surface the outcome; the CLI prints a `FAILED` line. No destructive rollback (provenance stays reachable per /wh:close; `graph_consistency_check` reconciles drift).

## Tests

`tests/integrations/asta/test_failsafe.py`: `job_outcome` unit cases + live-Neo4j e2e — a failed Theorizer Task ingests **zero** outputs but a failed Execution; failed-then-successful-retry flips the status back; `record-failure` writes a visible failed Execution.

Adversarially reviewed (lens re-ran the suite + reproduced live). One blocker found (reused Execution stuck `failed`) — fixed + regression-tested, re-confirmed PASS. `ruff` + `mypy` clean, **1908 passed, 2 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)