### PR TITLE
Research dashboard: live, interactive overview of the knowledge graph

### DIFF
--- a/tests/test_dashboard_cli.py
+++ b/tests/test_dashboard_cli.py
@@ -10,7 +10,6 @@ from types import SimpleNamespace
 
 from typer.testing import CliRunner
 
-import wheeler.dashboard as dashboard_pkg
 import wheeler.tools.cli as cli
 
 runner = CliRunner()
@@ -60,44 +59,45 @@ def test_dashboard_note_set_and_clear(monkeypatch, tmp_path):
     assert "headline result" not in notes_file.read_text()
 
 
-def test_dashboard_render_writes_file(monkeypatch, tmp_path):
+def test_dashboard_serves_live(monkeypatch, tmp_path):
     _patch_config(monkeypatch, tmp_path)
+    import wheeler.dashboard.serve as serve_mod
 
-    async def fake_gather(config, *, limit=12, plan_id=None):
-        return {
-            "schema_version": 1,
-            "title": "Wheeler Research Dashboard",
-            "generated": "2026-06-20T14:00:00Z",
-            "project": "",
-            "meta": {"project_root": str(tmp_path)},
-            "counts": {"Finding": 0, "OpenQuestion": 0, "Plan": 0},
-            "hero": [],
-            "questions": [],
-            "plans": [],
-            "results": [],
-            "figures": [],
-            "notes": {},
-        }
+    calls = {}
 
-    monkeypatch.setattr(dashboard_pkg, "gather_dashboard_data", fake_gather)
+    def fake_render_live(config, limit=12):
+        return "<!DOCTYPE html><html></html>"
 
-    out = tmp_path / "dash.html"
-    r = runner.invoke(cli.app, ["dashboard", "-o", str(out)])
+    def fake_serve(config, *, host, port, limit, open_browser, on_start=None):
+        calls["served"] = (host, port, limit)
+        if on_start:
+            on_start(f"http://{host}:{port}/")
+
+    monkeypatch.setattr(serve_mod, "render_live", fake_render_live)
+    monkeypatch.setattr(serve_mod, "serve", fake_serve)
+
+    r = runner.invoke(cli.app, ["dashboard", "--no-open", "--port", "0"])
     assert r.exit_code == 0, r.stdout
-    assert out.exists()
-    assert "<!DOCTYPE html>" in out.read_text()
+    assert calls["served"][1] == 0
+    assert "live at" in r.stdout.lower()
 
 
-def test_dashboard_render_neo4j_down_writes_nothing(monkeypatch, tmp_path):
+def test_dashboard_neo4j_down_does_not_serve(monkeypatch, tmp_path):
     _patch_config(monkeypatch, tmp_path)
+    import wheeler.dashboard.serve as serve_mod
 
-    async def boom(config, *, limit=12, plan_id=None):
+    def boom(config, limit=12):
         raise RuntimeError("connection refused")
 
-    monkeypatch.setattr(dashboard_pkg, "gather_dashboard_data", boom)
+    served = {"called": False}
 
-    out = tmp_path / "dash.html"
-    r = runner.invoke(cli.app, ["dashboard", "-o", str(out)])
+    def fake_serve(*a, **k):
+        served["called"] = True
+
+    monkeypatch.setattr(serve_mod, "render_live", boom)
+    monkeypatch.setattr(serve_mod, "serve", fake_serve)
+
+    r = runner.invoke(cli.app, ["dashboard", "--no-open"])
     assert r.exit_code == 1
-    assert not out.exists()
+    assert served["called"] is False
     assert "Neo4j" in r.stdout or "graph" in r.stdout

--- a/tests/test_dashboard_cli.py
+++ b/tests/test_dashboard_cli.py
@@ -5,7 +5,6 @@ read is monkeypatched so the wiring is testable offline.
 """
 from __future__ import annotations
 
-from pathlib import Path
 from types import SimpleNamespace
 
 from typer.testing import CliRunner
@@ -43,20 +42,34 @@ def test_dashboard_pin_unpin_pins(monkeypatch, tmp_path):
     assert "No pinned figures" in r.stdout
 
 
-def test_dashboard_note_set_and_clear(monkeypatch, tmp_path):
+def test_dashboard_note_records_graph_note(monkeypatch, tmp_path):
     _patch_config(monkeypatch, tmp_path)
+    import wheeler.dashboard.gather as g
 
+    captured = {}
+
+    async def fake_record(config, figure_id, text):
+        captured["args"] = (figure_id, text)
+        return "N-7"
+
+    monkeypatch.setattr(g, "record_figure_note", fake_record)
     r = runner.invoke(cli.app, ["dashboard", "note", "F-9", "headline result"])
-    assert r.exit_code == 0
-    notes_file = Path(tmp_path) / ".wheeler" / "dashboard" / "notes.json"
-    assert "headline result" in notes_file.read_text()
+    assert r.exit_code == 0, r.stdout
+    assert captured["args"] == ("F-9", "headline result")
+    assert "N-7" in r.stdout and "F-9" in r.stdout
 
+
+def test_dashboard_notes_lists_graph_notes(monkeypatch, tmp_path):
+    _patch_config(monkeypatch, tmp_path)
+    import wheeler.dashboard.gather as g
+
+    async def fake_list(config):
+        return [{"nid": "N-1", "fid": "F-9", "content": "a durable note"}]
+
+    monkeypatch.setattr(g, "list_all_figure_notes", fake_list)
     r = runner.invoke(cli.app, ["dashboard", "notes"])
-    assert "F-9" in r.stdout
-
-    r = runner.invoke(cli.app, ["dashboard", "note", "F-9"])
     assert r.exit_code == 0
-    assert "headline result" not in notes_file.read_text()
+    assert "N-1" in r.stdout and "F-9" in r.stdout
 
 
 def test_dashboard_serves_live(monkeypatch, tmp_path):

--- a/tests/test_dashboard_cli.py
+++ b/tests/test_dashboard_cli.py
@@ -1,0 +1,103 @@
+"""Typer CliRunner tests for the `wheeler dashboard` command surface.
+
+Pin/unpin/note touch only local files (no Neo4j). The render callback's graph
+read is monkeypatched so the wiring is testable offline.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from typer.testing import CliRunner
+
+import wheeler.dashboard as dashboard_pkg
+import wheeler.tools.cli as cli
+
+runner = CliRunner()
+
+
+def _patch_config(monkeypatch, tmp_path, ptag=""):
+    config = SimpleNamespace(
+        project_root=str(tmp_path),
+        knowledge_path="knowledge",
+        neo4j=SimpleNamespace(project_tag=ptag),
+    )
+    monkeypatch.setattr(cli, "load_config", lambda *a, **k: config)
+    return config
+
+
+def test_dashboard_pin_unpin_pins(monkeypatch, tmp_path):
+    _patch_config(monkeypatch, tmp_path)
+
+    r = runner.invoke(cli.app, ["dashboard", "pin", "F-1234"])
+    assert r.exit_code == 0
+    assert "Pinned" in r.stdout
+
+    r = runner.invoke(cli.app, ["dashboard", "pins"])
+    assert "F-1234" in r.stdout
+
+    r = runner.invoke(cli.app, ["dashboard", "unpin", "F-1234"])
+    assert r.exit_code == 0
+    assert "Unpinned" in r.stdout
+
+    r = runner.invoke(cli.app, ["dashboard", "pins"])
+    assert "No pinned figures" in r.stdout
+
+
+def test_dashboard_note_set_and_clear(monkeypatch, tmp_path):
+    _patch_config(monkeypatch, tmp_path)
+
+    r = runner.invoke(cli.app, ["dashboard", "note", "F-9", "headline result"])
+    assert r.exit_code == 0
+    notes_file = Path(tmp_path) / ".wheeler" / "dashboard" / "notes.json"
+    assert "headline result" in notes_file.read_text()
+
+    r = runner.invoke(cli.app, ["dashboard", "notes"])
+    assert "F-9" in r.stdout
+
+    r = runner.invoke(cli.app, ["dashboard", "note", "F-9"])
+    assert r.exit_code == 0
+    assert "headline result" not in notes_file.read_text()
+
+
+def test_dashboard_render_writes_file(monkeypatch, tmp_path):
+    _patch_config(monkeypatch, tmp_path)
+
+    async def fake_gather(config, *, limit=12, plan_id=None):
+        return {
+            "schema_version": 1,
+            "title": "Wheeler Research Dashboard",
+            "generated": "2026-06-20T14:00:00Z",
+            "project": "",
+            "meta": {"project_root": str(tmp_path)},
+            "counts": {"Finding": 0, "OpenQuestion": 0, "Plan": 0},
+            "hero": [],
+            "questions": [],
+            "plans": [],
+            "results": [],
+            "figures": [],
+            "notes": {},
+        }
+
+    monkeypatch.setattr(dashboard_pkg, "gather_dashboard_data", fake_gather)
+
+    out = tmp_path / "dash.html"
+    r = runner.invoke(cli.app, ["dashboard", "-o", str(out)])
+    assert r.exit_code == 0, r.stdout
+    assert out.exists()
+    assert "<!DOCTYPE html>" in out.read_text()
+
+
+def test_dashboard_render_neo4j_down_writes_nothing(monkeypatch, tmp_path):
+    _patch_config(monkeypatch, tmp_path)
+
+    async def boom(config, *, limit=12, plan_id=None):
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(dashboard_pkg, "gather_dashboard_data", boom)
+
+    out = tmp_path / "dash.html"
+    r = runner.invoke(cli.app, ["dashboard", "-o", str(out)])
+    assert r.exit_code == 1
+    assert not out.exists()
+    assert "Neo4j" in r.stdout or "graph" in r.stdout

--- a/tests/test_dashboard_gather.py
+++ b/tests/test_dashboard_gather.py
@@ -1,0 +1,99 @@
+"""Tests for the dashboard gather helpers (pure functions + local state I/O).
+
+These do not touch Neo4j. The async gather_dashboard_data path is exercised by
+the optional live smoke test.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from wheeler.dashboard.gather import (
+    attach_notes,
+    rank_results,
+    read_notes,
+    read_pins,
+    select_figures,
+    select_open_plans,
+    split_pinned,
+    write_notes,
+    write_pins,
+)
+
+
+def _config(tmp_path, ptag=""):
+    return SimpleNamespace(
+        project_root=str(tmp_path),
+        knowledge_path="knowledge",
+        neo4j=SimpleNamespace(project_tag=ptag),
+    )
+
+
+def test_rank_results_orders_fresh_high_confidence_first():
+    findings = [
+        {"id": "F-a", "confidence": 0.2, "stability": 0.5, "stale": False},
+        {"id": "F-b", "confidence": 0.9, "stability": 0.5, "stale": False},
+        {"id": "F-c", "confidence": 0.9, "stability": 0.5, "stale": True},
+    ]
+    ranked = [f["id"] for f in rank_results(findings)]
+    assert ranked == ["F-b", "F-a", "F-c"]  # stale sinks; high conf rises
+
+
+def test_select_open_plans_filters_status():
+    plans = [
+        {"id": "PL-1", "status": "in-progress"},
+        {"id": "PL-2", "status": "completed"},
+        {"id": "PL-3", "status": "approved"},
+        {"id": "PL-4", "status": "draft"},
+    ]
+    assert [p["id"] for p in select_open_plans(plans)] == ["PL-1", "PL-3"]
+
+
+def test_select_figures_requires_type_and_existing_path(tmp_path):
+    (tmp_path / "real.png").write_bytes(b"x")
+    findings = [
+        {"id": "F-1", "artifact_type": "figure", "path": "real.png"},
+        {"id": "F-2", "artifact_type": "figure", "path": "missing.png"},
+        {"id": "F-3", "artifact_type": "number", "path": "real.png"},
+        {"id": "F-4", "artifact_type": "figure", "path": ""},
+    ]
+    assert [f["id"] for f in select_figures(findings, tmp_path)] == ["F-1"]
+
+
+def test_split_pinned_preserves_pin_order_and_drops_dangling():
+    figures = [{"id": "F-1"}, {"id": "F-2"}, {"id": "F-3"}]
+    hero, rest = split_pinned(figures, ["F-3", "F-ghost", "F-1"])
+    assert [f["id"] for f in hero] == ["F-3", "F-1"]
+    assert [f["id"] for f in rest] == ["F-2"]
+
+
+def test_attach_notes_in_place():
+    figs = [{"id": "F-1"}, {"id": "F-2"}]
+    attach_notes(figs, {"F-1": "hello"})
+    assert figs[0]["note"] == "hello"
+    assert "note" not in figs[1]
+
+
+def test_pins_roundtrip_atomic(tmp_path):
+    config = _config(tmp_path, ptag="proj")
+    assert read_pins(config) == []
+    write_pins(config, ["F-1", "F-2"])
+    assert read_pins(config) == ["F-1", "F-2"]
+    pins_file = Path(tmp_path) / ".wheeler" / "dashboard" / "pins.json"
+    assert pins_file.exists()
+    assert '"project_tag": "proj"' in pins_file.read_text()
+
+
+def test_notes_roundtrip(tmp_path):
+    config = _config(tmp_path)
+    assert read_notes(config) == {}
+    write_notes(config, {"F-1": "a note"})
+    assert read_notes(config) == {"F-1": "a note"}
+
+
+def test_read_state_tolerates_corrupt_file(tmp_path):
+    config = _config(tmp_path)
+    d = Path(tmp_path) / ".wheeler" / "dashboard"
+    d.mkdir(parents=True)
+    (d / "pins.json").write_text("{ not json", encoding="utf-8")
+    assert read_pins(config) == []

--- a/tests/test_dashboard_gather.py
+++ b/tests/test_dashboard_gather.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from wheeler.dashboard.gather import (
+    _figure_from_id,
     attach_notes,
     rank_results,
     read_notes,
@@ -67,11 +68,53 @@ def test_split_pinned_preserves_pin_order_and_drops_dangling():
     assert [f["id"] for f in rest] == ["F-2"]
 
 
-def test_attach_notes_in_place():
+def test_attach_notes_sets_note():
     figs = [{"id": "F-1"}, {"id": "F-2"}]
     attach_notes(figs, {"F-1": "hello"})
     assert figs[0]["note"] == "hello"
     assert "note" not in figs[1]
+
+
+def test_attach_notes_does_not_alias_results():
+    # The same finding dict can sit in both the figures list and the results
+    # list; attaching a note must not mutate the shared object in results.
+    shared = {"id": "F-1", "artifact_type": "figure"}
+    figures = [shared]
+    results = [shared]
+    attach_notes(figures, {"F-1": "a note"})
+    assert figures[0]["note"] == "a note"
+    assert "note" not in results[0]  # results untouched
+    assert results[0] is shared
+
+
+def test_read_pins_rejects_other_project_tag(tmp_path):
+    write_pins(_config(tmp_path, ptag="alpha"), ["F-1"])
+    # Same tag: visible.
+    assert read_pins(_config(tmp_path, ptag="alpha")) == ["F-1"]
+    # Different tag: hidden (do not render another namespace's pins).
+    assert read_pins(_config(tmp_path, ptag="beta")) == []
+
+
+def test_read_pins_legacy_file_without_tag(tmp_path):
+    d = Path(tmp_path) / ".wheeler" / "dashboard"
+    d.mkdir(parents=True)
+    (d / "pins.json").write_text('{"pins": ["F-9"]}', encoding="utf-8")
+    assert read_pins(_config(tmp_path, ptag="anything")) == ["F-9"]
+
+
+def test_figure_from_id_loads_pinned_figure(tmp_path):
+    kp = tmp_path / "knowledge"
+    kp.mkdir()
+    (tmp_path / "fig.png").write_bytes(b"x")
+    (kp / "F-old.json").write_text(
+        '{"id": "F-old", "type": "Finding", "artifact_type": "figure", '
+        '"path": "fig.png", "title": "Old fig"}',
+        encoding="utf-8",
+    )
+    f = _figure_from_id(kp, "F-old", Path(tmp_path))
+    assert f is not None and f["id"] == "F-old" and f["title"] == "Old fig"
+    # A non-figure or missing-file id returns None.
+    assert _figure_from_id(kp, "F-missing", Path(tmp_path)) is None
 
 
 def test_pins_roundtrip_atomic(tmp_path):

--- a/tests/test_dashboard_gather.py
+++ b/tests/test_dashboard_gather.py
@@ -10,14 +10,13 @@ from types import SimpleNamespace
 
 from wheeler.dashboard.gather import (
     _figure_from_id,
-    attach_notes,
+    attach_graph_notes,
     rank_results,
-    read_notes,
     read_pins,
+    record_figure_note,
     select_figures,
     select_open_plans,
     split_pinned,
-    write_notes,
     write_pins,
 )
 
@@ -68,23 +67,51 @@ def test_split_pinned_preserves_pin_order_and_drops_dangling():
     assert [f["id"] for f in rest] == ["F-2"]
 
 
-def test_attach_notes_sets_note():
+def test_attach_graph_notes_sets_newest_and_id():
     figs = [{"id": "F-1"}, {"id": "F-2"}]
-    attach_notes(figs, {"F-1": "hello"})
-    assert figs[0]["note"] == "hello"
+    rows = [
+        {"fid": "F-1", "nid": "N-new", "content": "newest"},
+        {"fid": "F-1", "nid": "N-old", "content": "older"},  # rows sorted date DESC
+    ]
+    attach_graph_notes(figs, rows)
+    assert figs[0]["note"] == "newest" and figs[0]["note_id"] == "N-new"
     assert "note" not in figs[1]
 
 
-def test_attach_notes_does_not_alias_results():
+def test_attach_graph_notes_does_not_alias_results():
     # The same finding dict can sit in both the figures list and the results
     # list; attaching a note must not mutate the shared object in results.
     shared = {"id": "F-1", "artifact_type": "figure"}
     figures = [shared]
     results = [shared]
-    attach_notes(figures, {"F-1": "a note"})
+    attach_graph_notes(figures, [{"fid": "F-1", "nid": "N-1", "content": "a note"}])
     assert figures[0]["note"] == "a note"
     assert "note" not in results[0]  # results untouched
     assert results[0] is shared
+
+
+def test_record_figure_note_creates_note_and_links(monkeypatch):
+    import json as _json
+
+    import wheeler.tools.graph_tools as gt
+
+    calls = []
+
+    async def fake_execute_tool(tool, args, config):
+        calls.append((tool, args))
+        if tool == "add_note":
+            return _json.dumps({"node_id": "N-42", "status": "created"})
+        return _json.dumps({"status": "linked"})
+
+    monkeypatch.setattr(gt, "execute_tool", fake_execute_tool)
+
+    import asyncio
+
+    nid = asyncio.run(record_figure_note(object(), "F-9", "a durable note"))
+    assert nid == "N-42"
+    assert calls[0][0] == "add_note" and calls[0][1]["content"] == "a durable note"
+    assert calls[1][0] == "link_nodes"
+    assert calls[1][1] == {"source_id": "N-42", "target_id": "F-9", "relationship": "RELEVANT_TO"}
 
 
 def test_read_pins_rejects_other_project_tag(tmp_path):
@@ -125,13 +152,6 @@ def test_pins_roundtrip_atomic(tmp_path):
     pins_file = Path(tmp_path) / ".wheeler" / "dashboard" / "pins.json"
     assert pins_file.exists()
     assert '"project_tag": "proj"' in pins_file.read_text()
-
-
-def test_notes_roundtrip(tmp_path):
-    config = _config(tmp_path)
-    assert read_notes(config) == {}
-    write_notes(config, {"F-1": "a note"})
-    assert read_notes(config) == {"F-1": "a note"}
 
 
 def test_read_state_tolerates_corrupt_file(tmp_path):

--- a/tests/test_dashboard_serve.py
+++ b/tests/test_dashboard_serve.py
@@ -1,0 +1,68 @@
+"""Smoke test for the live dashboard server (real socket, no Neo4j).
+
+Starts the actual ThreadingHTTPServer on an ephemeral port with ``render_live``
+monkeypatched, makes a real HTTP request, and asserts the live page comes back.
+This exercises the end-to-end serving path that ``wheeler dashboard`` uses.
+"""
+from __future__ import annotations
+
+import threading
+import urllib.request
+from types import SimpleNamespace
+
+import wheeler.dashboard.serve as serve_mod
+
+
+def _config(tmp_path):
+    return SimpleNamespace(
+        project_root=str(tmp_path),
+        knowledge_path="knowledge",
+        neo4j=SimpleNamespace(project_tag=""),
+    )
+
+
+def test_live_server_serves_rendered_page(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        serve_mod,
+        "render_live",
+        lambda config, limit=12: "<!DOCTYPE html><html><body>live dashboard</body></html>",
+    )
+
+    httpd = serve_mod.make_server(_config(tmp_path), "127.0.0.1", 0, 12)
+    port = httpd.server_address[1]
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    try:
+        with urllib.request.urlopen(f"http://127.0.0.1:{port}/", timeout=5) as resp:
+            assert resp.status == 200
+            body = resp.read().decode("utf-8")
+        assert "<!DOCTYPE html>" in body
+        assert "live dashboard" in body
+        # favicon path is handled (no 500)
+        req = urllib.request.Request(f"http://127.0.0.1:{port}/favicon.ico")
+        with urllib.request.urlopen(req, timeout=5) as resp2:
+            assert resp2.status == 204
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+
+
+def test_live_server_renders_error_page_when_graph_down(monkeypatch, tmp_path):
+    def boom(config, limit=12):
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(serve_mod, "render_live", boom)
+    httpd = serve_mod.make_server(_config(tmp_path), "127.0.0.1", 0, 12)
+    port = httpd.server_address[1]
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    try:
+        try:
+            urllib.request.urlopen(f"http://127.0.0.1:{port}/", timeout=5)
+            raise AssertionError("expected HTTP error")
+        except urllib.error.HTTPError as e:
+            assert e.code == 503
+            assert b"could not read the graph" in e.read().lower()
+    finally:
+        httpd.shutdown()
+        httpd.server_close()

--- a/tests/test_dashboard_serve.py
+++ b/tests/test_dashboard_serve.py
@@ -47,6 +47,39 @@ def test_live_server_serves_rendered_page(monkeypatch, tmp_path):
         httpd.server_close()
 
 
+def test_render_live_invalidates_driver(monkeypatch, tmp_path):
+    # Each request runs its own asyncio.run (fresh loop); the cached Neo4j driver
+    # must be discarded afterward so the next request does not reuse a driver
+    # bound to a dead loop. Assert invalidate is called, even on error.
+    import wheeler.dashboard as dashboard_pkg
+    import wheeler.graph.driver as driver_mod
+
+    calls = {"invalidated": 0}
+    monkeypatch.setattr(driver_mod, "invalidate_async_driver", lambda: calls.__setitem__("invalidated", calls["invalidated"] + 1))
+
+    async def fake_gather(config, *, limit=12, plan_id=None):
+        return {"meta": {"project_root": "."}, "generated": "2026-06-20T14:00:00Z",
+                "counts": {}, "hero": [], "questions": [], "plans": [], "results": [],
+                "figures": [], "notes": {}, "project": "", "title": "T"}
+
+    monkeypatch.setattr(dashboard_pkg, "gather_dashboard_data", fake_gather)
+
+    cfg = _config(tmp_path)
+    out = serve_mod.render_live(cfg, 5)
+    assert "<!DOCTYPE html>" in out
+    assert calls["invalidated"] == 1
+
+    async def boom(config, *, limit=12, plan_id=None):
+        raise RuntimeError("down")
+
+    monkeypatch.setattr(dashboard_pkg, "gather_dashboard_data", boom)
+    try:
+        serve_mod.render_live(cfg, 5)
+    except RuntimeError:
+        pass
+    assert calls["invalidated"] == 2  # invalidated even when gather raised
+
+
 def test_live_server_renders_error_page_when_graph_down(monkeypatch, tmp_path):
     def boom(config, limit=12):
         raise RuntimeError("connection refused")

--- a/tests/test_dashboard_slice.py
+++ b/tests/test_dashboard_slice.py
@@ -1,0 +1,132 @@
+"""End-to-end vertical slice for the dashboard.
+
+This exercises the whole render pipeline against a realistic payload, the same
+dict shape ``gather_dashboard_data`` produces (inferred from the function's
+return value): counts, hero (pinned) figures, open questions, open plans, ranked
+results, unpinned figures, and durable notes. It writes a real HTML file so the
+artifact can be opened and eyeballed, and asserts the full slice end to end:
+
+  payload  ->  render()  ->  self-contained HTML on disk
+
+It covers both figure kinds the renderer supports: a static PNG (base64 data
+URI) and an interactive HTML figure (sandboxed iframe), with one pinned as a
+hero figure and a durable note attached.
+"""
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+from wheeler.dashboard.render import render
+
+PNG_1x1 = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+)
+
+# A minimal but real standalone interactive figure (what a Plotly/Bokeh export
+# looks like in spirit: self-contained HTML with an inline script).
+INTERACTIVE_HTML = (
+    "<!doctype html><html><body>"
+    "<div id='chart'>interactive</div>"
+    "<script>document.getElementById('chart').title = 'live';</script>"
+    "</body></html>"
+)
+
+
+def _realistic_payload(root: Path) -> dict:
+    """Build the exact dict shape gather_dashboard_data returns, with real files."""
+    figdir = root / "analysis_exports" / "pilot_2026-06-20" / "figures"
+    figdir.mkdir(parents=True, exist_ok=True)
+    png = figdir / "pilot_2026-06-20_fig_A_scaling.png"
+    png.write_bytes(PNG_1x1)
+    interactive = figdir / "pilot_2026-06-20_fig_B_interactive.html"
+    interactive.write_text(INTERACTIVE_HTML, encoding="utf-8")
+
+    hero_fig = {
+        "id": "F-aaaa1111",
+        "title": "fig_A scaling curve",
+        "path": str(png.relative_to(root)),
+        "confidence": 0.86,
+        "description": "Adaptation index scales 2x with firing rate. See [F-bbbb2222].",
+        "note": "Headline figure for the pilot.",
+    }
+    interactive_fig = {
+        "id": "F-cccc3333",
+        "title": "fig_B interactive explorer",
+        "path": str(interactive.relative_to(root)),
+        "confidence": 0.72,
+        "description": "Interactive sweep across stimulus conditions.",
+    }
+    return {
+        "schema_version": 1,
+        "title": "Wheeler Research Dashboard",
+        "generated": "2026-06-20T14:00:00Z",
+        "project": "pilot",
+        "meta": {"project_root": str(root)},
+        "counts": {"Finding": 42, "OpenQuestion": 7, "Plan": 3},
+        "hero": [hero_fig],
+        "questions": [
+            {"id": "Q-1111aaaa", "question": "Does density set oscillation frequency?", "priority": 9, "tier": "generated"},
+            {"id": "Q-2222bbbb", "question": "Is the 2x scaling robust to noise [F-aaaa1111]?", "priority": 6, "tier": "generated"},
+        ],
+        "plans": [
+            {"id": "PL-3333cccc", "title": "Operating margin pilot", "status": "in-progress",
+             "path": ".plans/operating_margin_pilot.md", "updated": "2026-06-18T10:00:00Z", "tier": "generated"},
+            {"id": "PL-4444dddd", "title": "Noise robustness sweep", "status": "approved",
+             "path": ".plans/noise_sweep.md", "updated": "2026-06-15T09:00:00Z", "tier": "generated"},
+        ],
+        "results": [
+            {"id": "F-aaaa1111", "title": "fig_A scaling curve", "description": "2x scaling confirmed.",
+             "confidence": 0.86, "tier": "generated", "stale": False, "stability": 0.4},
+            {"id": "F-bbbb2222", "title": "baseline drift", "description": "Baseline drifts under 1%.",
+             "confidence": 0.6, "tier": "reference", "stale": True, "stability": 0.8},
+        ],
+        "figures": [interactive_fig],
+        "notes": {"F-aaaa1111": "Headline figure for the pilot."},
+    }
+
+
+def test_vertical_slice_renders_full_dashboard(tmp_path):
+    payload = _realistic_payload(tmp_path)
+    html, missing = render(payload)
+
+    # Nothing missing: both figure files resolved and embedded.
+    assert missing == [], missing
+
+    # All four zones + hero present and populated.
+    assert "Main Figures" in html
+    assert "Open Questions" in html and "Q-1111aaaa" in html
+    assert "Open Plans" in html and "PL-3333cccc" in html
+    assert "Major Results" in html and "F-bbbb2222" in html
+    assert "Figures" in html
+
+    # Both figure kinds embedded the right way.
+    assert "data:image/png;base64," in html          # static PNG hero
+    assert "<iframe" in html and 'sandbox="allow-scripts"' in html  # interactive
+
+    # Counts strip, project label, theme, durable note, and node badges.
+    assert "42" in html and "findings" in html
+    assert "project: pilot" in html
+    assert 'data-theme="auto"' in html
+    assert "Headline figure for the pilot." in html
+    assert 'class="node-id t-F"' in html
+
+    # Determinism: identical bytes on a second render.
+    again, _ = render(payload)
+    assert again == html
+
+    # Write the real artifact so it can be opened/inspected.
+    out = tmp_path / "dashboard.html"
+    out.write_text(html, encoding="utf-8")
+    assert out.exists() and out.stat().st_size > 2000
+
+
+if __name__ == "__main__":
+    # Manual run: emit a sample artifact next to this file for eyeballing.
+    import tempfile
+
+    d = Path(tempfile.mkdtemp())
+    html, _ = render(_realistic_payload(d))
+    out = Path("dashboard_sample.html")
+    out.write_text(html, encoding="utf-8")
+    print(f"wrote {out.resolve()}")

--- a/tests/test_dashboard_slice.py
+++ b/tests/test_dashboard_slice.py
@@ -49,6 +49,7 @@ def _realistic_payload(root: Path) -> dict:
         "confidence": 0.86,
         "description": "Adaptation index scales 2x with firing rate. See [F-bbbb2222].",
         "note": "Headline figure for the pilot.",
+        "note_id": "N-hero0001",  # provenance-tracked ResearchNote
     }
     interactive_fig = {
         "id": "F-cccc3333",
@@ -82,7 +83,6 @@ def _realistic_payload(root: Path) -> dict:
              "confidence": 0.6, "tier": "reference", "stale": True, "stability": 0.8},
         ],
         "figures": [interactive_fig],
-        "notes": {"F-aaaa1111": "Headline figure for the pilot."},
     }
 
 

--- a/tests/test_graph_tools.py
+++ b/tests/test_graph_tools.py
@@ -774,3 +774,31 @@ class TestAddDatasetMetadata:
         assert "parent_link" not in result
         assert result["status"] == "created"
         assert result["label"] == "Dataset"
+
+
+class TestOpenQuestionFiltering:
+    """query_open_questions must hide answered questions by default (wh/CLAUDE.md)."""
+
+    class _CaptureBackend:
+        def __init__(self):
+            self.query = ""
+
+        async def run_cypher(self, query, params=None):
+            self.query = query
+            return []
+
+    @pytest.mark.asyncio
+    async def test_excludes_answered_by_default(self):
+        from wheeler.tools.graph_tools.queries import query_open_questions
+
+        be = self._CaptureBackend()
+        await query_open_questions(be, {"limit": 5})
+        assert "q.status = 'open' OR q.status IS NULL" in be.query
+
+    @pytest.mark.asyncio
+    async def test_include_answered_bypasses_filter(self):
+        from wheeler.tools.graph_tools.queries import query_open_questions
+
+        be = self._CaptureBackend()
+        await query_open_questions(be, {"limit": 5, "include_answered": True})
+        assert "q.status" not in be.query

--- a/tests/test_render_dashboard.py
+++ b/tests/test_render_dashboard.py
@@ -177,8 +177,8 @@ def test_refresh_button_and_graph_provenance():
     # A refresh control that reloads the file from disk.
     assert 'id="refresh"' in html
     assert "location.reload()" in html
-    # Clear that the page is generated from the graph, with the regenerate command.
-    assert "Snapshot of the knowledge graph" in html
+    # Clear that the page is a live view of the graph, served by the command.
+    assert "Live view of the knowledge graph" in html
     assert "<code>wheeler dashboard</code>" in html
 
 

--- a/tests/test_render_dashboard.py
+++ b/tests/test_render_dashboard.py
@@ -1,0 +1,197 @@
+"""Offline, dict-driven tests for the dashboard renderer (no Neo4j needed)."""
+from __future__ import annotations
+
+import base64
+
+from wheeler.dashboard.render import (
+    alt_text,
+    embed_figure,
+    linkify_nodes,
+    node_badge,
+    render,
+)
+
+# 1x1 transparent PNG (same trick as test_render_brief.py).
+PNG_1x1 = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+)
+
+
+def _base_data(**over):
+    data = {
+        "schema_version": 1,
+        "title": "Test Dashboard",
+        "generated": "2026-06-20T14:00:00Z",
+        "project": "",
+        "meta": {"project_root": "."},
+        "counts": {"Finding": 3, "OpenQuestion": 2, "Plan": 1},
+        "hero": [],
+        "questions": [],
+        "plans": [],
+        "results": [],
+        "figures": [],
+        "notes": {},
+    }
+    data.update(over)
+    return data
+
+
+def test_renders_four_zones():
+    html, missing = render(
+        _base_data(
+            questions=[{"id": "Q-1111", "question": "Why?", "priority": 9}],
+            plans=[{"id": "PL-2222", "title": "My plan", "status": "in-progress", "updated": ""}],
+            results=[{"id": "F-3333", "description": "A result", "confidence": 0.8}],
+        )
+    )
+    assert "Open Questions" in html
+    assert "Open Plans" in html
+    assert "Major Results" in html
+    assert "Figures" in html
+    assert "Q-1111" in html and "PL-2222" in html and "F-3333" in html
+    assert missing == []
+
+
+def test_empty_graph_empty_states():
+    html, missing = render(_base_data())
+    assert "No open questions recorded yet." in html
+    assert "No open plans" in html
+    assert "No findings recorded yet." in html
+    assert "No result figures yet." in html
+    assert missing == []
+
+
+def test_escapes_html_and_xss():
+    html, _ = render(
+        _base_data(results=[{"id": "F-9999", "description": "<script>alert('x')</script> & <b>", "confidence": 0.5}])
+    )
+    assert "<script>alert" not in html
+    assert "&lt;script&gt;" in html
+    assert "&amp;" in html
+
+
+def test_node_ids_become_badges():
+    html, _ = render(
+        _base_data(questions=[{"id": "Q-1111", "question": "See [F-abcd] for context", "priority": 5}])
+    )
+    assert 'class="node-id t-F"' in html
+    assert "F-abcd" in html
+
+
+def test_embeds_png_as_base64(tmp_path):
+    fig = tmp_path / "result.png"
+    fig.write_bytes(PNG_1x1)
+    html, missing = render(
+        _base_data(
+            meta={"project_root": str(tmp_path)},
+            figures=[{"id": "F-7777", "title": "Result", "path": "result.png", "description": "cap"}],
+        )
+    )
+    assert "data:image/png;base64," in html
+    assert missing == []
+
+
+def test_missing_figure_placeholder():
+    html, missing = render(
+        _base_data(figures=[{"id": "F-8888", "title": "Gone", "path": "nope.png"}])
+    )
+    assert "Figure file not found" in html
+    assert "nope.png" in missing
+
+
+def test_interactive_html_figure_is_sandboxed_iframe(tmp_path):
+    fig = tmp_path / "plot.html"
+    fig.write_text("<html><body><script>1+1</script>plot</body></html>", encoding="utf-8")
+    html, missing = render(
+        _base_data(
+            meta={"project_root": str(tmp_path)},
+            hero=[{"id": "F-aaaa", "title": "Live plot", "path": "plot.html"}],
+        )
+    )
+    assert "<iframe" in html
+    assert 'sandbox="allow-scripts"' in html
+    assert "srcdoc=" in html
+    # the inner double-quote-free content is preserved; ampersands escaped
+    assert missing == []
+
+
+def test_svg_is_data_uri_not_inlined(tmp_path):
+    svg = tmp_path / "fig.svg"
+    svg.write_text('<svg xmlns="http://www.w3.org/2000/svg"><script>evil()</script></svg>', encoding="utf-8")
+    html, _ = render(
+        _base_data(
+            meta={"project_root": str(tmp_path)},
+            figures=[{"id": "F-bbbb", "title": "vec", "path": "fig.svg"}],
+        )
+    )
+    assert "data:image/svg+xml;base64," in html
+    # raw <script> from the SVG must not appear unescaped in the page
+    assert "<script>evil()" not in html
+
+
+def test_hero_section_only_when_pinned(tmp_path):
+    fig = tmp_path / "h.png"
+    fig.write_bytes(PNG_1x1)
+    html_no, _ = render(_base_data())
+    assert "Main Figures" not in html_no
+    html_yes, _ = render(
+        _base_data(
+            meta={"project_root": str(tmp_path)},
+            hero=[{"id": "F-cccc", "title": "Hero", "path": "h.png"}],
+        )
+    )
+    assert "Main Figures" in html_yes
+
+
+def test_figure_note_rendered_and_escaped(tmp_path):
+    fig = tmp_path / "n.png"
+    fig.write_bytes(PNG_1x1)
+    html, _ = render(
+        _base_data(
+            meta={"project_root": str(tmp_path)},
+            figures=[{"id": "F-dddd", "title": "N", "path": "n.png", "note": "key <result>"}],
+        )
+    )
+    assert 'data-figid="F-dddd"' in html
+    assert "key &lt;result&gt;" in html
+
+
+def test_byte_stability():
+    data = _base_data(
+        questions=[{"id": "Q-1", "question": "q", "priority": 3}],
+        results=[{"id": "F-1", "description": "d", "confidence": 0.7}],
+    )
+    h1, _ = render(data)
+    h2, _ = render(data)
+    assert h1 == h2
+
+
+def test_theme_supports_auto():
+    html, _ = render(_base_data())
+    assert 'data-theme="auto"' in html
+    assert "prefers-color-scheme: dark" in html
+
+
+def test_refresh_button_and_graph_provenance():
+    html, _ = render(_base_data())
+    # A refresh control that reloads the file from disk.
+    assert 'id="refresh"' in html
+    assert "location.reload()" in html
+    # Clear that the page is generated from the graph, with the regenerate command.
+    assert "Snapshot of the knowledge graph" in html
+    assert "<code>wheeler dashboard</code>" in html
+
+
+def test_helpers():
+    assert 'class="node-id t-Q"' in node_badge("Q-1234")
+    assert "&lt;b&gt;" in linkify_nodes("<b>")
+    assert alt_text({"title": "T"}) == "T"
+    assert alt_text({"description": "d" * 300}) == "d" * 120
+    assert alt_text({"id": "F-1"}) == "Figure F-1"
+
+
+def test_embed_figure_missing_appends(tmp_path):
+    missing: list[str] = []
+    out = embed_figure("ghost.png", tmp_path, "alt", "title", {"used": 0}, missing)
+    assert "not found" in out
+    assert missing == ["ghost.png"]

--- a/tests/test_render_dashboard.py
+++ b/tests/test_render_dashboard.py
@@ -99,6 +99,28 @@ def test_missing_figure_placeholder():
     assert "nope.png" in missing
 
 
+def test_project_tag_cannot_break_out_of_script():
+    # A project tag containing </script> must not close the inline <script>.
+    html, _ = render(_base_data(project="</script><img src=x onerror=alert(1)>"))
+    assert "</script><img" not in html          # raw breakout sequence absent
+    assert "<\\/script" in html                  # defused form present in the JS string
+
+
+def test_interactive_figure_srcdoc_escapes_attribute(tmp_path):
+    fig = tmp_path / "plot.html"
+    fig.write_text('<div title="a & b">x</div><script>1</script>', encoding="utf-8")
+    html, missing = render(
+        _base_data(
+            meta={"project_root": str(tmp_path)},
+            figures=[{"id": "F-q", "title": "P", "path": "plot.html"}],
+        )
+    )
+    assert missing == []
+    # The double-quote and ampersand in the figure content are attribute-escaped
+    # so they cannot close the double-quoted srcdoc attribute.
+    assert "&quot;" in html and "&amp;" in html
+
+
 def test_interactive_html_figure_is_sandboxed_iframe(tmp_path):
     fig = tmp_path / "plot.html"
     fig.write_text("<html><body><script>1+1</script>plot</body></html>", encoding="utf-8")

--- a/tests/test_render_dashboard.py
+++ b/tests/test_render_dashboard.py
@@ -182,7 +182,19 @@ def test_refresh_button_and_graph_provenance():
     assert "<code>wheeler dashboard</code>" in html
 
 
+def test_node_badges_are_copyable():
+    html, _ = render(
+        _base_data(questions=[{"id": "Q-1111", "question": "q?", "priority": 5}])
+    )
+    # Badge carries the id and copy affordances; the JS wires click + right-click.
+    assert 'data-nodeid="Q-1111"' in html
+    assert 'role="button"' in html and 'tabindex="0"' in html
+    assert "Copy reference" in html and "Copy node id" in html
+    assert 'id="nodemenu"' in html and 'id="toast"' in html
+
+
 def test_helpers():
+    assert 'data-nodeid="Q-1234"' in node_badge("Q-1234")
     assert 'class="node-id t-Q"' in node_badge("Q-1234")
     assert "&lt;b&gt;" in linkify_nodes("<b>")
     assert alt_text({"title": "T"}) == "T"

--- a/tests/test_render_dashboard.py
+++ b/tests/test_render_dashboard.py
@@ -165,17 +165,20 @@ def test_hero_section_only_when_pinned(tmp_path):
     assert "Main Figures" in html_yes
 
 
-def test_figure_note_rendered_and_escaped(tmp_path):
+def test_figure_durable_note_rendered_with_provenance_badge(tmp_path):
     fig = tmp_path / "n.png"
     fig.write_bytes(PNG_1x1)
     html, _ = render(
         _base_data(
             meta={"project_root": str(tmp_path)},
-            figures=[{"id": "F-dddd", "title": "N", "path": "n.png", "note": "key <result>"}],
+            figures=[{"id": "F-dddd", "title": "N", "path": "n.png",
+                      "note": "key <result>", "note_id": "N-xyz9"}],
         )
     )
     assert 'data-figid="F-dddd"' in html
-    assert "key &lt;result&gt;" in html
+    assert "durable-note" in html
+    assert "key &lt;result&gt;" in html             # note content escaped
+    assert 'data-nodeid="N-xyz9"' in html           # ResearchNote provenance badge
 
 
 def test_byte_stability():
@@ -229,3 +232,20 @@ def test_embed_figure_missing_appends(tmp_path):
     out = embed_figure("ghost.png", tmp_path, "alt", "title", {"used": 0}, missing)
     assert "not found" in out
     assert missing == ["ghost.png"]
+
+
+def test_embed_cache_memoizes_by_file_signature(tmp_path):
+    from wheeler.dashboard.render import _EMBED_CACHE
+
+    _EMBED_CACHE.clear()
+    fig = tmp_path / "c.png"
+    fig.write_bytes(PNG_1x1)
+    data = _base_data(
+        meta={"project_root": str(tmp_path)},
+        figures=[{"id": "F-c", "title": "C", "path": "c.png"}],
+    )
+    h1, _ = render(data)
+    assert len(_EMBED_CACHE) == 1   # encoded once and cached
+    h2, _ = render(data)
+    assert h1 == h2                 # identical output, served from cache
+    assert len(_EMBED_CACHE) == 1   # not re-encoded

--- a/wheeler/dashboard/__init__.py
+++ b/wheeler/dashboard/__init__.py
@@ -1,13 +1,15 @@
 """Read-only HTML research dashboard for a Wheeler investigation.
 
-A static, self-contained, interactive overview of the most recent progress
-across the whole knowledge graph: open questions, open plans, major results, and
-result figures (pinnable as hero figures, with per-figure notes and an infinite
-canvas). Rendered on demand by the ``wheeler dashboard`` CLI command.
+A live, interactive overview of the most recent progress across the whole
+knowledge graph: open questions, open plans, major results, and result figures
+(pinnable as hero figures, with copyable node badges, per-figure notes, and an
+infinite canvas). ``wheeler dashboard`` serves it from a tiny local HTTP server
+that re-queries the graph on every load, so Refresh always shows current data.
 
 - ``gather_dashboard_data(config)`` reads the graph and builds the data dict.
 - ``render(data)`` turns that dict into one self-contained HTML string (pure,
   stdlib-only, deterministic).
+- ``serve`` (in ``serve.py``) wraps both in a stdlib server, no web framework.
 """
 from __future__ import annotations
 

--- a/wheeler/dashboard/__init__.py
+++ b/wheeler/dashboard/__init__.py
@@ -1,0 +1,17 @@
+"""Read-only HTML research dashboard for a Wheeler investigation.
+
+A static, self-contained, interactive overview of the most recent progress
+across the whole knowledge graph: open questions, open plans, major results, and
+result figures (pinnable as hero figures, with per-figure notes and an infinite
+canvas). Rendered on demand by the ``wheeler dashboard`` CLI command.
+
+- ``gather_dashboard_data(config)`` reads the graph and builds the data dict.
+- ``render(data)`` turns that dict into one self-contained HTML string (pure,
+  stdlib-only, deterministic).
+"""
+from __future__ import annotations
+
+from wheeler.dashboard.gather import gather_dashboard_data
+from wheeler.dashboard.render import render
+
+__all__ = ["gather_dashboard_data", "render"]

--- a/wheeler/dashboard/gather.py
+++ b/wheeler/dashboard/gather.py
@@ -1,0 +1,237 @@
+"""Assemble the dashboard data dict from the live knowledge graph.
+
+``gather_dashboard_data(config)`` opens one backend, runs the existing
+read-only ``query_*`` helpers SEQUENTIALLY (each ``run_cypher`` is independently
+sessioned; never ``asyncio.gather`` graph queries), enriches findings from their
+``knowledge/{id}.json`` files (so figure-only fields like ``artifact_type`` and
+``path`` are available), reconciles local pins/notes, and returns the plain dict
+``render`` consumes. This module is read-only: it never mutates the graph and so
+does not route through ``execute_tool``.
+
+The ranking/selection/pin/note logic is factored into pure module-level
+functions so they unit-test without Neo4j.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from wheeler.config import WheelerConfig
+
+logger = logging.getLogger(__name__)
+
+OPEN_PLAN_STATUSES = ("approved", "in-progress")
+SCHEMA_VERSION = 1
+
+
+# --------------------------------------------------------------------------- pure helpers
+
+
+def rank_results(findings: list[dict]) -> list[dict]:
+    """Rank findings as 'major results': fresh first, then high confidence, then
+    high stability. Deterministic (ties broken by id)."""
+    return sorted(
+        findings,
+        key=lambda f: (
+            bool(f.get("stale", False)),
+            -float(f.get("confidence") or 0.0),
+            -float(f.get("stability") or 0.0),
+            str(f.get("id", "")),
+        ),
+    )
+
+
+def select_open_plans(plans: list[dict]) -> list[dict]:
+    """Keep only plans whose status is open (approved or in-progress)."""
+    return [p for p in plans if str(p.get("status", "")).lower() in OPEN_PLAN_STATUSES]
+
+
+def is_figure(f: dict, root: Path) -> bool:
+    """True if a finding is a figure with a resolvable, existing file."""
+    if str(f.get("artifact_type", "")).lower() != "figure":
+        return False
+    path = f.get("path") or ""
+    if not path:
+        return False
+    p = Path(path)
+    fp = p if p.is_absolute() else (root / p)
+    return fp.exists()
+
+
+def select_figures(findings: list[dict], root: Path) -> list[dict]:
+    """Findings that are on-disk figures, in the given order."""
+    return [f for f in findings if is_figure(f, root)]
+
+
+def split_pinned(
+    figures: list[dict], pinned_ids: list[str]
+) -> tuple[list[dict], list[dict]]:
+    """Return (hero, rest). ``hero`` follows pin order and drops dangling pins
+    (ids that no longer resolve to a figure). ``rest`` keeps the input order."""
+    by_id = {f.get("id"): f for f in figures}
+    hero = [by_id[i] for i in pinned_ids if i in by_id]
+    pinned_set = {i for i in pinned_ids if i in by_id}
+    rest = [f for f in figures if f.get("id") not in pinned_set]
+    return hero, rest
+
+
+def attach_notes(figures: list[dict], notes: dict[str, str]) -> None:
+    """Attach the durable note text to each figure dict (in place)."""
+    for f in figures:
+        note = notes.get(f.get("id", ""))
+        if note:
+            f["note"] = note
+
+
+# --------------------------------------------------------------------------- local state I/O
+
+
+def _state_dir(config: WheelerConfig) -> Path:
+    root = Path(getattr(config, "project_root", ".") or ".")
+    return root / ".wheeler" / "dashboard"
+
+
+def _read_state(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+
+
+def _write_state(path: Path, payload: dict) -> None:
+    """Atomic write (tmp + rename), mirroring knowledge/store.write_node."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    tmp.rename(path)
+
+
+def read_pins(config: WheelerConfig) -> list[str]:
+    data = _read_state(_state_dir(config) / "pins.json")
+    pins = data.get("pins", [])
+    return [str(x) for x in pins] if isinstance(pins, list) else []
+
+
+def write_pins(config: WheelerConfig, pins: list[str]) -> None:
+    ptag = getattr(config.neo4j, "project_tag", "") if hasattr(config, "neo4j") else ""
+    _write_state(_state_dir(config) / "pins.json", {"project_tag": ptag, "pins": pins})
+
+
+def read_notes(config: WheelerConfig) -> dict[str, str]:
+    data = _read_state(_state_dir(config) / "notes.json")
+    notes = data.get("notes", {})
+    return {str(k): str(v) for k, v in notes.items()} if isinstance(notes, dict) else {}
+
+
+def write_notes(config: WheelerConfig, notes: dict[str, str]) -> None:
+    ptag = getattr(config.neo4j, "project_tag", "") if hasattr(config, "neo4j") else ""
+    _write_state(_state_dir(config) / "notes.json", {"project_tag": ptag, "notes": notes})
+
+
+# --------------------------------------------------------------------------- enrichment
+
+
+def _enrich_finding(knowledge_path: Path | None, f: dict) -> dict:
+    """Merge figure-only fields (path, artifact_type, title, stale, stability)
+    from the knowledge JSON file into a finding dict returned by query_findings."""
+    if knowledge_path is None:
+        return f
+    try:
+        from wheeler.knowledge.store import read_node
+
+        model = read_node(knowledge_path, f.get("id", ""))
+    except FileNotFoundError:
+        return f
+    except Exception:
+        logger.debug("enrichment failed for %s", f.get("id"), exc_info=True)
+        return f
+    f = dict(f)
+    f["path"] = getattr(model, "path", "")
+    f["artifact_type"] = getattr(model, "artifact_type", "")
+    f["title"] = getattr(model, "title", "")
+    f["stale"] = getattr(model, "stale", False)
+    f["stability"] = getattr(model, "stability", 0.0)
+    return f
+
+
+# --------------------------------------------------------------------------- main entry
+
+
+async def gather_dashboard_data(
+    config: WheelerConfig, *, limit: int = 12, plan_id: str | None = None
+) -> dict[str, Any]:
+    """Open the backend, query the graph read-only, and build the render dict."""
+    from wheeler.graph.backend import get_backend
+    from wheeler.tools.graph_tools.queries import (
+        query_findings,
+        query_open_questions,
+        query_plans,
+    )
+
+    knowledge_path = Path(config.knowledge_path) if getattr(config, "knowledge_path", None) else None
+    project_root = str(Path(getattr(config, "project_root", ".") or ".").resolve())
+    project_tag = getattr(config.neo4j, "project_tag", "") if hasattr(config, "neo4j") else ""
+
+    backend = get_backend(config)
+    await backend.initialize()
+    try:
+        q_raw = await query_open_questions(backend, {"_config": config, "limit": limit})
+        # Two passes for the two open statuses (query_plans takes a single status).
+        plans_acc: list[dict] = []
+        for status in OPEN_PLAN_STATUSES:
+            pr = await query_plans(
+                backend, {"_config": config, "status": status, "limit": max(limit * 2, 40)}
+            )
+            plans_acc.extend(json.loads(pr).get("plans", []))
+        # Fetch findings generously: figure selection filters on a JSON-only field,
+        # so a small limit would silently hide figures past the cut.
+        f_raw = await query_findings(
+            backend, {"_config": config, "limit": max(limit * 4, 200)}
+        )
+        counts = await backend.count_all()
+    finally:
+        await backend.close()
+
+    questions = json.loads(q_raw).get("questions", [])[:limit]
+    open_plans = select_open_plans(plans_acc)
+    open_plans.sort(key=lambda p: (str(p.get("updated", "")), str(p.get("id", ""))), reverse=True)
+    open_plans = open_plans[:limit]
+
+    findings = json.loads(f_raw).get("findings", [])
+    enriched = [_enrich_finding(knowledge_path, f) for f in findings]
+
+    root = Path(project_root)
+    all_figures = select_figures(enriched, root)
+    notes = read_notes(config)
+    attach_notes(all_figures, notes)
+
+    pins = read_pins(config)
+    hero, rest_figures = split_pinned(all_figures, pins)
+
+    results = rank_results(enriched)[:limit]
+
+    clean_counts = {k: v for k, v in (counts or {}).items() if not str(k).startswith("_")}
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "title": "Wheeler Research Dashboard",
+        "generated": _now_iso(),
+        "project": project_tag,
+        "meta": {"project_root": project_root},
+        "counts": clean_counts,
+        "hero": hero,
+        "questions": questions,
+        "plans": open_plans,
+        "results": results,
+        "figures": rest_figures[:limit],
+        "notes": notes,
+    }
+
+
+def _now_iso() -> str:
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/wheeler/dashboard/gather.py
+++ b/wheeler/dashboard/gather.py
@@ -79,11 +79,12 @@ def split_pinned(
 
 
 def attach_notes(figures: list[dict], notes: dict[str, str]) -> None:
-    """Attach the durable note text to each figure dict (in place)."""
-    for f in figures:
+    """Attach durable note text to each figure. Replaces each list entry with a
+    fresh dict (copy) so it never mutates a finding object that is also shared
+    with the results zone (avoids cross-zone aliasing)."""
+    for i, f in enumerate(figures):
         note = notes.get(f.get("id", ""))
-        if note:
-            f["note"] = note
+        figures[i] = {**f, "note": note} if note else dict(f)
 
 
 # --------------------------------------------------------------------------- local state I/O
@@ -101,6 +102,21 @@ def _read_state(path: Path) -> dict:
         return {}
 
 
+def _current_tag(config: WheelerConfig) -> str:
+    return getattr(config.neo4j, "project_tag", "") if hasattr(config, "neo4j") else ""
+
+
+def _tag_matches(config: WheelerConfig, data: dict) -> bool:
+    """True if the state file belongs to the current project_tag. Files written
+    before tag-stamping (no project_tag key) are treated as matching for
+    back-compat; a stamped tag that differs from the current one is rejected so
+    pins/notes from another namespace do not render against this project."""
+    stored = data.get("project_tag")
+    if stored is None:
+        return True
+    return str(stored) == _current_tag(config)
+
+
 def _write_state(path: Path, payload: dict) -> None:
     """Atomic write (tmp + rename), mirroring knowledge/store.write_node."""
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -111,24 +127,32 @@ def _write_state(path: Path, payload: dict) -> None:
 
 def read_pins(config: WheelerConfig) -> list[str]:
     data = _read_state(_state_dir(config) / "pins.json")
+    if not _tag_matches(config, data):
+        return []
     pins = data.get("pins", [])
     return [str(x) for x in pins] if isinstance(pins, list) else []
 
 
 def write_pins(config: WheelerConfig, pins: list[str]) -> None:
-    ptag = getattr(config.neo4j, "project_tag", "") if hasattr(config, "neo4j") else ""
-    _write_state(_state_dir(config) / "pins.json", {"project_tag": ptag, "pins": pins})
+    _write_state(
+        _state_dir(config) / "pins.json",
+        {"project_tag": _current_tag(config), "pins": pins},
+    )
 
 
 def read_notes(config: WheelerConfig) -> dict[str, str]:
     data = _read_state(_state_dir(config) / "notes.json")
+    if not _tag_matches(config, data):
+        return {}
     notes = data.get("notes", {})
     return {str(k): str(v) for k, v in notes.items()} if isinstance(notes, dict) else {}
 
 
 def write_notes(config: WheelerConfig, notes: dict[str, str]) -> None:
-    ptag = getattr(config.neo4j, "project_tag", "") if hasattr(config, "neo4j") else ""
-    _write_state(_state_dir(config) / "notes.json", {"project_tag": ptag, "notes": notes})
+    _write_state(
+        _state_dir(config) / "notes.json",
+        {"project_tag": _current_tag(config), "notes": notes},
+    )
 
 
 # --------------------------------------------------------------------------- enrichment
@@ -157,6 +181,35 @@ def _enrich_finding(knowledge_path: Path | None, f: dict) -> dict:
     return f
 
 
+def _figure_from_id(knowledge_path: Path | None, node_id: str, root: Path) -> dict | None:
+    """Load a figure finding directly by id (used so a pinned figure that is
+    older than the fetched findings window is never silently dropped). Returns a
+    finding dict if the node is a figure with an existing file, else None."""
+    if knowledge_path is None or not node_id:
+        return None
+    try:
+        from wheeler.knowledge.store import read_node
+
+        model = read_node(knowledge_path, node_id)
+    except FileNotFoundError:
+        return None
+    except Exception:
+        logger.debug("could not load pinned figure %s", node_id, exc_info=True)
+        return None
+    f = {
+        "id": getattr(model, "id", node_id),
+        "description": getattr(model, "description", ""),
+        "confidence": getattr(model, "confidence", 0.0),
+        "tier": getattr(model, "tier", "generated"),
+        "path": getattr(model, "path", ""),
+        "artifact_type": getattr(model, "artifact_type", ""),
+        "title": getattr(model, "title", ""),
+        "stale": getattr(model, "stale", False),
+        "stability": getattr(model, "stability", 0.0),
+    }
+    return f if is_figure(f, root) else None
+
+
 # --------------------------------------------------------------------------- main entry
 
 
@@ -176,8 +229,8 @@ async def gather_dashboard_data(
     project_tag = getattr(config.neo4j, "project_tag", "") if hasattr(config, "neo4j") else ""
 
     backend = get_backend(config)
-    await backend.initialize()
     try:
+        await backend.initialize()
         q_raw = await query_open_questions(backend, {"_config": config, "limit": limit})
         # Two passes for the two open statuses (query_plans takes a single status).
         plans_acc: list[dict] = []
@@ -205,10 +258,20 @@ async def gather_dashboard_data(
 
     root = Path(project_root)
     all_figures = select_figures(enriched, root)
+
+    # A pinned figure may be older than the fetched findings window; load any such
+    # pins directly so they are never silently dropped from the hero section.
+    pins = read_pins(config)
+    present = {f.get("id") for f in all_figures}
+    for pid in pins:
+        if pid not in present:
+            extra = _figure_from_id(knowledge_path, pid, root)
+            if extra is not None:
+                all_figures.append(extra)
+                present.add(pid)
+
     notes = read_notes(config)
     attach_notes(all_figures, notes)
-
-    pins = read_pins(config)
     hero, rest_figures = split_pinned(all_figures, pins)
 
     results = rank_results(enriched)[:limit]

--- a/wheeler/dashboard/gather.py
+++ b/wheeler/dashboard/gather.py
@@ -78,15 +78,6 @@ def split_pinned(
     return hero, rest
 
 
-def attach_notes(figures: list[dict], notes: dict[str, str]) -> None:
-    """Attach durable note text to each figure. Replaces each list entry with a
-    fresh dict (copy) so it never mutates a finding object that is also shared
-    with the results zone (avoids cross-zone aliasing)."""
-    for i, f in enumerate(figures):
-        note = notes.get(f.get("id", ""))
-        figures[i] = {**f, "note": note} if note else dict(f)
-
-
 # --------------------------------------------------------------------------- local state I/O
 
 
@@ -140,19 +131,102 @@ def write_pins(config: WheelerConfig, pins: list[str]) -> None:
     )
 
 
-def read_notes(config: WheelerConfig) -> dict[str, str]:
-    data = _read_state(_state_dir(config) / "notes.json")
-    if not _tag_matches(config, data):
-        return {}
-    notes = data.get("notes", {})
-    return {str(k): str(v) for k, v in notes.items()} if isinstance(notes, dict) else {}
+# --------------------------------------------------------------------------- figure notes (graph)
+#
+# A note on a figure is a research fact, so it lives in the graph as a
+# ResearchNote (N-) linked RELEVANT_TO the figure (F-), giving it provenance and
+# letting it travel with backups: exactly the wh:note / add_note path. The
+# dashboard writes these through execute_tool (the only graph writer; lazy
+# import, like integrations) and reads them back per figure. The in-browser
+# textarea remains a browser-local scratch pad, seeded from the durable note.
 
 
-def write_notes(config: WheelerConfig, notes: dict[str, str]) -> None:
-    _write_state(
-        _state_dir(config) / "notes.json",
-        {"project_tag": _current_tag(config), "notes": notes},
+async def record_figure_note(config: WheelerConfig, figure_id: str, text: str) -> str | None:
+    """Create a ResearchNote and link it RELEVANT_TO the figure. Returns the
+    new note id, or None if creation failed. Routes through execute_tool so the
+    triple-write (graph + JSON + synthesis) and provenance all apply."""
+    from wheeler.tools.graph_tools import execute_tool
+
+    res = json.loads(
+        await execute_tool(
+            "add_note",
+            {
+                "content": text,
+                "title": f"Dashboard note on {figure_id}",
+                "context": "Authored from the Wheeler dashboard",
+            },
+            config,
+        )
     )
+    note_id = res.get("node_id")
+    if not note_id:
+        return None
+    await execute_tool(
+        "link_nodes",
+        {"source_id": note_id, "target_id": figure_id, "relationship": "RELEVANT_TO"},
+        config,
+    )
+    return note_id
+
+
+async def fetch_figure_notes(backend, figure_ids: list[str], project_tag: str) -> list[dict]:
+    """Return ResearchNotes linked RELEVANT_TO any of the given figure ids, as
+    rows {fid, nid, content, date}, newest first."""
+    if not figure_ids:
+        return []
+    pw = ""
+    params: dict = {"ids": figure_ids}
+    if project_tag:
+        pw = " AND f._wheeler_project = $ptag AND n._wheeler_project = $ptag"
+        params["ptag"] = project_tag
+    rows = await backend.run_cypher(
+        "MATCH (n:ResearchNote)-[:RELEVANT_TO]->(f:Finding) "
+        f"WHERE f.id IN $ids{pw} "
+        "RETURN f.id AS fid, n.id AS nid, n.content AS content, n.date AS date "
+        "ORDER BY n.date DESC",
+        params,
+    )
+    return [dict(r) for r in rows]
+
+
+async def list_all_figure_notes(config: WheelerConfig) -> list[dict]:
+    """List every ResearchNote linked RELEVANT_TO a figure (for the CLI)."""
+    from wheeler.graph.backend import get_backend
+
+    backend = get_backend(config)
+    try:
+        await backend.initialize()
+        ptag = _current_tag(config)
+        pw, params = "", {}
+        if ptag:
+            pw = " WHERE f._wheeler_project = $ptag AND n._wheeler_project = $ptag"
+            params["ptag"] = ptag
+        rows = await backend.run_cypher(
+            "MATCH (n:ResearchNote)-[:RELEVANT_TO]->(f:Finding)"
+            f"{pw} RETURN f.id AS fid, n.id AS nid, n.content AS content "
+            "ORDER BY n.date DESC",
+            params,
+        )
+        return [dict(r) for r in rows]
+    finally:
+        await backend.close()
+
+
+def attach_graph_notes(figures: list[dict], note_rows: list[dict]) -> None:
+    """Attach the newest ResearchNote per figure (content + id) to each figure
+    dict. Pure; rows are pre-sorted newest-first. Replaces each entry with a
+    copy so it never aliases the same finding object shown in the results zone."""
+    latest: dict = {}
+    for r in note_rows:
+        fid = r.get("fid")
+        if fid is not None and fid not in latest:
+            latest[fid] = r  # first seen = newest (rows sorted date DESC)
+    for i, f in enumerate(figures):
+        row = latest.get(f.get("id"))
+        if row:
+            figures[i] = {**f, "note": row.get("content", ""), "note_id": row.get("nid", "")}
+        else:
+            figures[i] = dict(f)
 
 
 # --------------------------------------------------------------------------- enrichment
@@ -244,38 +318,42 @@ async def gather_dashboard_data(
         f_raw = await query_findings(
             backend, {"_config": config, "limit": max(limit * 4, 200)}
         )
+
+        questions = json.loads(q_raw).get("questions", [])[:limit]
+        open_plans = select_open_plans(plans_acc)
+        open_plans.sort(
+            key=lambda p: (str(p.get("updated", "")), str(p.get("id", ""))), reverse=True
+        )
+        open_plans = open_plans[:limit]
+
+        findings = json.loads(f_raw).get("findings", [])
+        enriched = [_enrich_finding(knowledge_path, f) for f in findings]
+
+        root = Path(project_root)
+        all_figures = select_figures(enriched, root)
+
+        # A pinned figure may be older than the fetched findings window; load any
+        # such pins directly so they are never silently dropped from the hero.
+        pins = read_pins(config)
+        present = {f.get("id") for f in all_figures}
+        for pid in pins:
+            if pid not in present:
+                extra = _figure_from_id(knowledge_path, pid, root)
+                if extra is not None:
+                    all_figures.append(extra)
+                    present.add(pid)
+
+        # Pull figure notes from the graph (ResearchNote -RELEVANT_TO-> figure).
+        note_rows = await fetch_figure_notes(
+            backend, [str(f.get("id", "")) for f in all_figures], project_tag
+        )
         counts = await backend.count_all()
     finally:
         await backend.close()
 
-    questions = json.loads(q_raw).get("questions", [])[:limit]
-    open_plans = select_open_plans(plans_acc)
-    open_plans.sort(key=lambda p: (str(p.get("updated", "")), str(p.get("id", ""))), reverse=True)
-    open_plans = open_plans[:limit]
-
-    findings = json.loads(f_raw).get("findings", [])
-    enriched = [_enrich_finding(knowledge_path, f) for f in findings]
-
-    root = Path(project_root)
-    all_figures = select_figures(enriched, root)
-
-    # A pinned figure may be older than the fetched findings window; load any such
-    # pins directly so they are never silently dropped from the hero section.
-    pins = read_pins(config)
-    present = {f.get("id") for f in all_figures}
-    for pid in pins:
-        if pid not in present:
-            extra = _figure_from_id(knowledge_path, pid, root)
-            if extra is not None:
-                all_figures.append(extra)
-                present.add(pid)
-
-    notes = read_notes(config)
-    attach_notes(all_figures, notes)
+    attach_graph_notes(all_figures, note_rows)
     hero, rest_figures = split_pinned(all_figures, pins)
-
     results = rank_results(enriched)[:limit]
-
     clean_counts = {k: v for k, v in (counts or {}).items() if not str(k).startswith("_")}
 
     return {
@@ -290,7 +368,6 @@ async def gather_dashboard_data(
         "plans": open_plans,
         "results": results,
         "figures": rest_figures[:limit],
-        "notes": notes,
     }
 
 

--- a/wheeler/dashboard/render.py
+++ b/wheeler/dashboard/render.py
@@ -50,7 +50,13 @@ def node_badge(node_id: str) -> str:
     nid = str(node_id)
     prefix = nid.split("-", 1)[0][:1].upper() if "-" in nid else ""
     cls = f"node-id t-{prefix}" if prefix else "node-id"
-    return f'<span class="{cls}">{esc(nid)}</span>'
+    # Copyable: click (or Enter) copies the [NODE_ID] reference; right-click opens
+    # a menu to copy the reference or the bare id. Lets the scientist grab a node
+    # and point an LLM at it.
+    return (
+        f'<span class="{cls}" data-nodeid="{esc(nid)}" role="button" tabindex="0" '
+        f'title="Click to copy [{esc(nid)}], right-click for options">{esc(nid)}</span>'
+    )
 
 
 def linkify_nodes(text: str) -> str:

--- a/wheeler/dashboard/render.py
+++ b/wheeler/dashboard/render.py
@@ -1,0 +1,313 @@
+"""Pure, deterministic, stdlib-only renderer for the research dashboard.
+
+``render(data) -> (html, missing)`` turns a plain data dict (see
+``gather.py`` for how it is assembled from the graph) into one self-contained
+HTML string. It imports nothing internal, so it is trivially unit-testable
+offline with a hand-built dict (mirrors ``tests/test_render_brief.py``).
+
+Determinism: no ``datetime.now()`` and no unsorted-set/dict iteration. The
+timestamp is an input field (``data["generated"]``); list order is preserved as
+given by ``gather`` (so pinned hero figures keep their pin order). The same dict
+renders identical bytes every time.
+
+Safety: every text field is HTML-escaped via ``esc``/``linkify_nodes``. Figures
+are embedded as ``data:`` URIs (raster/SVG) or sandboxed ``<iframe srcdoc>``
+(interactive HTML); SVG is never inlined, so it cannot execute script in the
+page. Per-image and whole-document byte ceilings guard against blow-up.
+"""
+from __future__ import annotations
+
+import base64
+import html
+import json
+import mimetypes
+import re
+from datetime import datetime
+from pathlib import Path
+from string import Template
+
+from wheeler.dashboard.template import DASHBOARD_TEMPLATE
+
+SCHEMA_VERSION = 1
+RASTER_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".webp"}
+INTERACTIVE_EXTS = {".html", ".htm"}
+MAX_FIG_BYTES = 8 * 1024 * 1024
+MAX_TOTAL_BYTES = 80 * 1024 * 1024
+ALT_DESC_CHARS = 120
+NODE_ID_RE = re.compile(r"\[([A-Z]{1,2}-[0-9a-fA-F]{4,})\]")
+
+_COUNT_ORDER = [("Finding", "findings"), ("OpenQuestion", "questions"), ("Plan", "plans")]
+
+
+# --------------------------------------------------------------------------- text
+
+
+def esc(value) -> str:
+    return html.escape("" if value is None else str(value))
+
+
+def node_badge(node_id: str) -> str:
+    nid = str(node_id)
+    prefix = nid.split("-", 1)[0][:1].upper() if "-" in nid else ""
+    cls = f"node-id t-{prefix}" if prefix else "node-id"
+    return f'<span class="{cls}">{esc(nid)}</span>'
+
+
+def linkify_nodes(text: str) -> str:
+    """Escape text, then wrap [NODE_ID] tokens in styled badges."""
+    out, last = [], 0
+    s = "" if text is None else str(text)
+    for m in NODE_ID_RE.finditer(s):
+        out.append(esc(s[last:m.start()]))
+        out.append(node_badge(m.group(1)))
+        last = m.end()
+    out.append(esc(s[last:]))
+    return "".join(out)
+
+
+def pill(label: str, kind: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", str(kind).lower()).strip("-")
+    return f'<span class="pill pill-{slug}">{esc(label)}</span>'
+
+
+def fmt_date(iso: object) -> str:
+    try:
+        return datetime.fromisoformat(str(iso).replace("Z", "+00:00")).strftime("%Y-%m-%d %H:%M")
+    except (ValueError, TypeError):
+        return str(iso or "")
+
+
+def fmt_conf(conf) -> str:
+    try:
+        c = float(conf)
+    except (ValueError, TypeError):
+        return ""
+    if c <= 0:
+        return ""
+    return f"conf {c:.2f}"
+
+
+def alt_text(f: dict) -> str:
+    """Deterministic non-empty, non-huge alt text: title, else short description, else id."""
+    title = (f.get("title") or "").strip()
+    if title:
+        return title
+    desc = (f.get("description") or "").strip()
+    if desc:
+        return desc[:ALT_DESC_CHARS]
+    return f"Figure {f.get('id', '')}".strip()
+
+
+# --------------------------------------------------------------------------- figures
+
+
+def resolve(path: str, root: Path) -> Path:
+    p = Path(path)
+    return p if p.is_absolute() else (root / p)
+
+
+def embed_figure(path: str, root: Path, alt: str, title: str, budget: dict, missing: list) -> str:
+    """Return an HTML fragment embedding one figure. Appends to ``missing`` when
+    the file is absent or unembeddable. ``budget`` is ``{"used": int}`` tracked
+    across the whole document."""
+    if not path:
+        missing.append(path or "(no path)")
+        return '<div class="fig-placeholder">No figure path.</div>'
+    fp = resolve(path, root)
+    if not fp.exists():
+        missing.append(path)
+        return f'<div class="fig-placeholder">Figure file not found:<br><code>{esc(path)}</code></div>'
+
+    ext = fp.suffix.lower()
+    try:
+        size = fp.stat().st_size
+    except OSError:
+        size = 0
+    if size > MAX_FIG_BYTES or budget["used"] + size > MAX_TOTAL_BYTES:
+        missing.append(path)
+        return (
+            f'<div class="fig-placeholder">Figure too large to embed '
+            f'({size // 1024} KB):<br><code>{esc(fp.name)}</code></div>'
+        )
+
+    if ext in INTERACTIVE_EXTS:
+        content = fp.read_text(encoding="utf-8", errors="replace")
+        budget["used"] += len(content.encode("utf-8"))
+        srcdoc = content.replace("&", "&amp;").replace('"', "&quot;")
+        return (
+            f'<iframe sandbox="allow-scripts" loading="lazy" '
+            f'title="{esc(title or alt)}" srcdoc="{srcdoc}"></iframe>'
+        )
+
+    if ext in RASTER_EXTS or ext == ".svg":
+        mime = "image/svg+xml" if ext == ".svg" else (mimetypes.guess_type(fp.name)[0] or "image/png")
+        data = fp.read_bytes()
+        budget["used"] += len(data)
+        b64 = base64.b64encode(data).decode("ascii")
+        return f'<img src="data:{mime};base64,{b64}" alt="{esc(alt)}">'
+
+    missing.append(path)
+    return f'<div class="fig-placeholder">Unsupported figure type:<br><code>{esc(fp.name)}</code></div>'
+
+
+# --------------------------------------------------------------------------- cards
+
+
+def render_question_card(q: dict) -> str:
+    prio = q.get("priority")
+    prio_pill = pill(f"P{prio}", "prio") if prio is not None else ""
+    return (
+        '<div class="card">'
+        f'<div class="card-head">{node_badge(q.get("id", "?"))}{prio_pill}</div>'
+        f'<p class="desc">{linkify_nodes(q.get("question", ""))}</p>'
+        "</div>"
+    )
+
+
+def render_plan_card(p: dict) -> str:
+    status = p.get("status", "")
+    status_pill = pill(status, status) if status else ""
+    updated = fmt_date(p.get("updated"))
+    path = esc(p.get("path", ""))
+    meta = " &middot; ".join(x for x in [f"updated {esc(updated)}" if updated else "", path] if x)
+    return (
+        '<div class="card">'
+        f'<div class="card-head">{node_badge(p.get("id", "?"))}'
+        f'<span class="card-title">{esc(p.get("title", "Untitled plan"))}</span>{status_pill}</div>'
+        f'<div class="meta">{meta}</div>'
+        "</div>"
+    )
+
+
+def render_result_card(f: dict) -> str:
+    conf = fmt_conf(f.get("confidence"))
+    conf_pill = pill(conf, "conf") if conf else ""
+    stale = '<span class="flag-stale">stale</span>' if f.get("stale") else ""
+    title = f.get("title") or "Finding"
+    desc = str(f.get("description") or "")
+    short = desc if len(desc) <= 200 else desc[:200] + "..."
+    more = (
+        f'<details><summary>More</summary><p class="desc">{linkify_nodes(desc)}</p></details>'
+        if len(desc) > 200 else ""
+    )
+    return (
+        '<div class="card">'
+        f'<div class="card-head">{node_badge(f.get("id", "?"))}'
+        f'<span class="card-title">{esc(title)}</span>{conf_pill}{stale}</div>'
+        f'<p class="desc">{linkify_nodes(short)}</p>{more}'
+        "</div>"
+    )
+
+
+def render_figure_card(f: dict, root: Path, budget: dict, missing: list, *, hero: bool = False) -> str:
+    fid = f.get("id", "")
+    title = f.get("title") or "Figure"
+    alt = alt_text(f)
+    media = embed_figure(f.get("path", ""), root, alt, title, budget, missing)
+    conf = fmt_conf(f.get("confidence"))
+    conf_pill = pill(conf, "conf") if conf else ""
+    desc = str(f.get("description") or "")
+    legend = f'<p class="fig-legend">{linkify_nodes(desc)}</p>' if desc else ""
+    note = esc(f.get("note") or "")
+    cls = "card fig-card hero-card" if hero else "card fig-card"
+    return (
+        f'<div class="{cls}">'
+        f'<div class="card-head">{node_badge(fid)}'
+        f'<span class="card-title">{esc(title)}</span>{conf_pill}</div>'
+        f'<div class="fig-media" data-figid="{esc(fid)}" data-title="{esc(title)}">{media}</div>'
+        f"{legend}"
+        '<div class="note-wrap">'
+        f'<label for="note-{esc(fid)}">Note</label>'
+        f'<textarea id="note-{esc(fid)}" class="note" data-figid="{esc(fid)}" '
+        f'placeholder="Add a note...">{note}</textarea>'
+        '<div class="note-row">'
+        f'<button type="button" class="toolbtn note-copy" data-figid="{esc(fid)}">Copy</button>'
+        '<span class="note-hint">saved in this browser; '
+        "use <code>wheeler dashboard note</code> to make it durable</span></div>"
+        "</div>"
+        "</div>"
+    )
+
+
+# --------------------------------------------------------------------------- assembly
+
+
+def _zone(cards: list[str], empty: str) -> str:
+    return "".join(cards) if cards else f'<p class="empty">{empty}</p>'
+
+
+def render(data: dict) -> tuple[str, list[str]]:
+    """Render the dashboard. Returns ``(html, missing_figure_paths)``."""
+    meta = data.get("meta") or {}
+    root = Path(meta.get("project_root") or ".").resolve()
+    missing: list[str] = []
+    budget = {"used": 0}
+
+    project = data.get("project") or ""
+    project_label = f" &middot; project: {esc(project)}" if project else ""
+    gen = fmt_date(data.get("generated"))
+    when = esc(gen) if gen else "unknown time"
+    gen_line = f"Snapshot of the knowledge graph &middot; generated {when}"
+
+    counts = data.get("counts") or {}
+    count_chips = "".join(
+        f'<span class="count"><b>{esc(counts.get(key, 0))}</b> {esc(label)}</span>'
+        for key, label in _COUNT_ORDER
+    )
+
+    questions = data.get("questions") or []
+    plans = data.get("plans") or []
+    results = data.get("results") or []
+    figures = data.get("figures") or []
+    hero = data.get("hero") or []
+
+    hero_cards = [render_figure_card(f, root, budget, missing, hero=True) for f in hero]
+    hero_html = (
+        '<section class="hero" aria-labelledby="z-hero">'
+        f'<h2 class="zone-h" id="z-hero">Main Figures <span class="badge-count">{len(hero)}</span></h2>'
+        f'<div class="hero-grid">{"".join(hero_cards)}</div></section>'
+        if hero else ""
+    )
+
+    questions_html = _zone(
+        [render_question_card(q) for q in questions], "No open questions recorded yet."
+    )
+    plans_html = _zone(
+        [render_plan_card(p) for p in plans], "No open plans (approved or in-progress)."
+    )
+    results_html = _zone(
+        [render_result_card(f) for f in results], "No findings recorded yet."
+    )
+    figures_html = _zone(
+        [render_figure_card(f, root, budget, missing) for f in figures], "No result figures yet."
+    )
+
+    footer = (
+        "Wheeler research dashboard: a read-only snapshot generated from the "
+        "knowledge graph. Regenerate with <code>wheeler dashboard</code> "
+        "(use Refresh to reload this file after regenerating). "
+        'Badges: <span class="node-id t-Q">Q-</span> question, '
+        '<span class="node-id t-P">PL-</span> plan, '
+        '<span class="node-id t-F">F-</span> finding. '
+        'Notes edited here are local to this browser unless saved with '
+        "<code>wheeler dashboard note</code>."
+    )
+
+    out = Template(DASHBOARD_TEMPLATE).safe_substitute(
+        TITLE=esc(data.get("title") or "Wheeler Research Dashboard"),
+        GENERATED_LINE=gen_line,
+        PROJECT=project_label,
+        PROJECT_JSON=json.dumps(project),
+        COUNTS_STRIP=count_chips,
+        HERO_HTML=hero_html,
+        QUESTIONS_HTML=questions_html,
+        PLANS_HTML=plans_html,
+        RESULTS_HTML=results_html,
+        FIGURES_HTML=figures_html,
+        Q_COUNT=str(len(questions)),
+        PL_COUNT=str(len(plans)),
+        R_COUNT=str(len(results)),
+        F_COUNT=str(len(figures)),
+        FOOTER=footer,
+    )
+    return out, missing

--- a/wheeler/dashboard/render.py
+++ b/wheeler/dashboard/render.py
@@ -38,6 +38,28 @@ NODE_ID_RE = re.compile(r"\[([A-Z]{1,2}-[0-9a-fA-F]{4,})\]")
 
 _COUNT_ORDER = [("Finding", "findings"), ("OpenQuestion", "questions"), ("Plan", "plans")]
 
+# Memoize the expensive part of embedding (file read + base64/escape) by file
+# signature, so repeated live renders do not re-encode unchanged figures. Keyed
+# by (abspath, mtime_ns, size); a touched/replaced file misses and re-encodes.
+# This is a pure speed cache: output bytes are identical with or without it.
+_EMBED_CACHE: dict[tuple, str] = {}
+_EMBED_CACHE_MAX = 256
+
+
+def _embed_payload_cached(fp: Path, ext: str, sig: tuple) -> str:
+    cached = _EMBED_CACHE.get(sig)
+    if cached is not None:
+        return cached
+    if ext in INTERACTIVE_EXTS:
+        content = fp.read_text(encoding="utf-8", errors="replace")
+        payload = content.replace("&", "&amp;").replace('"', "&quot;")
+    else:
+        payload = base64.b64encode(fp.read_bytes()).decode("ascii")
+    if len(_EMBED_CACHE) >= _EMBED_CACHE_MAX:
+        _EMBED_CACHE.clear()
+    _EMBED_CACHE[sig] = payload
+    return payload
+
 
 # --------------------------------------------------------------------------- text
 
@@ -126,9 +148,10 @@ def embed_figure(path: str, root: Path, alt: str, title: str, budget: dict, miss
 
     ext = fp.suffix.lower()
     try:
-        size = fp.stat().st_size
+        st = fp.stat()
+        size, mtime_ns = st.st_size, st.st_mtime_ns
     except OSError:
-        size = 0
+        size, mtime_ns = 0, 0
     if size > MAX_FIG_BYTES or budget["used"] + size > MAX_TOTAL_BYTES:
         missing.append(path)
         return (
@@ -137,9 +160,8 @@ def embed_figure(path: str, root: Path, alt: str, title: str, budget: dict, miss
         )
 
     if ext in INTERACTIVE_EXTS:
-        content = fp.read_text(encoding="utf-8", errors="replace")
-        budget["used"] += len(content.encode("utf-8"))
-        srcdoc = content.replace("&", "&amp;").replace('"', "&quot;")
+        srcdoc = _embed_payload_cached(fp, ext, (str(fp), mtime_ns, size))
+        budget["used"] += size
         return (
             f'<iframe sandbox="allow-scripts" loading="lazy" '
             f'title="{esc(title or alt)}" srcdoc="{srcdoc}"></iframe>'
@@ -147,9 +169,8 @@ def embed_figure(path: str, root: Path, alt: str, title: str, budget: dict, miss
 
     if ext in RASTER_EXTS or ext == ".svg":
         mime = "image/svg+xml" if ext == ".svg" else (mimetypes.guess_type(fp.name)[0] or "image/png")
-        data = fp.read_bytes()
-        budget["used"] += len(data)
-        b64 = base64.b64encode(data).decode("ascii")
+        b64 = _embed_payload_cached(fp, ext, (str(fp), mtime_ns, size))
+        budget["used"] += size
         return f'<img src="data:{mime};base64,{b64}" alt="{esc(alt)}">'
 
     missing.append(path)
@@ -214,22 +235,32 @@ def render_figure_card(f: dict, root: Path, budget: dict, missing: list, *, hero
     conf_pill = pill(conf, "conf") if conf else ""
     desc = str(f.get("description") or "")
     legend = f'<p class="fig-legend">{linkify_nodes(desc)}</p>' if desc else ""
-    note = esc(f.get("note") or "")
     cls = "card fig-card hero-card" if hero else "card fig-card"
+
+    # Durable note: a provenance-tracked ResearchNote (N-) linked to the figure,
+    # shown read-only with its copyable node badge. The textarea below is a
+    # browser-local scratch pad; run `wheeler dashboard note` to make it durable.
+    note_id = f.get("note_id") or ""
+    durable = (
+        f'<div class="durable-note">{node_badge(note_id)} '
+        f'{linkify_nodes(f.get("note") or "")}</div>'
+        if note_id else ""
+    )
     return (
         f'<div class="{cls}">'
         f'<div class="card-head">{node_badge(fid)}'
         f'<span class="card-title">{esc(title)}</span>{conf_pill}</div>'
         f'<div class="fig-media" data-figid="{esc(fid)}" data-title="{esc(title)}">{media}</div>'
-        f"{legend}"
+        f"{legend}{durable}"
         '<div class="note-wrap">'
-        f'<label for="note-{esc(fid)}">Note</label>'
+        f'<label for="note-{esc(fid)}">Scratch note</label>'
         f'<textarea id="note-{esc(fid)}" class="note" data-figid="{esc(fid)}" '
-        f'placeholder="Add a note...">{note}</textarea>'
+        f'placeholder="Local scratch note..."></textarea>'
         '<div class="note-row">'
         f'<button type="button" class="toolbtn note-copy" data-figid="{esc(fid)}">Copy</button>'
-        '<span class="note-hint">saved in this browser; '
-        "use <code>wheeler dashboard note</code> to make it durable</span></div>"
+        '<span class="note-hint">local to this browser; run '
+        "<code>wheeler dashboard note "
+        f'{esc(fid)} "..."</code> to save a durable note</span></div>'
         "</div>"
         "</div>"
     )

--- a/wheeler/dashboard/render.py
+++ b/wheeler/dashboard/render.py
@@ -303,7 +303,10 @@ def render(data: dict) -> tuple[str, list[str]]:
         TITLE=esc(data.get("title") or "Wheeler Research Dashboard"),
         GENERATED_LINE=gen_line,
         PROJECT=project_label,
-        PROJECT_JSON=json.dumps(project),
+        # Defuse a "</script>" inside the project tag from breaking out of the
+        # inline <script>: "<\/" is valid JSON-in-JS and the parser no longer
+        # sees a closing script tag.
+        PROJECT_JSON=json.dumps(project).replace("</", "<\\/"),
         COUNTS_STRIP=count_chips,
         HERO_HTML=hero_html,
         QUESTIONS_HTML=questions_html,

--- a/wheeler/dashboard/render.py
+++ b/wheeler/dashboard/render.py
@@ -253,7 +253,7 @@ def render(data: dict) -> tuple[str, list[str]]:
     project_label = f" &middot; project: {esc(project)}" if project else ""
     gen = fmt_date(data.get("generated"))
     when = esc(gen) if gen else "unknown time"
-    gen_line = f"Snapshot of the knowledge graph &middot; generated {when}"
+    gen_line = f"Live view of the knowledge graph &middot; rendered {when}"
 
     counts = data.get("counts") or {}
     count_chips = "".join(
@@ -289,13 +289,13 @@ def render(data: dict) -> tuple[str, list[str]]:
     )
 
     footer = (
-        "Wheeler research dashboard: a read-only snapshot generated from the "
-        "knowledge graph. Regenerate with <code>wheeler dashboard</code> "
-        "(use Refresh to reload this file after regenerating). "
+        "Wheeler research dashboard: a live read-only view served from the "
+        "knowledge graph by <code>wheeler dashboard</code>. Refresh re-queries "
+        "the graph. "
         'Badges: <span class="node-id t-Q">Q-</span> question, '
         '<span class="node-id t-P">PL-</span> plan, '
-        '<span class="node-id t-F">F-</span> finding. '
-        'Notes edited here are local to this browser unless saved with '
+        '<span class="node-id t-F">F-</span> finding. Click a badge to copy its '
+        "reference. Notes edited here are local to this browser unless saved with "
         "<code>wheeler dashboard note</code>."
     )
 

--- a/wheeler/dashboard/serve.py
+++ b/wheeler/dashboard/serve.py
@@ -13,7 +13,8 @@ from __future__ import annotations
 import asyncio
 import html
 import logging
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -21,19 +22,31 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# The Neo4j async driver is a process-global singleton bound to whatever event
+# loop created it (graph/driver.py). Each request runs its own asyncio.run (a
+# fresh loop), so we serialize graph access and discard the cached driver after
+# every run, matching the MCP servers' invalidate_async_driver() idiom. This is
+# why the server is single-threaded (HTTPServer, not ThreadingHTTPServer): a
+# localhost single-user tool gains nothing from concurrency and the driver is
+# not safe to share across loops/threads.
+_RENDER_LOCK = threading.Lock()
+
 
 def render_live(config: WheelerConfig, limit: int = 12) -> str:
     """Query the graph and render the dashboard HTML for one request."""
     from wheeler.dashboard import gather_dashboard_data, render
+    from wheeler.graph.driver import invalidate_async_driver
 
-    data = asyncio.run(gather_dashboard_data(config, limit=limit))
-    out, _missing = render(data)
-    return out
+    with _RENDER_LOCK:
+        try:
+            data = asyncio.run(gather_dashboard_data(config, limit=limit))
+            out, _missing = render(data)
+            return out
+        finally:
+            invalidate_async_driver()
 
 
-def make_server(
-    config: WheelerConfig, host: str, port: int, limit: int
-) -> ThreadingHTTPServer:
+def make_server(config: WheelerConfig, host: str, port: int, limit: int) -> HTTPServer:
     """Build (but do not start) the dashboard HTTP server."""
 
     class Handler(BaseHTTPRequestHandler):
@@ -70,7 +83,7 @@ def make_server(
         def log_message(self, *args) -> None:  # keep the console quiet
             return
 
-    return ThreadingHTTPServer((host, port), Handler)
+    return HTTPServer((host, port), Handler)
 
 
 def serve(

--- a/wheeler/dashboard/serve.py
+++ b/wheeler/dashboard/serve.py
@@ -1,0 +1,107 @@
+"""Live local server for the research dashboard.
+
+``wheeler dashboard`` serves the dashboard from a tiny stdlib HTTP server that
+re-queries the knowledge graph and re-renders on every request, so the browser's
+Refresh always shows current data. No web framework dependency: it reuses the
+same pure ``gather_dashboard_data`` + ``render`` used everywhere else.
+
+The page embeds all figures as data URIs / sandboxed iframes, so a single HTML
+response is fully self-contained: no separate asset routes are needed.
+"""
+from __future__ import annotations
+
+import asyncio
+import html
+import logging
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from wheeler.config import WheelerConfig
+
+logger = logging.getLogger(__name__)
+
+
+def render_live(config: WheelerConfig, limit: int = 12) -> str:
+    """Query the graph and render the dashboard HTML for one request."""
+    from wheeler.dashboard import gather_dashboard_data, render
+
+    data = asyncio.run(gather_dashboard_data(config, limit=limit))
+    out, _missing = render(data)
+    return out
+
+
+def make_server(
+    config: WheelerConfig, host: str, port: int, limit: int
+) -> ThreadingHTTPServer:
+    """Build (but do not start) the dashboard HTTP server."""
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            path = self.path.split("?", 1)[0]
+            if path == "/favicon.ico":
+                self.send_response(204)
+                self.end_headers()
+                return
+            if path not in ("/", "/index.html"):
+                self.send_response(404)
+                self.end_headers()
+                return
+            try:
+                body = render_live(config, limit).encode("utf-8")
+                status = 200
+            except Exception as exc:  # graph down mid-session: show it, keep serving
+                logger.warning("dashboard render failed: %s", exc)
+                body = (
+                    "<!DOCTYPE html><html><body style='font-family:sans-serif;padding:2rem'>"
+                    "<h1>Dashboard could not read the graph</h1>"
+                    f"<pre>{html.escape(str(exc))}</pre>"
+                    "<p>Is Neo4j running? Check wheeler.yaml, then Refresh.</p>"
+                    "</body></html>"
+                ).encode("utf-8")
+                status = 503
+            self.send_response(status)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args) -> None:  # keep the console quiet
+            return
+
+    return ThreadingHTTPServer((host, port), Handler)
+
+
+def serve(
+    config: WheelerConfig,
+    *,
+    host: str = "127.0.0.1",
+    port: int = 8765,
+    limit: int = 12,
+    open_browser: bool = True,
+    on_start=None,
+) -> None:
+    """Serve the dashboard until interrupted (Ctrl+C). Blocking.
+
+    ``on_start(url)`` is called once the server is bound (used by the CLI to
+    print the URL). Raises ``OSError`` if the address cannot be bound.
+    """
+    import webbrowser
+
+    httpd = make_server(config, host, port, limit)
+    bound_port = httpd.server_address[1]
+    url = f"http://{host}:{bound_port}/"
+    if on_start is not None:
+        on_start(url)
+    if open_browser:
+        try:
+            webbrowser.open(url)
+        except Exception:
+            logger.debug("could not open browser", exc_info=True)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        httpd.server_close()

--- a/wheeler/dashboard/template.py
+++ b/wheeler/dashboard/template.py
@@ -1,0 +1,372 @@
+"""The self-contained HTML/CSS/JS shell for the research dashboard.
+
+A single ``string.Template`` with ``$SLOTS`` that ``render.py`` fills. Kept as a
+module-string constant (not a data file) so it ships with the package with zero
+packaging surface and ``render.py`` stays import-only and stdlib-only.
+
+No ``$`` appears in the CSS or JS below (only in the template slots), so
+``string.Template`` substitution is unambiguous. The JS avoids template literals
+for the same reason.
+"""
+from __future__ import annotations
+
+DASHBOARD_TEMPLATE = """<!DOCTYPE html>
+<html lang="en" data-theme="auto">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>$TITLE</title>
+<style>
+:root {
+  --bg: #f6f7f9; --panel: #ffffff; --ink: #1c2330; --muted: #5b6472;
+  --line: #d8dde5; --accent: #2f6df0; --accent-ink: #ffffff;
+  --pill-bg: #eef1f6; --shadow: 0 1px 3px rgba(20,30,50,.10);
+  --q: #7c4dff; --pl: #0a8f6b; --f: #d9730d; --warn: #b25000; --stale: #b00020;
+}
+html[data-theme="dark"] {
+  --bg: #11151c; --panel: #1a212c; --ink: #e7ecf3; --muted: #9aa6b6;
+  --line: #2a3340; --accent: #5b8cff; --accent-ink: #0b0e13;
+  --pill-bg: #232c39; --shadow: 0 1px 3px rgba(0,0,0,.45);
+  --q: #b39dff; --pl: #4fd2a8; --f: #f6a96b; --warn: #ffb86b; --stale: #ff6b81;
+}
+/* auto: follow the OS preference when no explicit choice is made */
+@media (prefers-color-scheme: dark) {
+  html[data-theme="auto"] {
+    --bg: #11151c; --panel: #1a212c; --ink: #e7ecf3; --muted: #9aa6b6;
+    --line: #2a3340; --accent: #5b8cff; --accent-ink: #0b0e13;
+    --pill-bg: #232c39; --shadow: 0 1px 3px rgba(0,0,0,.45);
+    --q: #b39dff; --pl: #4fd2a8; --f: #f6a96b; --warn: #ffb86b; --stale: #ff6b81;
+  }
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0; background: var(--bg); color: var(--ink);
+  font: 15px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+a { color: var(--accent); }
+.wrap { max-width: 1280px; margin: 0 auto; padding: 18px; }
+header.top {
+  display: flex; align-items: center; gap: 14px; flex-wrap: wrap;
+  padding-bottom: 12px; border-bottom: 1px solid var(--line); margin-bottom: 16px;
+}
+header.top h1 { font-size: 20px; margin: 0; }
+.gen { color: var(--muted); font-size: 13px; }
+.counts { display: flex; gap: 8px; flex-wrap: wrap; }
+.count { background: var(--pill-bg); border-radius: 999px; padding: 3px 11px; font-size: 13px; }
+.count b { color: var(--ink); }
+.spacer { flex: 1 1 auto; }
+.toolbtn {
+  background: var(--panel); color: var(--ink); border: 1px solid var(--line);
+  border-radius: 8px; padding: 6px 12px; font-size: 13px; cursor: pointer;
+}
+.toolbtn:hover { border-color: var(--accent); }
+.toolbtn:focus-visible, a:focus-visible, summary:focus-visible, textarea:focus-visible {
+  outline: 3px solid var(--accent); outline-offset: 2px;
+}
+#filter {
+  background: var(--panel); color: var(--ink); border: 1px solid var(--line);
+  border-radius: 8px; padding: 6px 12px; font-size: 13px; min-width: 200px;
+}
+/* hero */
+section.hero { margin-bottom: 16px; }
+.hero-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(360px, 1fr)); gap: 14px; }
+.zone-h { display: flex; align-items: baseline; gap: 8px; margin: 0 0 10px; font-size: 16px; }
+.zone-h .badge-count { color: var(--muted); font-size: 13px; font-weight: 400; }
+/* four corners */
+.zones { display: grid; grid-template-columns: 1fr 1fr; grid-template-rows: auto auto; gap: 16px; }
+@media (max-width: 900px) { .zones { grid-template-columns: 1fr; } }
+section.zone {
+  background: var(--panel); border: 1px solid var(--line); border-radius: 12px;
+  box-shadow: var(--shadow); padding: 14px; min-height: 120px;
+}
+.card {
+  border: 1px solid var(--line); border-radius: 10px; padding: 10px 12px;
+  margin-bottom: 10px; background: var(--bg);
+}
+.card:last-child { margin-bottom: 0; }
+.card-head { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.card-title { font-weight: 600; }
+.empty { color: var(--muted); font-style: italic; }
+/* badges + pills */
+.node-id {
+  font: 600 12px/1 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  padding: 2px 6px; border-radius: 5px; background: var(--pill-bg); color: var(--ink);
+  border: 1px solid var(--line);
+}
+.node-id.t-Q { color: var(--q); border-color: var(--q); }
+.node-id.t-P { color: var(--pl); border-color: var(--pl); }
+.node-id.t-F { color: var(--f); border-color: var(--f); }
+.pill { font-size: 12px; padding: 2px 9px; border-radius: 999px; background: var(--pill-bg); }
+.pill-in-progress { background: #fde9d0; color: #8a4b00; }
+.pill-approved { background: #d6f0e4; color: #0a6b4f; }
+.pill-prio { background: var(--q); color: #fff; }
+.flag-stale { color: var(--stale); font-size: 12px; font-weight: 600; }
+.meta { color: var(--muted); font-size: 12px; }
+details > summary { cursor: pointer; color: var(--accent); font-size: 13px; margin-top: 6px; }
+details[open] > summary { margin-bottom: 6px; }
+.desc { margin: 6px 0 0; }
+/* figures */
+.fig-card { display: flex; flex-direction: column; }
+.fig-media { position: relative; background: var(--bg); border-radius: 8px; overflow: hidden; text-align: center; }
+.fig-media img { max-width: 100%; height: auto; display: block; margin: 0 auto; cursor: zoom-in; }
+.fig-media iframe { width: 100%; height: 360px; border: 0; background: #fff; }
+.hero .fig-media iframe { height: 460px; }
+.fig-placeholder { padding: 20px; color: var(--muted); font-size: 13px; }
+.fig-legend { font-size: 13px; margin: 8px 0 4px; }
+.note-wrap { margin-top: 8px; }
+.note-wrap label { font-size: 12px; color: var(--muted); display: block; margin-bottom: 3px; }
+.note {
+  width: 100%; min-height: 44px; resize: vertical; border: 1px solid var(--line);
+  border-radius: 8px; padding: 7px 9px; font: inherit; font-size: 13px;
+  background: var(--panel); color: var(--ink);
+}
+.note-row { display: flex; align-items: center; gap: 8px; margin-top: 4px; }
+.note-hint { font-size: 11px; color: var(--muted); }
+/* lightbox */
+.lightbox {
+  display: none; position: fixed; inset: 0; background: rgba(8,12,20,.86);
+  z-index: 50; align-items: center; justify-content: center; padding: 24px;
+}
+.lightbox.open { display: flex; }
+.lightbox img { max-width: 96vw; max-height: 92vh; border-radius: 8px; }
+/* canvas */
+.canvas-overlay {
+  display: none; position: fixed; inset: 0; background: var(--bg); z-index: 60; flex-direction: column;
+}
+.canvas-overlay.open { display: flex; }
+.canvas-bar {
+  display: flex; align-items: center; gap: 8px; padding: 10px 14px;
+  border-bottom: 1px solid var(--line); background: var(--panel);
+}
+.canvas-bar .title { font-weight: 600; }
+.canvas-viewport { flex: 1 1 auto; overflow: hidden; position: relative; cursor: grab; }
+.canvas-viewport.panning { cursor: grabbing; }
+.canvas-surface { position: absolute; top: 0; left: 0; transform-origin: 0 0; }
+.canvas-tile {
+  position: absolute; width: 460px; background: var(--panel); border: 1px solid var(--line);
+  border-radius: 10px; box-shadow: var(--shadow); padding: 10px;
+}
+@media (prefers-reduced-motion: reduce) {
+  .canvas-surface, .fig-media img { transition: none !important; }
+}
+footer { margin-top: 22px; padding-top: 12px; border-top: 1px solid var(--line); color: var(--muted); font-size: 12px; }
+.legend { display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 6px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+<header class="top">
+  <h1>$TITLE</h1>
+  <span class="gen">$GENERATED_LINE$PROJECT</span>
+  <span class="spacer"></span>
+  <div class="counts">$COUNTS_STRIP</div>
+  <input id="filter" type="search" placeholder="Filter cards..." aria-label="Filter cards by text">
+  <button class="toolbtn" id="refresh" type="button"
+    title="Reload this file from disk. To pull fresh graph data, re-run: wheeler dashboard">Refresh</button>
+  <button class="toolbtn" id="canvas-open" type="button">Open canvas</button>
+  <button class="toolbtn" id="theme-toggle" type="button" aria-label="Cycle light, dark, or auto theme">Theme</button>
+</header>
+
+$HERO_HTML
+
+<div class="zones">
+  <section class="zone" aria-labelledby="z-questions">
+    <h2 class="zone-h" id="z-questions">Open Questions <span class="badge-count">$Q_COUNT</span></h2>
+    $QUESTIONS_HTML
+  </section>
+  <section class="zone" aria-labelledby="z-plans">
+    <h2 class="zone-h" id="z-plans">Open Plans <span class="badge-count">$PL_COUNT</span></h2>
+    $PLANS_HTML
+  </section>
+  <section class="zone" aria-labelledby="z-results">
+    <h2 class="zone-h" id="z-results">Major Results <span class="badge-count">$R_COUNT</span></h2>
+    $RESULTS_HTML
+  </section>
+  <section class="zone" aria-labelledby="z-figures">
+    <h2 class="zone-h" id="z-figures">Figures <span class="badge-count">$F_COUNT</span></h2>
+    $FIGURES_HTML
+  </section>
+</div>
+
+<footer>$FOOTER</footer>
+</div>
+
+<div class="lightbox" id="lightbox" role="dialog" aria-modal="true" aria-label="Figure zoom">
+  <img id="lightbox-img" src="" alt="">
+</div>
+
+<div class="canvas-overlay" id="canvas" role="dialog" aria-modal="true" aria-label="Figure canvas">
+  <div class="canvas-bar">
+    <span class="title">Figure canvas</span>
+    <button class="toolbtn" type="button" data-canvas="zoomout" aria-label="Zoom out">-</button>
+    <button class="toolbtn" type="button" data-canvas="zoomin" aria-label="Zoom in">+</button>
+    <button class="toolbtn" type="button" data-canvas="reset">Fit</button>
+    <span class="spacer"></span>
+    <span class="note-hint">drag to pan, wheel to zoom, arrows to pan, Esc to close</span>
+    <button class="toolbtn" type="button" data-canvas="close">Close</button>
+  </div>
+  <div class="canvas-viewport" id="canvas-viewport" tabindex="0">
+    <div class="canvas-surface" id="canvas-surface"></div>
+  </div>
+</div>
+
+<script>
+(function () {
+  "use strict";
+  var PROJECT = $PROJECT_JSON;
+  var noteKey = function (id) { return "wh-note:" + PROJECT + ":" + id; };
+
+  // --- theme: light / dark / auto (auto follows the OS via CSS media query) ---
+  var THEME_KEY = "wh-dash-theme";
+  var THEMES = ["light", "dark", "auto"];
+  // --- refresh: reload the file from disk (re-run `wheeler dashboard` for fresh graph data) ---
+  var rb = document.getElementById("refresh");
+  if (rb) rb.addEventListener("click", function () { location.reload(); });
+
+  var tt = document.getElementById("theme-toggle");
+  function setTheme(t) {
+    document.documentElement.setAttribute("data-theme", t);
+    if (tt) tt.textContent = "Theme: " + t;
+    try { localStorage.setItem(THEME_KEY, t); } catch (e) {}
+  }
+  var saved = "auto";
+  try { saved = localStorage.getItem(THEME_KEY) || "auto"; } catch (e) {}
+  if (THEMES.indexOf(saved) === -1) saved = "auto";
+  setTheme(saved);
+  if (tt) tt.addEventListener("click", function () {
+    var cur = document.documentElement.getAttribute("data-theme");
+    var next = THEMES[(THEMES.indexOf(cur) + 1) % THEMES.length];
+    setTheme(next);
+  });
+
+  // --- notes: seed from localStorage, autosave, sync instances sharing a figid ---
+  function allNotes(id) {
+    return Array.prototype.slice.call(document.querySelectorAll('textarea.note[data-figid="' + id + '"]'));
+  }
+  Array.prototype.forEach.call(document.querySelectorAll("textarea.note"), function (ta) {
+    var id = ta.getAttribute("data-figid");
+    try {
+      var v = localStorage.getItem(noteKey(id));
+      if (v !== null) ta.value = v;
+    } catch (e) {}
+  });
+  document.addEventListener("input", function (ev) {
+    var ta = ev.target;
+    if (!ta.classList || !ta.classList.contains("note")) return;
+    var id = ta.getAttribute("data-figid");
+    try { localStorage.setItem(noteKey(id), ta.value); } catch (e) {}
+    allNotes(id).forEach(function (other) { if (other !== ta) other.value = ta.value; });
+  });
+  document.addEventListener("click", function (ev) {
+    var b = ev.target;
+    if (!b.classList || !b.classList.contains("note-copy")) return;
+    var id = b.getAttribute("data-figid");
+    var ta = document.querySelector('textarea.note[data-figid="' + id + '"]');
+    if (ta && navigator.clipboard) navigator.clipboard.writeText(ta.value);
+  });
+
+  // --- filter ---
+  var fi = document.getElementById("filter");
+  if (fi) fi.addEventListener("input", function () {
+    var q = fi.value.trim().toLowerCase();
+    Array.prototype.forEach.call(document.querySelectorAll(".card"), function (c) {
+      c.style.display = (!q || c.textContent.toLowerCase().indexOf(q) !== -1) ? "" : "none";
+    });
+  });
+
+  // --- lightbox ---
+  var lb = document.getElementById("lightbox"), lbi = document.getElementById("lightbox-img");
+  var lbTrigger = null;
+  function openLB(src, alt) {
+    lbi.src = src; lbi.alt = alt || ""; lb.classList.add("open"); lb.focus();
+  }
+  function closeLB() {
+    lb.classList.remove("open"); lbi.src = "";
+    if (lbTrigger) { lbTrigger.focus(); lbTrigger = null; }
+  }
+  document.addEventListener("click", function (ev) {
+    var img = ev.target;
+    if (img.tagName === "IMG" && img.closest && img.closest(".fig-media") && !img.closest(".canvas-tile")) {
+      lbTrigger = img; openLB(img.src, img.alt);
+    } else if (ev.target === lb || ev.target === lbi) { closeLB(); }
+  });
+
+  // --- canvas ---
+  var canvas = document.getElementById("canvas");
+  var surface = document.getElementById("canvas-surface");
+  var viewport = document.getElementById("canvas-viewport");
+  var view = { x: 40, y: 40, s: 1 };
+  var canvasTrigger = null, built = false;
+  function applyView() {
+    surface.style.transform = "translate(" + view.x + "px," + view.y + "px) scale(" + view.s + ")";
+  }
+  function buildCanvas() {
+    if (built) return;
+    var cards = document.querySelectorAll(".fig-card");
+    var col = 0, row = 0, perRow = 3;
+    Array.prototype.forEach.call(cards, function (card, i) {
+      var tile = document.createElement("div");
+      tile.className = "canvas-tile";
+      tile.style.left = (col * 500) + "px";
+      tile.style.top = (row * 540) + "px";
+      tile.innerHTML = card.innerHTML;
+      surface.appendChild(tile);
+      col++; if (col >= perRow) { col = 0; row++; }
+    });
+    built = true;
+  }
+  function openCanvas() {
+    buildCanvas(); canvas.classList.add("open"); view = { x: 40, y: 40, s: 1 }; applyView();
+    viewport.focus();
+  }
+  function closeCanvas() {
+    canvas.classList.remove("open");
+    if (canvasTrigger) { canvasTrigger.focus(); canvasTrigger = null; }
+  }
+  var co = document.getElementById("canvas-open");
+  if (co) co.addEventListener("click", function () { canvasTrigger = co; openCanvas(); });
+  canvas.addEventListener("click", function (ev) {
+    var act = ev.target.getAttribute && ev.target.getAttribute("data-canvas");
+    if (act === "close") closeCanvas();
+    else if (act === "zoomin") { view.s = Math.min(4, view.s * 1.2); applyView(); }
+    else if (act === "zoomout") { view.s = Math.max(0.2, view.s / 1.2); applyView(); }
+    else if (act === "reset") { view = { x: 40, y: 40, s: 1 }; applyView(); }
+  });
+  viewport.addEventListener("wheel", function (ev) {
+    if (!canvas.classList.contains("open")) return;
+    ev.preventDefault();
+    var f = ev.deltaY < 0 ? 1.1 : 1 / 1.1;
+    view.s = Math.max(0.2, Math.min(4, view.s * f)); applyView();
+  }, { passive: false });
+  var drag = null;
+  viewport.addEventListener("mousedown", function (ev) {
+    if (ev.target.closest && ev.target.closest("textarea, button, a")) return;
+    drag = { x: ev.clientX, y: ev.clientY, ox: view.x, oy: view.y };
+    viewport.classList.add("panning");
+  });
+  window.addEventListener("mousemove", function (ev) {
+    if (!drag) return;
+    view.x = drag.ox + (ev.clientX - drag.x); view.y = drag.oy + (ev.clientY - drag.y); applyView();
+  });
+  window.addEventListener("mouseup", function () { drag = null; viewport.classList.remove("panning"); });
+  viewport.addEventListener("keydown", function (ev) {
+    var step = 60;
+    if (ev.key === "ArrowLeft") { view.x += step; applyView(); }
+    else if (ev.key === "ArrowRight") { view.x -= step; applyView(); }
+    else if (ev.key === "ArrowUp") { view.y += step; applyView(); }
+    else if (ev.key === "ArrowDown") { view.y -= step; applyView(); }
+    else if (ev.key === "+" || ev.key === "=") { view.s = Math.min(4, view.s * 1.2); applyView(); }
+    else if (ev.key === "-") { view.s = Math.max(0.2, view.s / 1.2); applyView(); }
+  });
+
+  // --- global escape ---
+  document.addEventListener("keydown", function (ev) {
+    if (ev.key !== "Escape") return;
+    if (canvas.classList.contains("open")) closeCanvas();
+    else if (lb.classList.contains("open")) closeLB();
+  });
+})();
+</script>
+</body>
+</html>
+"""

--- a/wheeler/dashboard/template.py
+++ b/wheeler/dashboard/template.py
@@ -327,7 +327,10 @@ $HERO_HTML
     var id = ta.getAttribute("data-figid");
     try {
       var v = localStorage.getItem(noteKey(id));
-      if (v !== null) ta.value = v;
+      // Only seed from local storage when the server-rendered durable note is
+      // empty, so a durable note (set via `wheeler dashboard note`) is never
+      // clobbered by a stale or empty browser-local value.
+      if (v && !ta.value) ta.value = v;
     } catch (e) {}
   });
   document.addEventListener("input", function (ev) {
@@ -390,6 +393,17 @@ $HERO_HTML
       tile.style.left = (col * 500) + "px";
       tile.style.top = (row * 540) + "px";
       tile.innerHTML = card.innerHTML;
+      // Strip duplicate ids/for-refs the clone introduces, and avoid embedding
+      // interactive iframes twice (double payload + re-running their scripts):
+      // replace cloned iframes with a lightweight placeholder.
+      Array.prototype.forEach.call(tile.querySelectorAll("[id]"), function (e) { e.removeAttribute("id"); });
+      Array.prototype.forEach.call(tile.querySelectorAll("label[for]"), function (e) { e.removeAttribute("for"); });
+      Array.prototype.forEach.call(tile.querySelectorAll("iframe"), function (fr) {
+        var ph = document.createElement("div");
+        ph.className = "fig-placeholder";
+        ph.textContent = "Interactive figure (open from the main view)";
+        fr.parentNode.replaceChild(ph, fr);
+      });
       surface.appendChild(tile);
       col++; if (col >= perRow) { col = 0; row++; }
     });

--- a/wheeler/dashboard/template.py
+++ b/wheeler/dashboard/template.py
@@ -180,7 +180,7 @@ footer { margin-top: 22px; padding-top: 12px; border-top: 1px solid var(--line);
   <div class="counts">$COUNTS_STRIP</div>
   <input id="filter" type="search" placeholder="Filter cards..." aria-label="Filter cards by text">
   <button class="toolbtn" id="refresh" type="button"
-    title="Reload this file from disk. To pull fresh graph data, re-run: wheeler dashboard">Refresh</button>
+    title="Reload to re-query the knowledge graph for the latest data">Refresh</button>
   <button class="toolbtn" id="canvas-open" type="button">Open canvas</button>
   <button class="toolbtn" id="theme-toggle" type="button" aria-label="Cycle light, dark, or auto theme">Theme</button>
 </header>

--- a/wheeler/dashboard/template.py
+++ b/wheeler/dashboard/template.py
@@ -96,6 +96,24 @@ section.zone {
 .node-id.t-Q { color: var(--q); border-color: var(--q); }
 .node-id.t-P { color: var(--pl); border-color: var(--pl); }
 .node-id.t-F { color: var(--f); border-color: var(--f); }
+.node-id[data-nodeid] { cursor: pointer; }
+.node-id[data-nodeid]:hover { filter: brightness(1.12); }
+#toast {
+  position: fixed; bottom: 22px; left: 50%; transform: translateX(-50%);
+  background: var(--ink); color: var(--bg); padding: 8px 14px; border-radius: 8px;
+  font-size: 13px; opacity: 0; pointer-events: none; transition: opacity .18s; z-index: 80;
+}
+#toast.show { opacity: 1; }
+.nodemenu {
+  position: absolute; display: none; background: var(--panel); border: 1px solid var(--line);
+  border-radius: 8px; box-shadow: var(--shadow); z-index: 90; min-width: 170px; padding: 4px;
+}
+.nodemenu.open { display: block; }
+.nodemenu button {
+  display: block; width: 100%; text-align: left; background: none; border: 0; color: var(--ink);
+  padding: 7px 10px; border-radius: 6px; cursor: pointer; font: inherit; font-size: 13px;
+}
+.nodemenu button:hover { background: var(--pill-bg); }
 .pill { font-size: 12px; padding: 2px 9px; border-radius: 999px; background: var(--pill-bg); }
 .pill-in-progress { background: #fde9d0; color: #8a4b00; }
 .pill-approved { background: #d6f0e4; color: #0a6b4f; }
@@ -195,6 +213,13 @@ $HERO_HTML
   <img id="lightbox-img" src="" alt="">
 </div>
 
+<div id="toast" role="status" aria-live="polite"></div>
+
+<div class="nodemenu" id="nodemenu" role="menu" aria-label="Node actions">
+  <button type="button" data-copy="ref" role="menuitem">Copy reference [id]</button>
+  <button type="button" data-copy="id" role="menuitem">Copy node id</button>
+</div>
+
 <div class="canvas-overlay" id="canvas" role="dialog" aria-modal="true" aria-label="Figure canvas">
   <div class="canvas-bar">
     <span class="title">Figure canvas</span>
@@ -215,6 +240,61 @@ $HERO_HTML
   "use strict";
   var PROJECT = $PROJECT_JSON;
   var noteKey = function (id) { return "wh-note:" + PROJECT + ":" + id; };
+
+  // --- clipboard + toast ---
+  function copyText(t) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(t);
+    } else {
+      var ta = document.createElement("textarea");
+      ta.value = t; ta.style.position = "fixed"; ta.style.opacity = "0";
+      document.body.appendChild(ta); ta.select();
+      try { document.execCommand("copy"); } catch (e) {}
+      document.body.removeChild(ta);
+    }
+  }
+  var toastEl = document.getElementById("toast");
+  function toast(msg) {
+    toastEl.textContent = msg; toastEl.classList.add("show");
+    clearTimeout(toastEl._t);
+    toastEl._t = setTimeout(function () { toastEl.classList.remove("show"); }, 1400);
+  }
+
+  // --- copyable node badges: click/Enter copies [ID]; right-click for options ---
+  function badgeOf(t) { return t && t.closest ? t.closest(".node-id[data-nodeid]") : null; }
+  document.addEventListener("click", function (ev) {
+    var b = badgeOf(ev.target);
+    if (!b) return;
+    var id = b.getAttribute("data-nodeid");
+    copyText("[" + id + "]"); toast("Copied [" + id + "]");
+  });
+  document.addEventListener("keydown", function (ev) {
+    if (ev.key !== "Enter" && ev.key !== " ") return;
+    var b = ev.target;
+    if (!b.classList || !b.classList.contains("node-id") || !b.getAttribute("data-nodeid")) return;
+    ev.preventDefault();
+    var id = b.getAttribute("data-nodeid");
+    copyText("[" + id + "]"); toast("Copied [" + id + "]");
+  });
+  var nodemenu = document.getElementById("nodemenu");
+  var menuId = null;
+  document.addEventListener("contextmenu", function (ev) {
+    var b = badgeOf(ev.target);
+    if (!b) return;
+    ev.preventDefault();
+    menuId = b.getAttribute("data-nodeid");
+    nodemenu.style.left = ev.pageX + "px";
+    nodemenu.style.top = ev.pageY + "px";
+    nodemenu.classList.add("open");
+  });
+  nodemenu.addEventListener("click", function (ev) {
+    var act = ev.target.getAttribute && ev.target.getAttribute("data-copy");
+    if (!act || !menuId) return;
+    var val = act === "ref" ? "[" + menuId + "]" : menuId;
+    copyText(val); toast("Copied " + val);
+    nodemenu.classList.remove("open");
+  });
+  document.addEventListener("click", function () { nodemenu.classList.remove("open"); });
 
   // --- theme: light / dark / auto (auto follows the OS via CSS media query) ---
   var THEME_KEY = "wh-dash-theme";
@@ -362,7 +442,8 @@ $HERO_HTML
   // --- global escape ---
   document.addEventListener("keydown", function (ev) {
     if (ev.key !== "Escape") return;
-    if (canvas.classList.contains("open")) closeCanvas();
+    if (nodemenu.classList.contains("open")) nodemenu.classList.remove("open");
+    else if (canvas.classList.contains("open")) closeCanvas();
     else if (lb.classList.contains("open")) closeLB();
   });
 })();

--- a/wheeler/dashboard/template.py
+++ b/wheeler/dashboard/template.py
@@ -140,6 +140,10 @@ details[open] > summary { margin-bottom: 6px; }
 }
 .note-row { display: flex; align-items: center; gap: 8px; margin-top: 4px; }
 .note-hint { font-size: 11px; color: var(--muted); }
+.durable-note {
+  margin: 6px 0; padding: 7px 9px; border-left: 3px solid var(--pl);
+  background: var(--pill-bg); border-radius: 0 8px 8px 0; font-size: 13px;
+}
 /* lightbox */
 .lightbox {
   display: none; position: fixed; inset: 0; background: rgba(8,12,20,.86);

--- a/wheeler/tools/cli.py
+++ b/wheeler/tools/cli.py
@@ -999,38 +999,50 @@ def dashboard_pins() -> None:
 
 @dashboard_app.command("note")
 def dashboard_note(
-    figure_id: str = typer.Argument(..., help="Figure id to annotate."),
-    text: str = typer.Argument("", help="Note text. Empty clears the note."),
+    figure_id: str = typer.Argument(..., help="Figure id to annotate (e.g. F-1a2b)."),
+    text: str = typer.Argument(..., help="Note text."),
 ) -> None:
-    """Set (or clear, when text is empty) a durable note shown under a figure."""
-    from wheeler.dashboard.gather import read_notes, write_notes
+    """Record a durable note on a figure as a provenance-tracked ResearchNote.
+
+    Creates a ResearchNote (N-) linked RELEVANT_TO the figure, via the same
+    add_note path as wh:note, so the note lives in the graph and travels with
+    backups. Shown under the figure on the dashboard.
+    """
+    from wheeler.dashboard.gather import record_figure_note
 
     config = load_config()
-    notes = read_notes(config)
-    if text:
-        notes[figure_id] = text
-        write_notes(config, notes)
-        console.print(f"[green]Note set:[/green] {figure_id}")
-    else:
-        if figure_id in notes:
-            del notes[figure_id]
-            write_notes(config, notes)
-        console.print(f"[green]Note cleared:[/green] {figure_id}")
+    if not text.strip():
+        console.print("[yellow]Provide note text to record.[/yellow]")
+        raise typer.Exit(1)
+    try:
+        note_id = asyncio.run(record_figure_note(config, figure_id, text))
+    except Exception as exc:
+        console.print(f"[red]Could not record note:[/red] {exc}")
+        raise typer.Exit(1)
+    if not note_id:
+        console.print("[red]Note was not created.[/red]")
+        raise typer.Exit(1)
+    console.print(f"[green]Recorded[/green] {note_id} (ResearchNote) linked to {figure_id}")
 
 
 @dashboard_app.command("notes")
 def dashboard_notes() -> None:
-    """List durable figure notes."""
-    from wheeler.dashboard.gather import read_notes
+    """List figure notes (ResearchNotes linked to figures) from the graph."""
+    from wheeler.dashboard.gather import list_all_figure_notes
 
     config = load_config()
-    notes = read_notes(config)
-    if not notes:
-        console.print("[yellow]No durable notes.[/yellow]")
+    try:
+        rows = asyncio.run(list_all_figure_notes(config))
+    except Exception as exc:
+        console.print(f"[red]Could not read notes:[/red] {exc}")
+        raise typer.Exit(1)
+    if not rows:
+        console.print("[yellow]No figure notes.[/yellow]")
         return
-    for fid, text in notes.items():
-        snippet = text if len(text) <= 70 else text[:70] + "..."
-        console.print(f"  {fid}: {snippet}")
+    for r in rows:
+        content = str(r.get("content", ""))
+        snippet = content if len(content) <= 70 else content[:70] + "..."
+        console.print(f"  {r.get('nid')} -> {r.get('fid')}: {snippet}")
 
 
 # ---------------------------------------------------------------------------

--- a/wheeler/tools/cli.py
+++ b/wheeler/tools/cli.py
@@ -41,6 +41,11 @@ app.add_typer(graph_app, name="graph")
 dev_app = typer.Typer(help="Developer commands.")
 app.add_typer(dev_app, name="dev")
 
+dashboard_app = typer.Typer(
+    help="Render an interactive HTML research dashboard from the knowledge graph."
+)
+app.add_typer(dashboard_app, name="dashboard")
+
 # External-tool integrations (Asta Paper Finder, etc.). Guarded so a missing
 # integrations package never breaks the rest of the CLI.
 try:
@@ -897,6 +902,137 @@ def cmd_migrate(
     except Exception as exc:
         console.print(f"[red]Migration failed:[/red] {exc}")
         raise typer.Exit(1)
+
+
+# ---------------------------------------------------------------------------
+# dashboard
+# ---------------------------------------------------------------------------
+
+
+@dashboard_app.callback(invoke_without_command=True)
+def dashboard_main(
+    ctx: typer.Context,
+    output: Path = typer.Option(
+        Path(".wheeler/dashboard.html"), "--output", "-o", help="Output HTML file."
+    ),
+    limit: int = typer.Option(12, "--limit", "-l", help="Max items per zone."),
+    open_browser: bool = typer.Option(
+        False, "--open", help="Open the rendered file in a browser."
+    ),
+) -> None:
+    """Render the dashboard (default action when no subcommand is given)."""
+    if ctx.invoked_subcommand is not None:
+        return
+
+    import webbrowser
+
+    from wheeler.dashboard import gather_dashboard_data, render
+
+    config = load_config()
+    try:
+        data = asyncio.run(gather_dashboard_data(config, limit=limit))
+    except Exception as exc:
+        console.print(f"[red]Could not read the graph:[/red] {exc}")
+        console.print(
+            "[yellow]Is Neo4j running?[/yellow] Check your connection in wheeler.yaml. "
+            "No file was written."
+        )
+        raise typer.Exit(1)
+
+    html, missing = render(data)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(html, encoding="utf-8")
+    console.print(f"[green]Dashboard written:[/green] {output.resolve()}")
+    if missing:
+        console.print(f"[yellow]{len(missing)} figure file(s) missing or too large:[/yellow]")
+        for m in missing[:10]:
+            console.print(f"  - {m}")
+    if open_browser:
+        webbrowser.open(output.resolve().as_uri())
+
+
+@dashboard_app.command("pin")
+def dashboard_pin(
+    figure_id: str = typer.Argument(..., help="Finding/figure id to pin (e.g. F-1a2b)."),
+) -> None:
+    """Pin a figure as a main (hero) figure on the dashboard."""
+    from wheeler.dashboard.gather import read_pins, write_pins
+
+    config = load_config()
+    pins = read_pins(config)
+    if figure_id in pins:
+        console.print(f"[yellow]Already pinned:[/yellow] {figure_id}")
+        return
+    pins.append(figure_id)
+    write_pins(config, pins)
+    console.print(f"[green]Pinned:[/green] {figure_id} ({len(pins)} pinned)")
+
+
+@dashboard_app.command("unpin")
+def dashboard_unpin(
+    figure_id: str = typer.Argument(..., help="Figure id to unpin."),
+) -> None:
+    """Remove a figure from the main (hero) figures."""
+    from wheeler.dashboard.gather import read_pins, write_pins
+
+    config = load_config()
+    pins = read_pins(config)
+    if figure_id not in pins:
+        console.print(f"[yellow]Not pinned:[/yellow] {figure_id}")
+        return
+    pins = [p for p in pins if p != figure_id]
+    write_pins(config, pins)
+    console.print(f"[green]Unpinned:[/green] {figure_id} ({len(pins)} pinned)")
+
+
+@dashboard_app.command("pins")
+def dashboard_pins() -> None:
+    """List the currently pinned figures."""
+    from wheeler.dashboard.gather import read_pins
+
+    config = load_config()
+    pins = read_pins(config)
+    if not pins:
+        console.print("[yellow]No pinned figures.[/yellow]")
+        return
+    for i, p in enumerate(pins, start=1):
+        console.print(f"  {i}. {p}")
+
+
+@dashboard_app.command("note")
+def dashboard_note(
+    figure_id: str = typer.Argument(..., help="Figure id to annotate."),
+    text: str = typer.Argument("", help="Note text. Empty clears the note."),
+) -> None:
+    """Set (or clear, when text is empty) a durable note shown under a figure."""
+    from wheeler.dashboard.gather import read_notes, write_notes
+
+    config = load_config()
+    notes = read_notes(config)
+    if text:
+        notes[figure_id] = text
+        write_notes(config, notes)
+        console.print(f"[green]Note set:[/green] {figure_id}")
+    else:
+        if figure_id in notes:
+            del notes[figure_id]
+            write_notes(config, notes)
+        console.print(f"[green]Note cleared:[/green] {figure_id}")
+
+
+@dashboard_app.command("notes")
+def dashboard_notes() -> None:
+    """List durable figure notes."""
+    from wheeler.dashboard.gather import read_notes
+
+    config = load_config()
+    notes = read_notes(config)
+    if not notes:
+        console.print("[yellow]No durable notes.[/yellow]")
+        return
+    for fid, text in notes.items():
+        snippet = text if len(text) <= 70 else text[:70] + "..."
+        console.print(f"  {fid}: {snippet}")
 
 
 # ---------------------------------------------------------------------------

--- a/wheeler/tools/cli.py
+++ b/wheeler/tools/cli.py
@@ -912,43 +912,41 @@ def cmd_migrate(
 @dashboard_app.callback(invoke_without_command=True)
 def dashboard_main(
     ctx: typer.Context,
-    output: Path = typer.Option(
-        Path(".wheeler/dashboard.html"), "--output", "-o", help="Output HTML file."
-    ),
+    host: str = typer.Option("127.0.0.1", "--host", help="Host to bind."),
+    port: int = typer.Option(8765, "--port", "-p", help="Port to bind."),
     limit: int = typer.Option(12, "--limit", "-l", help="Max items per zone."),
     open_browser: bool = typer.Option(
-        False, "--open", help="Open the rendered file in a browser."
+        True, "--open/--no-open", help="Open the dashboard in a browser."
     ),
 ) -> None:
-    """Render the dashboard (default action when no subcommand is given)."""
+    """Serve a live HTML dashboard that re-queries the graph on every load."""
     if ctx.invoked_subcommand is not None:
         return
 
-    import webbrowser
-
-    from wheeler.dashboard import gather_dashboard_data, render
+    from wheeler.dashboard.serve import render_live, serve
 
     config = load_config()
+
+    # Fail fast with a friendly message if the graph is unreachable, rather than
+    # binding a port that only serves error pages.
     try:
-        data = asyncio.run(gather_dashboard_data(config, limit=limit))
+        render_live(config, limit)
     except Exception as exc:
         console.print(f"[red]Could not read the graph:[/red] {exc}")
         console.print(
-            "[yellow]Is Neo4j running?[/yellow] Check your connection in wheeler.yaml. "
-            "No file was written."
+            "[yellow]Is Neo4j running?[/yellow] Check your connection in wheeler.yaml."
         )
         raise typer.Exit(1)
 
-    html, missing = render(data)
-    output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(html, encoding="utf-8")
-    console.print(f"[green]Dashboard written:[/green] {output.resolve()}")
-    if missing:
-        console.print(f"[yellow]{len(missing)} figure file(s) missing or too large:[/yellow]")
-        for m in missing[:10]:
-            console.print(f"  - {m}")
-    if open_browser:
-        webbrowser.open(output.resolve().as_uri())
+    def _announce(url: str) -> None:
+        console.print(f"[green]Dashboard live at[/green] {url}  [dim](Ctrl+C to stop)[/dim]")
+
+    try:
+        serve(config, host=host, port=port, limit=limit, open_browser=open_browser, on_start=_announce)
+    except OSError as exc:
+        console.print(f"[red]Could not start server on {host}:{port}:[/red] {exc}")
+        console.print("[yellow]Try a different --port.[/yellow]")
+        raise typer.Exit(1)
 
 
 @dashboard_app.command("pin")

--- a/wheeler/tools/graph_tools/queries.py
+++ b/wheeler/tools/graph_tools/queries.py
@@ -149,10 +149,20 @@ async def query_findings(backend, args: dict) -> str:
 async def query_open_questions(backend, args: dict) -> str:
     ctx = _extract_context(args)
     limit = int(args.get("limit", 10))
+    # Only surface questions that are still open. Acts set status="answered"
+    # (and "in-progress") on questions; an answered question must no longer
+    # appear here (wh/CLAUDE.md). NULL status is treated as open for legacy
+    # nodes written before status tracking. Pass include_answered=True to bypass.
+    include_answered = bool(args.get("include_answered", False))
+    if include_answered:
+        where = _project_where("q", ctx.project_tag, has_existing_where=False)
+    else:
+        where = " WHERE (q.status = 'open' OR q.status IS NULL)" + _project_where(
+            "q", ctx.project_tag, has_existing_where=True
+        )
 
     records = await backend.run_cypher(
-        "MATCH (q:OpenQuestion)"
-        f"{_project_where('q', ctx.project_tag, has_existing_where=False)} "
+        f"MATCH (q:OpenQuestion){where} "
         "RETURN q.id AS id, q.question AS question, q.priority AS priority "
         "ORDER BY q.priority DESC LIMIT $limit",
         _inject_ptag({"limit": limit}, ctx.project_tag),


### PR DESCRIPTION
## What this adds

A new `wheeler dashboard` command that serves a **live, interactive HTML overview** of the most recent progress across the Wheeler knowledge graph. It re-queries the graph on every load (real Refresh), with four visual zones plus a pinnable hero section:

- **Open Questions** (priority), **Open Plans** (approved / in-progress), **Major Results** (findings), **Figures**.
- **Hero / main figures** you pin (`wheeler dashboard pin F-xxxx`), shown large; figures can be **static images or interactive HTML** (sandboxed `<iframe srcdoc>`).
- **Copyable node badges**: click (or right-click) any `[F-/Q-/PL-/N-xxxx]` to copy its reference and point an LLM straight at the node.
- **Infinite pan/zoom canvas**, light/dark/**auto** theme, text filter, figure lightbox, per-figure notes.

> Note: this started as a static file and is now a **live local server** (re-queries on every load). Earlier commits in the branch reflect that evolution.

## Built on existing infrastructure (not redundant stores)

- **Notes = provenance.** A figure note is a `ResearchNote` (`N-`) linked `RELEVANT_TO` the figure, created through the *same* `add_note` → `link_nodes` → `execute_tool` triple-write path as `wh:note`. It lives in the graph, travels in backups, and renders with a copyable `N-` badge. No separate notes store.
- **Filtering = the shared query, fixed in place.** `query_open_questions` now hides answered questions by default (`q.status = 'open' OR q.status IS NULL`), matching `wh/CLAUDE.md` and `/wh:resume|status`, so the dashboard and the acts agree on what "open" means (`include_answered=True` opts out).
- **Read-only render.** `gather_dashboard_data` reads via the existing `query_*` helpers (with `_config` injected for project-tag scoping) and `count_all`; `render(data)` is pure, stdlib-only, deterministic.
- **Pins** stay local view-state (a pin isn't a research fact): `.wheeler/dashboard/pins.json`, project-tag scoped, read-only to the graph.

## Architecture / layering

- New `wheeler/dashboard/` subpackage: `gather.py` (async read + pure helpers), `render.py` (pure HTML), `template.py` (self-contained HTML/CSS/JS), `serve.py` (stdlib HTTP server). No web-framework dependency.
- Read-only: does **not** route through `execute_tool` except the explicit `note` write (which correctly does). No imports added to `models.py`/`config.py`. Ships automatically (`packages = ["wheeler"]`).

## Performance

- Live graph queries every request (must be current); the expensive figure base64/srcdoc embedding is **memoized by file signature** `(path, mtime, size)`. Counts reuse `count_all()`.

## Hardened by adversarial review

Fixes applied and tested: single-threaded server + `invalidate_async_driver()` (no cross-loop driver reuse), `</script>` breakout defused in the inline script, `srcdoc` attribute-escaping confirmed, canvas clones strip duplicate ids and don't double-run iframes, durable-note vs browser-scratch precedence, pinned-figure-past-window loaded directly, project-tag-scoped pins/notes, non-aliasing note attach.

## Tests

`tests/test_render_dashboard.py`, `test_dashboard_gather.py`, `test_dashboard_cli.py`, `test_dashboard_serve.py` (real-socket smoke), `test_dashboard_slice.py` (end-to-end vertical slice), plus Wheeler-side open-question filter tests. Full non-e2e suite passes (exit 0); ruff + mypy clean.

## Try it

```bash
wheeler dashboard                 # serve live at http://127.0.0.1:8765 (Ctrl+C to stop)
wheeler dashboard pin F-1a2b      # main/hero figure
wheeler dashboard note F-1a2b "headline result"   # provenance-tracked ResearchNote
```

## Open question for review

- **Pins**: currently local view-state. Should pinning also become a graph signal (e.g. a node tag) for durability, or stay a pure dashboard preference? Notes already went to the graph; pins were left local deliberately. Happy to change.

Draft while the design settles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CXjbyJwZQPpZVtV9NJraJ