### PR TITLE
fix(asta): positive-only Paper Finder queries and the real Theorizer CLI (closes #83, #84)

### DIFF
--- a/.claude/commands/wh/asta-lit.md
+++ b/.claude/commands/wh/asta-lit.md
@@ -24,6 +24,9 @@ You are Wheeler, running an Asta Paper Finder literature search and marshalling 
 ## Choose the query and link target
 
 - The query is `$ARGUMENTS` when provided. If empty, ask the user for a topic or derive one from the active question.
+- Compose a POSITIVE TOPICAL query: name the subject matter you want in plain research language, a few hundred characters at most. Paper Finder parses the query into a paper specification, and positive topic statements are the only shape its grammar covers.
+- Do not put exclusions or negations in the query ("exclude mouse and rat studies", "avoid reviews", "not in humans"), and do not put meta-framing in it either ("find the core papers on", "the best work on", "identify key studies", "restrict to"). Both shapes fall outside the specification grammar: the search fails with `No rules matched for paper specification` and the whole run is lost.
+- Reshape a negative or meta-framed request into its positive equivalent before running. "Core papers on primate parasol mechanisms, excluding mouse and rat studies" becomes "macaque and human OFF-parasol ganglion cell mechanisms". Say what the papers should be ABOUT instead of what they should not be, then apply the excluded criteria yourself when you review the returned papers.
 - Pick at most one link target: the Question (`Q-...`) or Plan (`PL-...`) this search supports. Each found paper will be linked `RELEVANT_TO` that node. If there is no clear target, run without one.
 
 ## Run the search

--- a/.claude/commands/wh/asta-theorize.md
+++ b/.claude/commands/wh/asta-theorize.md
@@ -29,11 +29,13 @@ You are Wheeler, running an Asta Theorizer pass over a research question and mar
 
 ## Run the generation
 
-Run the CLI, writing the artifact to a temp file. This requires an Asta login:
+Run the CLI, capturing the artifact to a temp file. This requires an Asta login. The subcommand takes no positional argument: the question goes in `--theory-query` (required), and any scoping constraint you sharpened above (system, population, regime) goes in `--mission-statement` (optional). There is no output flag, so redirect stdout to the artifact path:
 
 ```
-asta generate-theories literature-theory-generation "$QUESTION" -o /tmp/asta-theorizer.json
+asta generate-theories literature-theory-generation --theory-query "$QUESTION" --mission-statement "$SCOPE" > /tmp/asta-theorizer.json
 ```
+
+Drop `--mission-statement` when there is no scoping constraint. Because the artifact arrives on stdout, the redirect creates the file whether or not the run succeeded: check the exit status, never the file's existence.
 
 If the command exits non-zero (including a login or auth failure), FIRST record the failed attempt so the expensive run is not silently lost (the failsafe: the external job is an Execution, and a failed one must be visible, not absent):
 

--- a/tests/regression/test_issue_83.py
+++ b/tests/regression/test_issue_83.py
@@ -32,13 +32,15 @@ def test_asta_lit_act_documents_positive_query_format() -> None:
     act_content = act_path.read_text()
 
     # The act should provide guidance on query format.
-    # Look for keywords that indicate positive query instruction:
+    # These phrases must be SPECIFIC to the new guidance. A bare "topic" is not
+    # enough: the unfixed act already said "ask the user for a topic", so that
+    # substring matched on main and the assertion guarded nothing.
     has_positive_guidance = any(
         phrase in act_content.lower()
         for phrase in [
-            "positive",
+            "positive topical",
             "topical query",
-            "topic",
+            "positive query",
             "avoid exclusion",
             "avoid negative",
             "no exclusion",

--- a/tests/regression/test_issue_83.py
+++ b/tests/regression/test_issue_83.py
@@ -1,0 +1,126 @@
+"""Regression test for issue #83: skill/wh:asta-lit query composition guidance.
+
+Issue: The wh:asta-lit act composes queries for Asta Paper Finder without
+guidance on query format. When composed queries contain exclusion clauses
+("Exclude mouse, rat...") or meta-framing ("Core papers on...", "Restrict to..."),
+Paper Finder may reject them with "No rules matched for paper specification".
+
+The act should instruct Claude to write positive topical queries only.
+
+Steps to reproduce:
+1. Read the wh:asta-lit act
+2. Observe it lacks guidance on query composition rules
+3. Invoke /wh:asta-lit with a request implying exclusions
+4. The act composes a query with negative/meta clauses
+5. Paper Finder rejects the query (v0.18.1) or performs poorly (newer versions)
+
+Expected: The act documents positive query composition rules.
+Actual: The act lacks this guidance.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_asta_lit_act_documents_positive_query_format() -> None:
+    """The wh:asta-lit act should document that queries must be positive topical."""
+    repo_root = Path(__file__).resolve().parents[2]
+    act_path = repo_root / ".claude" / "commands" / "wh" / "asta-lit.md"
+
+    assert act_path.exists(), f"Act file not found: {act_path}"
+    act_content = act_path.read_text()
+
+    # The act should provide guidance on query format.
+    # Look for keywords that indicate positive query instruction:
+    has_positive_guidance = any(
+        phrase in act_content.lower()
+        for phrase in [
+            "positive",
+            "topical query",
+            "topic",
+            "avoid exclusion",
+            "avoid negative",
+            "no exclusion",
+            "no 'exclude'",
+            "no 'restrict'",
+            "no meta-framing",
+            "without exclusion",
+        ]
+    )
+
+    assert has_positive_guidance, (
+        "The wh:asta-lit act does not document query format guidance. "
+        "It should instruct Claude to write positive topical queries only, "
+        "without exclusion clauses ('Exclude...'), negations, or meta-framing "
+        "('Core papers on', 'Restrict to', etc.). "
+        "This causes Paper Finder to reject or mishandle such queries."
+    )
+
+
+def test_asta_lit_act_advises_reshaping_negative_requests() -> None:
+    """The wh:asta-lit act should explain how to reshape negative user requests."""
+    repo_root = Path(__file__).resolve().parents[2]
+    act_path = repo_root / ".claude" / "commands" / "wh" / "asta-lit.md"
+
+    act_content = act_path.read_text()
+
+    # The act should mention reshaping or converting negative requests to positive queries
+    has_reshape_guidance = any(
+        phrase in act_content.lower()
+        for phrase in [
+            "reshape",
+            "rephrase",
+            "rewrite",
+            "convert",
+            "instead of",
+            "as a positive",
+            "focus on what",
+            "focus on topic",
+        ]
+    )
+
+    assert has_reshape_guidance, (
+        "The wh:asta-lit act does not explain how to reshape negative user requests "
+        "(e.g., 'excluding mouse studies') into positive queries (e.g., 'primate parasol mechanisms'). "
+        "Users cannot compose valid queries without this guidance."
+    )
+
+
+def test_asta_lit_act_specifies_no_exclusion_keywords() -> None:
+    """The wh:asta-lit act should explicitly forbid exclusion keywords in queries."""
+    repo_root = Path(__file__).resolve().parents[2]
+    act_path = repo_root / ".claude" / "commands" / "wh" / "asta-lit.md"
+
+    act_content = act_path.read_text()
+
+    # The act should explicitly mention that exclusions are not allowed
+    has_exclusion_warning = (
+        "exclude" in act_content.lower() and
+        ("not" in act_content.lower() or "avoid" in act_content.lower() or "do not" in act_content.lower())
+    )
+
+    assert has_exclusion_warning, (
+        "The wh:asta-lit act should explicitly warn against using 'Exclude', "
+        "'Avoid', or negation clauses in Paper Finder queries. "
+        "Paper Finder's specification parser rejects or performs poorly on such phrasing."
+    )
+
+
+def test_asta_lit_data_commands_asta_lit_in_sync() -> None:
+    """The shipped .claude/commands/wh/asta-lit.md and wheel/_data/commands/asta-lit.md must be identical."""
+    repo_root = Path(__file__).resolve().parents[2]
+    source_path = repo_root / ".claude" / "commands" / "wh" / "asta-lit.md"
+    shipped_path = repo_root / "wheeler" / "_data" / "commands" / "asta-lit.md"
+
+    assert source_path.exists(), f"Source act not found: {source_path}"
+    assert shipped_path.exists(), f"Shipped act not found: {shipped_path}"
+
+    source_content = source_path.read_text()
+    shipped_content = shipped_path.read_text()
+
+    assert source_content == shipped_content, (
+        "The .claude/commands/wh/asta-lit.md and wheeler/_data/commands/asta-lit.md "
+        "are out of sync. Run `python -c \"from wheeler.installer import sync_data; sync_data()\"` "
+        "to regenerate the shipped version."
+    )

--- a/tests/regression/test_issue_84.py
+++ b/tests/regression/test_issue_84.py
@@ -1,0 +1,104 @@
+"""Regression test for issue #84: wh:asta-theorize command template.
+
+Issue: The documented asta CLI command in the wh:asta-theorize act
+uses an outdated interface (pre-v0.18.1) with positional question
+argument and -o output flag. Asta v0.18.1 requires --theory-query
+(required), --mission-statement (optional), and outputs to stdout.
+
+The test verifies the act's command template has been updated
+to match the current asta CLI interface.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_asta_theorize_command_uses_theory_query_flag():
+    """Verify the wh:asta-theorize act uses --theory-query, not positional question."""
+    repo_root = Path(__file__).resolve().parents[2]
+    act_file = repo_root / ".claude" / "commands" / "wh" / "asta-theorize.md"
+
+    assert act_file.exists(), f"Act file not found: {act_file}"
+
+    content = act_file.read_text()
+
+    # The documented command must use --theory-query, not a positional argument.
+    # Positional form (wrong): asta generate-theories literature-theory-generation "$QUESTION"
+    # Flag form (correct): asta generate-theories literature-theory-generation --theory-query "$QUESTION"
+
+    assert (
+        "--theory-query" in content
+    ), (
+        "Act does not document --theory-query flag. "
+        "The asta v0.18.1 CLI requires --theory-query (required parameter). "
+        "See issue #84 for details."
+    )
+
+    # The documented command must NOT use the -o flag (removed in v0.18.1).
+    # The old (wrong) form: asta generate-theories ... "$QUESTION" -o /tmp/asta-theorizer.json
+    # The new (correct) form: asta generate-theories ... --theory-query ... > /tmp/asta-theorizer.json
+    #
+    # Note: We check for the specific pattern of the old command:
+    # "generate-theories literature-theory-generation" followed by quotes and then "-o"
+    # to catch the documented shell command, not just any mention of "-o" elsewhere.
+
+    lines = content.split("\n")
+    command_lines = [
+        line
+        for line in lines
+        if "generate-theories" in line and "literature-theory-generation" in line
+    ]
+
+    assert len(command_lines) > 0, (
+        "No asta generate-theories command found in act. "
+        "The act should document how to invoke the theorizer CLI."
+    )
+
+    # Check that the documented command(s) do NOT use "-o" in the shell invocation.
+    # This is the marker of the old, broken interface.
+    for line in command_lines:
+        # Skip comment lines
+        if line.strip().startswith("#"):
+            continue
+
+        # The line should not contain both "generate-theories" and "-o" together,
+        # which would indicate the old interface.
+        # However, "-o" might appear in comments or in different contexts,
+        # so we look for the specific pattern: a command that runs asta with -o.
+        #
+        # Heuristic: if the line looks like a shell command (contains "asta" and
+        # command args) and contains "-o", it's likely the old command.
+        if "asta" in line and "-o" in line:
+            # The new interface redirects to stdout: > /tmp/asta-theorizer.json
+            # The old interface used -o: -o /tmp/asta-theorizer.json
+            # Both have the output path, but only the old one has "-o" flag.
+            if not "> " in line:
+                # If there's no stdout redirect (>), then -o is being used as a flag,
+                # which is wrong.
+                assert (
+                    False
+                ), (
+                    f"Act command uses '-o' flag (old interface): {line.strip()}\n"
+                    "Asta v0.18.1 does not support the '-o' flag. "
+                    "Use stdout redirection (>) instead. "
+                    "See issue #84."
+                )
+
+
+def test_asta_theorize_command_documents_mission_statement():
+    """Verify the wh:asta-theorize act mentions --mission-statement (scope parameter)."""
+    repo_root = Path(__file__).resolve().parents[2]
+    act_file = repo_root / ".claude" / "commands" / "wh" / "asta-theorize.md"
+
+    assert act_file.exists(), f"Act file not found: {act_file}"
+
+    content = act_file.read_text()
+
+    # The act should document --mission-statement as the way to pass constraints/scope.
+    # This is an optional parameter in asta v0.18.1.
+    assert "--mission-statement" in content, (
+        "Act does not document --mission-statement parameter. "
+        "Asta v0.18.1 supports --mission-statement for scope/constraints. "
+        "See issue #84."
+    )

--- a/wheeler/_data/commands/asta-lit.md
+++ b/wheeler/_data/commands/asta-lit.md
@@ -24,6 +24,9 @@ You are Wheeler, running an Asta Paper Finder literature search and marshalling 
 ## Choose the query and link target
 
 - The query is `$ARGUMENTS` when provided. If empty, ask the user for a topic or derive one from the active question.
+- Compose a POSITIVE TOPICAL query: name the subject matter you want in plain research language, a few hundred characters at most. Paper Finder parses the query into a paper specification, and positive topic statements are the only shape its grammar covers.
+- Do not put exclusions or negations in the query ("exclude mouse and rat studies", "avoid reviews", "not in humans"), and do not put meta-framing in it either ("find the core papers on", "the best work on", "identify key studies", "restrict to"). Both shapes fall outside the specification grammar: the search fails with `No rules matched for paper specification` and the whole run is lost.
+- Reshape a negative or meta-framed request into its positive equivalent before running. "Core papers on primate parasol mechanisms, excluding mouse and rat studies" becomes "macaque and human OFF-parasol ganglion cell mechanisms". Say what the papers should be ABOUT instead of what they should not be, then apply the excluded criteria yourself when you review the returned papers.
 - Pick at most one link target: the Question (`Q-...`) or Plan (`PL-...`) this search supports. Each found paper will be linked `RELEVANT_TO` that node. If there is no clear target, run without one.
 
 ## Run the search

--- a/wheeler/_data/commands/asta-theorize.md
+++ b/wheeler/_data/commands/asta-theorize.md
@@ -29,11 +29,13 @@ You are Wheeler, running an Asta Theorizer pass over a research question and mar
 
 ## Run the generation
 
-Run the CLI, writing the artifact to a temp file. This requires an Asta login:
+Run the CLI, capturing the artifact to a temp file. This requires an Asta login. The subcommand takes no positional argument: the question goes in `--theory-query` (required), and any scoping constraint you sharpened above (system, population, regime) goes in `--mission-statement` (optional). There is no output flag, so redirect stdout to the artifact path:
 
 ```
-asta generate-theories literature-theory-generation "$QUESTION" -o /tmp/asta-theorizer.json
+asta generate-theories literature-theory-generation --theory-query "$QUESTION" --mission-statement "$SCOPE" > /tmp/asta-theorizer.json
 ```
+
+Drop `--mission-statement` when there is no scoping constraint. Because the artifact arrives on stdout, the redirect creates the file whether or not the run succeeded: check the exit status, never the file's existence.
 
 If the command exits non-zero (including a login or auth failure), FIRST record the failed attempt so the expensive run is not silently lost (the failsafe: the external job is an Execution, and a failed one must be visible, not absent):
 


### PR DESCRIPTION
## Summary

Two act-prose fixes to the Asta marshal-in layer, grouped because both edit `.claude/commands/wh/` and both must regenerate the `wheeler/_data/commands/` mirror.

- **#83**: `wh:asta-lit` now requires a positive topical query, bans exclusion and meta-framing clauses by name, and shows how to reshape a negative request. Paper Finder rejects the banned shapes with `No rules matched for paper specification`, losing the whole run.
- **#84**: `wh:asta-theorize` documents the real Theorizer interface (`--theory-query`, `--mission-statement`, stdout redirect) instead of the nonexistent `-o` plus positional question.

## Acceptance criteria (verified)

#83
- [x] Act instructs a positive topical query only: `asta-lit.md:27-29`, banning "exclude/restrict/avoid" and "core papers on" by name.
- [x] A request implying exclusions yields an acceptable query: the reshape rule uses the issue own failing example verbatim. Assessed statically, not by a live paid Asta call.
- [x] Existing tests still pass.

#84
- [x] Act documents `--theory-query` (required) and `--mission-statement` (scope).
- [x] Output captured via stdout redirect; no `-o` remains anywhere in either copy.
- [x] The documented command matches the installed CLI. Verified against `asta generate-theories literature-theory-generation --help` on v0.101.1, and by proving both flags parse cleanly (aborted on a deliberately invalid unrelated option so no paid run fired). The old form was confirmed to still fail: `Error: No such option -o` and `Error: Got unexpected extra argument`.
- [x] Existing tests still pass.

## Test results

- Regression tests: `tests/regression/test_issue_83.py` (4) and `test_issue_84.py` (2) pass; both files were red on main.
- Full suite: 2042 passed, 2 skipped, 0 failed. Collected-count delta versus the main baseline reconciles exactly.
- E2E: the diff touches zero Python source, so the behavioral surface is the act delivery pipeline. Verified source and `_data` mirror byte-identical across all 39 acts, then replayed the `wheeler install` copy path into a temp directory and asserted the delivered bytes carry the new guidance. `install()` was deliberately not called, since its `INSTALL_BASE` is the live `~/.claude` and it rewrites `settings.json`.

## Note on scope

One commit here (`e91c946`) was added by the cycle orchestrator after verification. The independent verifier found that `test_asta_lit_act_documents_positive_query_format` accepted the bare substring "topic", which the unfixed act already contained, so the assertion passed with or without the fix and guarded nothing. The predicate now requires phrases specific to the new guidance, and was confirmed False against `git show main:.claude/commands/wh/asta-lit.md`.

## Verified by

wheeler-issue-cycle, one independent Verifier per issue, 2026-07-24.

Closes #83
Closes #84