### PR TITLE
fix(llmsr-discover): branch the preflight on the observed error (closes #89)

### DIFF
--- a/.claude/commands/wh/llmsr-discover.md
+++ b/.claude/commands/wh/llmsr-discover.md
@@ -21,7 +21,12 @@ You are Wheeler, running LLM-SR equation discovery and marshalling the result in
 
 ## Preflight
 
-1. Confirm the tool is installed: `wheeler llmsr --help`. If it fails, say LLM-SR is not available (it needs the `scipy` extra) and stop. Do not attempt the run.
+1. Confirm the tool is installed: `wheeler llmsr --help`. If it fails, read the error and report the cause the output actually shows. Do not name a cause the output does not support.
+   - `No such command 'llmsr'`: the installed Wheeler build does not include the LLM-SR CLI engine. Report that, not a missing extra. (`wheeler/tools/cli.py` registers the subcommand inside a guarded try/except ImportError, so an absent or unimportable engine module drops the subcommand instead of raising.)
+   - An import error the command surfaces (`ModuleNotFoundError: No module named 'scipy'` or similar): the optional dependency is missing. Report that LLM-SR needs the `scipy` extra.
+   - Anything else: quote the error verbatim rather than guessing at a cause.
+
+   Stop in every case. Do not attempt the run.
 2. Read context so the run is shaped by the graph. Use `mcp__wheeler_core__search_context` on the request and `mcp__wheeler_query__query_datasets` / `query_open_questions` / `query_hypotheses` to see the dataset, the motivating question, and any existing hypotheses about the functional form. Use this only to pick inputs and a link target. Do not invent results. Do not do the scientist's thinking.
 
 ## Gather the run (ASK, do not assume)

--- a/tests/regression/test_issue_89.py
+++ b/tests/regression/test_issue_89.py
@@ -1,0 +1,106 @@
+"""Regression test for issue #89: llmsr-discover preflight hard-codes one failure cause.
+
+Issue: The /wh:llmsr-discover act's preflight step 1 reads:
+
+    "Confirm the tool is installed: `wheeler llmsr --help`. If it fails, say
+     LLM-SR is not available (it needs the `scipy` extra) and stop."
+
+That attributes every preflight failure to a missing scipy extra. In practice the
+command can fail because the `llmsr` subcommand is absent from the installed build
+while scipy is present, in which case the act tells the scientist a wrong cause and
+points them at an irrelevant fix.
+
+This is a defect in the act text itself, verifiable by reading the file. It does not
+require the command to be failing on this machine: the act prescribes the wrong
+diagnosis unconditionally.
+
+Expected: the preflight branches on the observed error before naming a cause.
+Actual: a single hard-coded cause.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ACT_RELPATH = (".claude", "commands", "wh", "llmsr-discover.md")
+MIRROR_RELPATH = ("wheeler", "_data", "commands", "llmsr-discover.md")
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _act_text() -> str:
+    act_path = _repo_root().joinpath(*ACT_RELPATH)
+    assert act_path.exists(), f"Act file not found: {act_path}"
+    return act_path.read_text()
+
+
+def test_preflight_distinguishes_missing_subcommand_from_missing_scipy() -> None:
+    """The preflight must name the missing-subcommand case, not just the scipy extra."""
+    act_content = _act_text().lower()
+
+    mentions_missing_command = any(
+        phrase in act_content
+        for phrase in [
+            "no such command",
+            "not include the llm-sr",
+            "does not include the llmsr",
+            "cli engine is absent",
+            "engine is not present",
+            "subcommand is absent",
+            "subcommand is missing",
+        ]
+    )
+
+    assert mentions_missing_command, (
+        "The /wh:llmsr-discover preflight does not describe the missing-subcommand "
+        "failure mode. When `wheeler llmsr --help` fails with \"No such command 'llmsr'\", "
+        "the act should report that the installed Wheeler build does not include the "
+        "LLM-SR CLI engine, rather than blaming the scipy extra."
+    )
+
+
+def test_preflight_does_not_hardcode_scipy_as_the_only_cause() -> None:
+    """The scipy extra must be presented as one branch, not the sole explanation."""
+    act_content = _act_text().lower()
+
+    if "scipy" not in act_content:
+        return  # scipy no longer named at all: cannot be hard-coded as the only cause
+
+    branches_on_observed_error = any(
+        phrase in act_content
+        for phrase in [
+            "modulenotfounderror",
+            "import error",
+            "importerror",
+            "if the error",
+            "depending on the error",
+            "based on the error",
+            "which error",
+            "distinguish",
+        ]
+    )
+
+    assert branches_on_observed_error, (
+        "The /wh:llmsr-discover preflight names the scipy extra without branching on "
+        "the observed error. It should distinguish a missing subcommand "
+        "(\"No such command 'llmsr'\") from a genuine scipy import failure "
+        "(ModuleNotFoundError) and report whichever actually occurred."
+    )
+
+
+def test_llmsr_discover_act_mirror_in_sync() -> None:
+    """The dev act and the shipped package mirror must stay byte-identical."""
+    source_path = _repo_root().joinpath(*ACT_RELPATH)
+    shipped_path = _repo_root().joinpath(*MIRROR_RELPATH)
+
+    assert source_path.exists(), f"Source act not found: {source_path}"
+    assert shipped_path.exists(), f"Shipped act not found: {shipped_path}"
+
+    assert source_path.read_text() == shipped_path.read_text(), (
+        ".claude/commands/wh/llmsr-discover.md and "
+        "wheeler/_data/commands/llmsr-discover.md are out of sync. Run "
+        '`python -c "from wheeler.installer import sync_data; sync_data()"` '
+        "to regenerate the shipped version."
+    )

--- a/wheeler/_data/commands/llmsr-discover.md
+++ b/wheeler/_data/commands/llmsr-discover.md
@@ -21,7 +21,12 @@ You are Wheeler, running LLM-SR equation discovery and marshalling the result in
 
 ## Preflight
 
-1. Confirm the tool is installed: `wheeler llmsr --help`. If it fails, say LLM-SR is not available (it needs the `scipy` extra) and stop. Do not attempt the run.
+1. Confirm the tool is installed: `wheeler llmsr --help`. If it fails, read the error and report the cause the output actually shows. Do not name a cause the output does not support.
+   - `No such command 'llmsr'`: the installed Wheeler build does not include the LLM-SR CLI engine. Report that, not a missing extra. (`wheeler/tools/cli.py` registers the subcommand inside a guarded try/except ImportError, so an absent or unimportable engine module drops the subcommand instead of raising.)
+   - An import error the command surfaces (`ModuleNotFoundError: No module named 'scipy'` or similar): the optional dependency is missing. Report that LLM-SR needs the `scipy` extra.
+   - Anything else: quote the error verbatim rather than guessing at a cause.
+
+   Stop in every case. Do not attempt the run.
 2. Read context so the run is shaped by the graph. Use `mcp__wheeler_core__search_context` on the request and `mcp__wheeler_query__query_datasets` / `query_open_questions` / `query_hypotheses` to see the dataset, the motivating question, and any existing hypotheses about the functional form. Use this only to pick inputs and a link target. Do not invent results. Do not do the scientist's thinking.
 
 ## Gather the run (ASK, do not assume)


### PR DESCRIPTION
## Summary

The `/wh:llmsr-discover` preflight attributed every `wheeler llmsr --help` failure to a missing `scipy` extra. That is a hard-coded guess: the command more commonly fails because the `llmsr` subcommand is absent from the build, since `wheeler/tools/cli.py` registers it inside a guarded `try/except ImportError` and so drops the subcommand rather than raising. On a machine with scipy installed, the act pointed the scientist at an irrelevant fix.

The preflight now reads the error first and reports the cause the output actually supports, across three branches.

## Acceptance criteria (verified)

- [x] `No such command` reports the build lacks the LLM-SR CLI engine, not a missing extra (`llmsr-discover.md:25`).
- [x] A genuine import error still reports the scipy extra, now keyed to an observed `ModuleNotFoundError` (`llmsr-discover.md:26`).
- [x] No single hard-coded cause remains: line 24 is now "read the error and report the cause the output actually shows", plus an else branch that quotes the error verbatim rather than guessing.

## Test results

- Regression test: `tests/regression/test_issue_89.py` all 3 pass. On main, 2 of the 3 failed.
- Full suite: 1974 passed, 2 skipped, 0 failed.
- Lint and types clean: ruff and mypy both pass.
- E2E: the diff touches zero Python source, so the behavioral surface is the act delivery pipeline. Verified the source and `wheeler/_data/commands/` mirror are byte-identical, replayed the `wheeler install` copy path into a temp directory, and asserted the delivered bytes name the missing-subcommand branch, keep a separate scipy branch, and no longer carry the old unconditional sentence. `install()` was deliberately not called, since its `INSTALL_BASE` is the live `~/.claude`.

## Related

Issue #88 (the packaging report this one came from) did NOT reproduce on main: `wheeler llmsr --help` works, the service is registered, both slash command copies exist, the `integrate ingest discover` and `record-failure discover` verbs are present, and the llmsr package ships in `dist/wheeler-0.11.0.tar.gz`. It has been left open with a request for diagnostics from the affected environment. This fix stands on its own regardless, since the preflight prescribed a wrong diagnosis unconditionally.

## Verified by

wheeler-issue-cycle, independent Verifier, 2026-07-24.

Closes #89