### PR TITLE
feat(asta): add Semantic Scholar `author` sub-query to the S2 adapter

### DIFF
--- a/.claude/commands/wh/asta-scholar.md
+++ b/.claude/commands/wh/asta-scholar.md
@@ -1,6 +1,6 @@
 ---
 name: wh:asta-scholar
-description: Use when the user wants to query Semantic Scholar via Asta (paper lookup, search, citations, or snippet search) and ingest the results into the Wheeler knowledge graph
+description: Use when the user wants to query Semantic Scholar via Asta (paper lookup, search, citations, snippet search, or an author's papers) and ingest the results into the Wheeler knowledge graph
 argument-hint: "[query, paper id, or DOI]"
 allowed-tools:
   - Read
@@ -16,12 +16,13 @@ allowed-tools:
 
 You are Wheeler, querying Semantic Scholar through the Asta CLI and marshalling the results into the knowledge graph. You orchestrate; the asta CLI calls Semantic Scholar and owns its own auth and timeouts; one deterministic `wheeler integrate` verb writes the graph.
 
-Semantic Scholar has four sub-queries. The ingest auto-detects which one from the artifact shape, so you only pick the right CLI call:
+Semantic Scholar has five sub-queries. The ingest auto-detects which one from the artifact shape, so you only pick the right CLI call:
 
 - `get`: one paper by id or DOI.
 - `search`: a relevance-ranked paper list for a query.
 - `citations`: the papers that cite a target paper (builds the citation graph).
 - `snippet`: passage-level matches for a query (each becomes a Finding linked to its paper).
+- `author`: an author's papers by author id (each becomes a Paper; the queried author is recorded on the run).
 
 ## Preflight
 
@@ -66,6 +67,15 @@ asta papers snippet "<query>" --fields corpusId,title,authors --limit <N> > /tmp
 wheeler integrate ingest semantic_scholar /tmp/asta-s2.json --link-to <Q- or PL- id> --used <Q- or PL- id>
 ```
 
+### Author's papers
+
+Fetch one author's papers by author id. Each becomes a Paper (`RELEVANT_TO` the link target, like search results); the queried author (id, name, paperCount, citationCount, hIndex) is stamped on the run Execution so the run is queryable by author. Request `corpusId` on the nested papers so they dedupe across services:
+
+```
+asta papers author <authorId> --fields corpusId,title,authors,year,venue,citationCount > /tmp/asta-s2.json
+wheeler integrate ingest semantic_scholar /tmp/asta-s2.json --link-to <Q- or PL- id> --used <Q- or PL- id>
+```
+
 If any CLI command exits non-zero, FIRST record the failed attempt so it is not silently lost (the failsafe: the external job is an Execution, and a failed one must be visible, not absent):
 
 ```
@@ -85,4 +95,4 @@ The ingest is structurally complete (each result `USED` the request inputs, snip
 
 ## Report
 
-Relay the printed summary (`created`, `deduped`, `linked`, `skipped`, the run Execution id, and the new node ids) to the user in one or two sentences. For a citations run, note that the citing papers now link `CITES` the target so the citation graph is queryable. For snippet runs, note the passage-level Findings (`artifact_type=snippet`) are linked `APPEARS_IN` their papers. Do not editorialize the science: the records are now in the graph, queryable by `corpus_id` and by their parked `custom_*` scalars. Never use em dashes.
+Relay the printed summary (`created`, `deduped`, `linked`, `skipped`, the run Execution id, and the new node ids) to the user in one or two sentences. For a citations run, note that the citing papers now link `CITES` the target so the citation graph is queryable. For snippet runs, note the passage-level Findings (`artifact_type=snippet`) are linked `APPEARS_IN` their papers. For an author run, note the author's papers are now in the graph and the run Execution carries the queried author (queryable as `custom_author_id` / `custom_author_name`). Do not editorialize the science: the records are now in the graph, queryable by `corpus_id` and by their parked `custom_*` scalars. Never use em dashes.

--- a/tests/integrations/asta/fixtures/s2_author.json
+++ b/tests/integrations/asta/fixtures/s2_author.json
@@ -1,0 +1,48 @@
+{
+  "_comment": "INFERRED shape from the documented S2 author-endpoint family, NOT a live `asta papers author` capture. Replace with a trimmed real capture when available; the parser ignores this key. See _parse_author in semantic_scholar.py.",
+  "authorId": "1741101",
+  "name": "Wolfram Schultz",
+  "affiliations": ["University of Cambridge"],
+  "homepage": "https://www.neuroscience.cam.ac.uk/",
+  "paperCount": 412,
+  "citationCount": 98765,
+  "hIndex": 142,
+  "url": "https://www.semanticscholar.org/author/1741101",
+  "papers": [
+    {
+      "paperId": "aaa1111111111111111111111111111111111111",
+      "corpusId": 501234001,
+      "title": "Dopamine neurons and their role in reward mechanisms",
+      "venue": "Journal of Neuroscience",
+      "year": 1998,
+      "citationCount": 3120,
+      "authors": [
+        {"authorId": "1741101", "name": "Wolfram Schultz"}
+      ]
+    },
+    {
+      "paperId": "bbb2222222222222222222222222222222222222",
+      "corpusId": 501234002,
+      "title": "A neural substrate of prediction and reward",
+      "venue": "Science",
+      "year": 1997,
+      "citationCount": 6890,
+      "authors": [
+        {"authorId": "1741101", "name": "Wolfram Schultz"},
+        {"authorId": "2222222", "name": "P. Dayan"},
+        {"authorId": "3333333", "name": "P. R. Montague"}
+      ]
+    },
+    {
+      "paperId": "ccc3333333333333333333333333333333333333",
+      "corpusId": 501234003,
+      "title": "Predictive reward signal of dopamine neurons",
+      "venue": "Journal of Neurophysiology",
+      "year": 1998,
+      "citationCount": 4501,
+      "authors": [
+        {"authorId": "1741101", "name": "Wolfram Schultz"}
+      ]
+    }
+  ]
+}

--- a/tests/integrations/asta/test_semantic_scholar.py
+++ b/tests/integrations/asta/test_semantic_scholar.py
@@ -31,6 +31,7 @@ GET_FIXTURE = FIX / "s2_get.json"
 SEARCH_FIXTURE = FIX / "s2_search.json"
 CITATIONS_FIXTURE = FIX / "s2_citations.json"
 SNIPPET_FIXTURE = FIX / "s2_snippet.json"
+AUTHOR_FIXTURE = FIX / "s2_author.json"
 
 # Service tag for every node this adapter writes. Teardown keys on it (plus the
 # fixture corpus_ids) so cleanup is hermetic regardless of a per-run e2e tag.
@@ -43,6 +44,15 @@ SNIPPET_CORPUS_IDS = ["203658198", "12580360"]
 # corpus_ids in the get + search fixtures.
 GET_CORPUS_ID = "210116405"
 SEARCH_CORPUS_IDS = ["301234001", "301234002", "301234003"]
+# author fixture: the queried author + the corpus_ids of their papers.
+# NOTE: s2_author.json is an INFERRED shape (the documented S2 author-endpoint
+# family), NOT a live `asta papers author` capture like the other four fixtures.
+# When a real author run is captured, drop a trimmed copy over s2_author.json and
+# fix these constants + any renamed keys in _parse_author. The parser is
+# defensive, so a key-name drift degrades gracefully rather than raising.
+AUTHOR_ID = "1741101"
+AUTHOR_NAME = "Wolfram Schultz"
+AUTHOR_CORPUS_IDS = ["501234001", "501234002", "501234003"]
 
 # The cited target paper for the citations e2e (a corpus_id, NOT in the output).
 TARGET_CORPUS_ID = "210116405"
@@ -77,6 +87,12 @@ class TestAutoDetectSubKind:
         parsed = parse_semantic_scholar(_load(SNIPPET_FIXTURE))
         assert parsed.sub_kind == "snippet"
         assert len(parsed.snippets) == 3
+
+    def test_detects_author(self):
+        parsed = parse_semantic_scholar(_load(AUTHOR_FIXTURE))
+        assert parsed.sub_kind == "author"
+        assert len(parsed.papers) == len(AUTHOR_CORPUS_IDS)
+        assert parsed.author is not None
 
 
 class TestParseGet:
@@ -173,6 +189,64 @@ class TestParseSnippet:
         parsed = parse_semantic_scholar(_load(SNIPPET_FIXTURE))
         kinds = {s.kind for s in parsed.snippets}
         assert kinds == {"body", "abstract"}
+
+
+class TestParseAuthor:
+    def test_author_meta_lifted_to_custom(self):
+        parsed = parse_semantic_scholar(_load(AUTHOR_FIXTURE))
+        author = parsed.author
+        assert author is not None
+        assert author.author_id == AUTHOR_ID
+        assert author.name == AUTHOR_NAME
+        # The scalars the run is queryable by, namespaced with author_.
+        assert author.custom["author_id"] == AUTHOR_ID
+        assert author.custom["author_name"] == AUTHOR_NAME
+        assert author.custom["author_paper_count"] == 412
+        assert author.custom["author_citation_count"] == 98765
+        assert author.custom["author_h_index"] == 142
+        assert author.custom["author_affiliations"] == "University of Cambridge"
+
+    def test_author_papers_parse_through_the_paper_path(self):
+        parsed = parse_semantic_scholar(_load(AUTHOR_FIXTURE))
+        cids = {p.corpus_id for p in parsed.papers}
+        assert cids == set(AUTHOR_CORPUS_IDS)
+        # Promoted + custom fields carry over from the shared paper parser.
+        by_cid = {p.corpus_id: p for p in parsed.papers}
+        assert by_cid["501234002"].title.startswith("A neural substrate")
+        assert by_cid["501234002"].year == 1997
+        assert "Dayan" in by_cid["501234002"].authors
+        assert by_cid["501234002"].custom["citation_count"] == 6890
+
+    def test_author_papers_under_data_key(self):
+        # The /author/{id}/papers endpoint nests papers under ``data`` instead of
+        # ``papers``; both are accepted so the run still buckets its papers.
+        doc = {
+            "authorId": "9",
+            "name": "Solo",
+            "data": [{"corpusId": 7, "title": "Lone paper", "year": 2020}],
+        }
+        parsed = parse_semantic_scholar(doc)
+        assert parsed.sub_kind == "author"
+        assert [p.corpus_id for p in parsed.papers] == ["7"]
+
+    def test_profile_only_author_has_no_papers(self):
+        # A bare author profile (no papers) is still an author run: it records the
+        # queried author, with an empty paper list.
+        parsed = parse_semantic_scholar({"authorId": "9", "name": "Solo"})
+        assert parsed.sub_kind == "author"
+        assert parsed.papers == []
+        assert parsed.author is not None and parsed.author.name == "Solo"
+
+    def test_get_with_nested_author_ids_is_not_misread_as_author(self):
+        # A paper ``get`` carries authorId only NESTED under authors[]; the
+        # top-level key is paperId, so it must stay a ``get`` (the author endpoint
+        # puts authorId at the top level).
+        doc = {
+            "paperId": "abc",
+            "title": "T",
+            "authors": [{"authorId": "1", "name": "A"}],
+        }
+        assert parse_semantic_scholar(doc).sub_kind == "get"
 
 
 class TestDefensive:
@@ -978,3 +1052,149 @@ class TestIngestSemanticScholarE2E:
                 xid=report3.execution_id,
             )
             assert (await res.single())["c"] == 0
+
+    @pytest.mark.asyncio
+    async def test_author_papers_and_execution_stamp_and_provenance(self, e2e_config):
+        """An ``author`` run: the author's papers + the queried-author stamp.
+
+        Asserts the full provenance contract for the new sub-kind:
+          - Execution kind ``s2-author``, stamped with the queried-author scalars
+            (custom_author_id / custom_author_name / custom_author_h_index),
+          - each author paper is a Paper node RELEVANT_TO the link target (the
+            author's papers ARE relevant to the question, like search results),
+          - each author paper WAS_DERIVED_FROM the raw Dataset (lineage), and
+            carries NO WAS_GENERATED_BY (Papers are reference entities),
+          - Execution -[USED]-> the link target (input-side provenance),
+          - re-ingest is idempotent (created==0, all deduped, same Execution).
+        """
+        from wheeler.graph.driver import get_async_driver
+        from wheeler.integrations.asta.semantic_scholar import (
+            ingest_semantic_scholar,
+        )
+        from wheeler.tools.graph_tools import execute_tool
+
+        doc = _load(AUTHOR_FIXTURE)
+        artifact_path = self._tmp / "s2_author_raw.json"
+        artifact_path.write_text(json.dumps(doc))
+        driver = get_async_driver(e2e_config)
+        db = e2e_config.neo4j.database
+
+        # The Question the author lookup supports (the link + USED target).
+        q_result = json.loads(await execute_tool(
+            "add_question",
+            {"question": "E2E author: what has this author published on reward?",
+             "priority": 5},
+            e2e_config,
+        ))
+        question_id = q_result["node_id"]
+        async with driver.session(database=db) as s:
+            await s.run(
+                "MATCH (n {id: $id}) SET n.e2e_tag = $tag",
+                id=question_id, tag=self._e2e_tag,
+            )
+
+        # --- First ingest of the author artifact ---
+        report1 = await ingest_semantic_scholar(
+            doc,
+            link_to=question_id,
+            config=e2e_config,
+            artifact_path=str(artifact_path),
+            used_inputs=[question_id],
+        )
+        await self._tag_all(e2e_config, report1)
+        exec_id = report1.execution_id
+        assert exec_id.startswith("X-")
+        # 3 distinct author papers created.
+        assert report1.created == len(AUTHOR_CORPUS_IDS)
+        assert report1.used == 1
+
+        # Execution kind reflects the sub-shape, scoped to THIS run's id.
+        async with driver.session(database=db) as s:
+            res = await s.run(
+                "MATCH (x:Execution {id: $xid}) RETURN x.kind AS kind",
+                xid=exec_id,
+            )
+            assert (await res.single())["kind"] == "s2-author"
+
+        # The queried-author scalars are stamped on the run Execution (the author
+        # dimension is queryable on the run, NOT as a new node type).
+        async with driver.session(database=db) as s:
+            res = await s.run(
+                "MATCH (x:Execution {id: $xid}) RETURN "
+                "x.custom_author_id AS aid, x.custom_author_name AS name, "
+                "x.custom_author_h_index AS h",
+                xid=exec_id,
+            )
+            rec = await res.single()
+        assert rec["aid"] == AUTHOR_ID
+        assert rec["name"] == AUTHOR_NAME
+        assert rec["h"] == 142
+
+        # One Paper per author corpus_id.
+        async with driver.session(database=db) as s:
+            res = await s.run(
+                "MATCH (p:Paper) WHERE p.corpus_id IN $cids "
+                "RETURN count(DISTINCT p) AS c",
+                cids=AUTHOR_CORPUS_IDS,
+            )
+            assert (await res.single())["c"] == len(AUTHOR_CORPUS_IDS)
+
+        # Each author paper RELEVANT_TO the Question (they ARE relevant, like
+        # search results).
+        async with driver.session(database=db) as s:
+            res = await s.run(
+                "MATCH (p:Paper)-[r:RELEVANT_TO]->(q {id: $qid}) "
+                "WHERE p.corpus_id IN $cids RETURN count(r) AS c",
+                qid=question_id, cids=AUTHOR_CORPUS_IDS,
+            )
+            assert (await res.single())["c"] == len(AUTHOR_CORPUS_IDS)
+
+        # Papers are REFERENCE ENTITIES: NO author paper carries WAS_GENERATED_BY.
+        async with driver.session(database=db) as s:
+            res = await s.run(
+                "MATCH (p:Paper)-[r:WAS_GENERATED_BY]->(x:Execution {id: $xid}) "
+                "WHERE p.corpus_id IN $cids RETURN count(r) AS c",
+                xid=exec_id, cids=AUTHOR_CORPUS_IDS,
+            )
+            assert (await res.single())["c"] == 0
+
+        # Each author paper WAS_DERIVED_FROM the raw Dataset (its lineage).
+        assert report1.artifact and report1.artifact.startswith("D-")
+        async with driver.session(database=db) as s:
+            res = await s.run(
+                "MATCH (p:Paper)-[r:WAS_DERIVED_FROM]->(d:Dataset {id: $aid}) "
+                "WHERE p.corpus_id IN $cids RETURN count(r) AS c",
+                aid=report1.artifact, cids=AUTHOR_CORPUS_IDS,
+            )
+            assert (await res.single())["c"] == len(AUTHOR_CORPUS_IDS)
+
+        # Input-side provenance: Execution -[USED]-> the Question.
+        async with driver.session(database=db) as s:
+            res = await s.run(
+                "MATCH (x:Execution {id: $xid})-[r:USED]->(q {id: $qid}) "
+                "RETURN count(r) AS c",
+                xid=exec_id, qid=question_id,
+            )
+            assert (await res.single())["c"] == 1
+
+        # --- Second ingest of the SAME artifact: idempotent ---
+        report2 = await ingest_semantic_scholar(
+            doc,
+            link_to=question_id,
+            config=e2e_config,
+            artifact_path=str(artifact_path),
+            used_inputs=[question_id],
+        )
+        await self._tag_all(e2e_config, report2)
+        assert report2.execution_id == exec_id
+        assert report2.created == 0
+        assert report2.deduped == len(AUTHOR_CORPUS_IDS)
+        assert report2.used == 0
+        # RELEVANT_TO not duplicated (link_once).
+        async with driver.session(database=db) as s:
+            res = await s.run(
+                "MATCH (p:Paper)-[r:RELEVANT_TO]->(q {id: $qid}) "
+                "WHERE p.corpus_id IN $cids RETURN count(r) AS c",
+                qid=question_id, cids=AUTHOR_CORPUS_IDS,
+            )
+            assert (await res.single())["c"] == len(AUTHOR_CORPUS_IDS)

--- a/wheeler/_data/commands/asta-scholar.md
+++ b/wheeler/_data/commands/asta-scholar.md
@@ -1,6 +1,6 @@
 ---
 name: wh:asta-scholar
-description: Use when the user wants to query Semantic Scholar via Asta (paper lookup, search, citations, or snippet search) and ingest the results into the Wheeler knowledge graph
+description: Use when the user wants to query Semantic Scholar via Asta (paper lookup, search, citations, snippet search, or an author's papers) and ingest the results into the Wheeler knowledge graph
 argument-hint: "[query, paper id, or DOI]"
 allowed-tools:
   - Read
@@ -16,12 +16,13 @@ allowed-tools:
 
 You are Wheeler, querying Semantic Scholar through the Asta CLI and marshalling the results into the knowledge graph. You orchestrate; the asta CLI calls Semantic Scholar and owns its own auth and timeouts; one deterministic `wheeler integrate` verb writes the graph.
 
-Semantic Scholar has four sub-queries. The ingest auto-detects which one from the artifact shape, so you only pick the right CLI call:
+Semantic Scholar has five sub-queries. The ingest auto-detects which one from the artifact shape, so you only pick the right CLI call:
 
 - `get`: one paper by id or DOI.
 - `search`: a relevance-ranked paper list for a query.
 - `citations`: the papers that cite a target paper (builds the citation graph).
 - `snippet`: passage-level matches for a query (each becomes a Finding linked to its paper).
+- `author`: an author's papers by author id (each becomes a Paper; the queried author is recorded on the run).
 
 ## Preflight
 
@@ -66,6 +67,15 @@ asta papers snippet "<query>" --fields corpusId,title,authors --limit <N> > /tmp
 wheeler integrate ingest semantic_scholar /tmp/asta-s2.json --link-to <Q- or PL- id> --used <Q- or PL- id>
 ```
 
+### Author's papers
+
+Fetch one author's papers by author id. Each becomes a Paper (`RELEVANT_TO` the link target, like search results); the queried author (id, name, paperCount, citationCount, hIndex) is stamped on the run Execution so the run is queryable by author. Request `corpusId` on the nested papers so they dedupe across services:
+
+```
+asta papers author <authorId> --fields corpusId,title,authors,year,venue,citationCount > /tmp/asta-s2.json
+wheeler integrate ingest semantic_scholar /tmp/asta-s2.json --link-to <Q- or PL- id> --used <Q- or PL- id>
+```
+
 If any CLI command exits non-zero, FIRST record the failed attempt so it is not silently lost (the failsafe: the external job is an Execution, and a failed one must be visible, not absent):
 
 ```
@@ -85,4 +95,4 @@ The ingest is structurally complete (each result `USED` the request inputs, snip
 
 ## Report
 
-Relay the printed summary (`created`, `deduped`, `linked`, `skipped`, the run Execution id, and the new node ids) to the user in one or two sentences. For a citations run, note that the citing papers now link `CITES` the target so the citation graph is queryable. For snippet runs, note the passage-level Findings (`artifact_type=snippet`) are linked `APPEARS_IN` their papers. Do not editorialize the science: the records are now in the graph, queryable by `corpus_id` and by their parked `custom_*` scalars. Never use em dashes.
+Relay the printed summary (`created`, `deduped`, `linked`, `skipped`, the run Execution id, and the new node ids) to the user in one or two sentences. For a citations run, note that the citing papers now link `CITES` the target so the citation graph is queryable. For snippet runs, note the passage-level Findings (`artifact_type=snippet`) are linked `APPEARS_IN` their papers. For an author run, note the author's papers are now in the graph and the run Execution carries the queried author (queryable as `custom_author_id` / `custom_author_name`). Do not editorialize the science: the records are now in the graph, queryable by `corpus_id` and by their parked `custom_*` scalars. Never use em dashes.

--- a/wheeler/integrations/asta/semantic_scholar.py
+++ b/wheeler/integrations/asta/semantic_scholar.py
@@ -15,7 +15,7 @@ the same cached backend the dispatch path uses, and reuse the shared helpers in
 the corpus_id normalization in ``schemas.py``.
 
 REAL Semantic Scholar REST output shapes (not A2A), captured live. The parser
-AUTO-DETECTS the sub-kind by keys, since all four are distinguishable:
+AUTO-DETECTS the sub-kind by keys, since all five are distinguishable:
 
   - ``get``: a single paper dict ``{paperId, title, venue, year, citationCount,
     url, openAccessPdf, publicationDate, authors:[{name, authorId}], abstract}``.
@@ -33,6 +33,18 @@ AUTO-DETECTS the sub-kind by keys, since all four are distinguishable:
   - ``snippet``: ``{data:[{paper:{corpusId, title, ...}, score, snippet:{text,
     snippetKind, ...}}], retrievalVersion}``. Detected by ``data[].snippet`` and
     a top-level ``retrievalVersion``. snippet-search DOES carry ``paper.corpusId``.
+  - ``author``: an author profile ``{authorId, name, paperCount, citationCount,
+    hIndex, affiliations, papers:[paper...]}`` from ``asta papers author
+    <authorId>``. Detected by a top-level ``authorId`` (the author endpoint) with
+    NO top-level ``paperId`` (which marks a single-paper ``get``). The author's
+    papers parse through the same paper path; they may instead arrive under
+    ``data`` (the ``/author/{id}/papers`` endpoint), which is also accepted.
+    NOTE: unlike the other four sub-shapes (captured from a live run), this
+    author shape is INFERRED from the documented S2 author-endpoint family, not
+    yet captured from a real ``asta papers author`` run. The parser is defensive
+    (missing keys are skipped, both ``papers`` and ``data`` containers accepted),
+    but VERIFY against one real capture and adjust the key names if the CLI
+    flattens or renames them. See the matching note on the test fixture.
 
 MAPPING (service = ``asta:semantic-scholar``):
   - get / search -> Paper nodes (dedupe by corpus_id when present, else a stable
@@ -52,6 +64,15 @@ MAPPING (service = ``asta:semantic-scholar``):
     confidence=score, title=short) -[APPEARS_IN]-> its Paper; the paper -> Paper
     node (corpusId present). Snippet Findings dedupe on a content hash so
     re-ingest is a no-op.
+  - author -> the author's papers become Paper nodes (REUSE the get/search path,
+    corpus_id dedupe), each RELEVANT_TO the link target (the author's papers ARE
+    relevant to the question that prompted the lookup, like search results). The
+    queried-author scalars (authorId, name, paperCount, citationCount, hIndex,
+    affiliations) are stamped onto the run Execution's custom bag
+    (``custom_author_id`` / ``custom_author_name`` / ...), NOT as a new node
+    type: the author dimension stays queryable on the run, and each paper already
+    carries the author in its ``authors`` field. No Author node type is created
+    (Papers remain reference entities; no WAS_GENERATED_BY).
   - raw output -> a Dataset node (structured reference records: data-ish is a
     Dataset, unlike Theorizer synthesis = Document), service-tagged, saved
     durably to ``.wheeler/asta/raw/asta-semantic-scholar/<sha>.json``. S2 has no
@@ -164,17 +185,35 @@ class S2Citation:
 
 
 @dataclass
+class S2Author:
+    """The queried author's profile from an ``asta papers author`` run.
+
+    The author dimension is stamped onto the run Execution (NOT a new node type);
+    ``custom`` holds the queryable scalars (``author_id`` / ``author_name`` /
+    ``author_paper_count`` / ...). The author's papers are parsed separately into
+    ``S2Parsed.papers`` and bucket like search results.
+    """
+
+    author_id: str
+    name: str
+    custom: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
 class S2Parsed:
     """The auto-detected, normalized result of parsing one S2 artifact.
 
-    ``sub_kind`` is one of get | search | citations | snippet | unknown.
-    Exactly one of the record lists is populated per sub_kind.
+    ``sub_kind`` is one of get | search | citations | snippet | author | unknown.
+    For get / search / author the ``papers`` list is populated (an author run
+    additionally sets ``author``); citations populates ``citations``; snippet
+    populates ``snippets``.
     """
 
     sub_kind: str
     papers: list[S2Paper] = field(default_factory=list)
     citations: list[S2Citation] = field(default_factory=list)
     snippets: list[S2Snippet] = field(default_factory=list)
+    author: S2Author | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -332,6 +371,45 @@ def _parse_paper(paper: Any) -> S2Paper | None:
     )
 
 
+# Scalar author-profile fields parked onto the run Execution's custom bag. Each
+# maps an S2 author key to the custom_<key> name the backend stores (namespaced
+# with author_ so it never collides with a paper scalar on the same node).
+_AUTHOR_CUSTOM_SCALAR_KEYS: tuple[tuple[str, str], ...] = (
+    ("paperCount", "author_paper_count"),
+    ("citationCount", "author_citation_count"),
+    ("hIndex", "author_h_index"),
+    ("url", "author_url"),
+    ("homepage", "author_homepage"),
+)
+
+
+def _parse_author(doc: dict[str, Any]) -> S2Author:
+    """Parse the author-profile scalars from an ``asta papers author`` doc.
+
+    Defensive: missing keys are simply absent from the custom bag. The author id
+    and name are also mirrored into custom (``author_id`` / ``author_name``) so
+    the run Execution is queryable by either. ``affiliations`` is a list of
+    strings, joined to one scalar so it stays queryable as a flat prop.
+    """
+    author_id = _as_str(doc.get("authorId"))
+    name = _as_str(doc.get("name"))
+    custom: dict[str, Any] = {}
+    if author_id:
+        custom["author_id"] = author_id
+    if name:
+        custom["author_name"] = name
+    for src_key, dst_key in _AUTHOR_CUSTOM_SCALAR_KEYS:
+        val = _scalar_or_none(doc.get(src_key))
+        if val is not None and val != "":
+            custom[dst_key] = val
+    aff = doc.get("affiliations")
+    if isinstance(aff, list):
+        names = [str(a) for a in aff if isinstance(a, (str, int, float)) and str(a)]
+        if names:
+            custom["author_affiliations"] = ", ".join(names)
+    return S2Author(author_id=author_id, name=name, custom=custom)
+
+
 # ---------------------------------------------------------------------------
 # Auto-detect the sub-kind
 # ---------------------------------------------------------------------------
@@ -340,14 +418,18 @@ def _parse_paper(paper: Any) -> S2Paper | None:
 def _detect_sub_kind(doc: dict[str, Any]) -> str:
     """Classify an S2 REST doc into get | search | citations | snippet.
 
-    The four sub-shapes are distinguishable by keys:
+    The five sub-shapes are distinguishable by keys:
       - snippet:   ``retrievalVersion`` present, or ANY ``data[i].snippet``.
       - citations: ANY ``data[i]`` is a dict carrying a ``citingPaper`` KEY
                    (whether its value is a dict, ``null``, or absent-but-present).
-      - search:    ``total`` present alongside a ``data`` list (and not the two
+      - author:    a top-level ``authorId`` (the author endpoint) with NO
+                   top-level ``paperId``. Checked BEFORE the generic ``data``-list
+                   shapes so an author profile whose papers arrive under ``data``
+                   is not misread as a search.
+      - search:    ``total`` present alongside a ``data`` list (and not the three
                    above, which also carry a ``data`` list).
       - get:       a top-level ``paperId`` (a single paper dict).
-    Order matters: snippet and citations are checked before the generic
+    Order matters: snippet, citations, and author are checked before the generic
     ``data``-list shapes so they are not misread as a search.
 
     Detection SCANS the whole ``data`` list rather than trusting ``data[0]``: a
@@ -366,6 +448,8 @@ def _detect_sub_kind(doc: dict[str, Any]) -> str:
         return "snippet"
     if any("citingPaper" in e for e in entries):
         return "citations"
+    if "authorId" in doc and "paperId" not in doc:
+        return "author"
     if "total" in doc and isinstance(data, list):
         return "search"
     if "paperId" in doc:
@@ -445,6 +529,22 @@ def parse_semantic_scholar(doc: Any) -> S2Parsed:
                     )
                 )
         return S2Parsed(sub_kind="snippet", snippets=snippets)
+
+    if sub_kind == "author":
+        author = _parse_author(doc)
+        # The author's papers are under ``papers`` (the author-profile endpoint),
+        # else ``data`` (the /author/{id}/papers listing). Each parses through the
+        # same paper path so corpus_id dedupe + the custom bag carry over.
+        papers_raw = doc.get("papers")
+        if not isinstance(papers_raw, list):
+            data = doc.get("data")
+            papers_raw = data if isinstance(data, list) else []
+        papers = []
+        for entry in papers_raw:
+            record = _parse_paper(entry)
+            if record is not None:
+                papers.append(record)
+        return S2Parsed(sub_kind="author", papers=papers, author=author)
 
     logger.warning("parse_semantic_scholar: unrecognized S2 shape, nothing to ingest")
     return S2Parsed(sub_kind="unknown")
@@ -648,7 +748,7 @@ async def ingest_semantic_scholar(
 
     Args:
         doc: The S2 REST artifact dict (auto-detected: get / search / citations /
-            snippet).
+            snippet / author).
         link_to: Optional node id (Plan/Question) that relevant results link to
             via RELEVANT_TO. Applied to get / search / snippet results (those ARE
             relevant to the question). NOT applied to the ``citations`` sub-kind:
@@ -787,7 +887,7 @@ async def ingest_semantic_scholar(
     # bucket. (An undetectable shape is a parse limitation, not a remote-job
     # failure, so the run is honestly "completed", not "failed".)
     if parsed.sub_kind == "unknown" or not (
-        parsed.papers or parsed.citations or parsed.snippets
+        parsed.papers or parsed.citations or parsed.snippets or parsed.author
     ):
         logger.warning(
             "ingest_semantic_scholar: nothing parseable in completed artifact "
@@ -802,6 +902,35 @@ async def ingest_semantic_scholar(
         seen_papers: dict[str, str] = {}
 
         if parsed.sub_kind in ("get", "search"):
+            for record in parsed.papers:
+                await _ingest_paper(
+                    backend=backend,
+                    execute_tool=execute_tool,
+                    config=config,
+                    record=record,
+                    session_id=session_id,
+                    artifact_id=artifact_id,
+                    link_to=link_to,
+                    paper_index=paper_index,
+                    fallback_index=fallback_index,
+                    seen_papers=seen_papers,
+                    report=report,
+                )
+
+        elif parsed.sub_kind == "author":
+            # Stamp the queried-author scalars onto the run Execution so the run
+            # is queryable by author (custom_author_id / custom_author_name / ...).
+            # No Author node type is created: the author dimension lives on the
+            # Execution, and each paper already names the author in its own
+            # ``authors`` field. Best-effort (a stamp failure never aborts ingest).
+            if exec_id and parsed.author is not None and parsed.author.custom:
+                await _stamp_custom(
+                    execute_tool, config, exec_id, parsed.author.custom
+                )
+            # The author's papers bucket exactly like search results: Paper nodes
+            # (corpus_id dedupe), RELEVANT_TO the link target (they ARE relevant
+            # to the question that prompted the lookup), WAS_DERIVED_FROM the raw
+            # Dataset. Papers stay reference entities (no WAS_GENERATED_BY).
             for record in parsed.papers:
                 await _ingest_paper(
                     backend=backend,


### PR DESCRIPTION
Extend the existing asta:semantic-scholar adapter with a fifth auto-detected
sub-kind, `author` (asta papers author <authorId>): an author profile whose
papers bucket as Paper nodes via the existing get/search path (corpus_id
dedupe), each RELEVANT_TO the link target, while the queried-author scalars
(authorId, name, paperCount, citationCount, hIndex, affiliations) are stamped
onto the run Execution's custom bag rather than a new node type.

Because the run routes through the same ingest_semantic_scholar path, it is
provenance-complete by construction: Execution -[USED]-> inputs, papers
WAS_DERIVED_FROM the raw Dataset (Papers stay reference entities, no
WAS_GENERATED_BY), the external-call failsafe (honest Execution status), and
the act's post-ingest semantic-wiring step all carry over. Detection keys on a
top-level authorId with no top-level paperId; papers are accepted under either
`papers` or `data`.

The /wh:asta-scholar act gains the author sub-query (CLI + ingest + report
note); the _data mirror is regenerated in sync.

The author payload shape is INFERRED from the documented S2 author-endpoint
family, not a live capture (the asta CLI is unavailable here). The parser is
defensive and the fixture/parser are marked for verification against one real
`asta papers author` run; key-name drift degrades gracefully.

Tests: 6 new parse-unit tests (detection, author-meta lift, papers-under-data,
profile-only, get-not-misread) plus a live-Neo4j e2e asserting the s2-author
Execution stamp, RELEVANT_TO + WAS_DERIVED_FROM edges, no WAS_GENERATED_BY on
papers, USED input provenance, and idempotent re-ingest. Service auditor: 0
blockers / 0 warnings.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01314e6vF3ohsdX1huJBEZ5n