### PR TITLE
feat(asta): seed the Theorizer from curated graph papers (closes #85)

### DIFF
--- a/.claude/commands/wh/asta-theorize.md
+++ b/.claude/commands/wh/asta-theorize.md
@@ -27,12 +27,38 @@ You are Wheeler, running an Asta Theorizer pass over a research question and mar
 - Sharpen it from the graph context: name the intervention or mechanism, the outcome, and the scope (system, population, regime). A crisp question yields crisper theories.
 - Pick at most one link target: the Question (`Q-...`) or Plan (`PL-...`) this generation supports. Each theory's parent node will be linked `AROSE_FROM` that node. If there is no clear target, run without one.
 
+## Decide whether to seed from the curated graph (ASK)
+
+By default the Theorizer runs its own PaperFinder and reads whatever it discovers. If the scientist has already curated a paper set in the graph (a `/wh:asta-lit` pass they then screened), offer to seed from it. Ask; do not assume. Seeding matters when the discovered literature keeps drifting off-target (the wrong species, preparation, or regime).
+
+Build the store from the GRAPH, never from a raw `/tmp/asta-paper-finder.json`: the artifact still contains the papers the scientist screened out, while the graph holds only the survivors.
+
+```
+wheeler integrate export-paper-store --link-to <Q- or PL- id> -o /tmp/asta-paper-store.json
+```
+
+The command prints `closed=yes|no`, a `used=P-...,P-...` line, and the exact `asta` command to run next. Read `closed` before going further, because it decides the flag pairing and the flag pairing decides whether curation survives:
+
+- **`closed=yes` (markdown mode, the default).** Every entry carries `paper_markdown`, so the Theorizer reads these papers directly. Run it with `--no-search-additional-papers`. PaperFinder never runs, nothing outside the set is pulled in, and the curation holds. The content is abstract-level, which is thinner than the server's own full-text hydration: that is the trade, corpus control for per-paper depth.
+- **`closed=no` (identifiers mode, or any entry lacking `paper_markdown`).** Identifier-only entries are hydrated during the PaperFinder step, so PaperFinder MUST stay on and can reintroduce exactly the papers that were screened out. Say this plainly rather than implying the run is curated. Hydration also costs roughly 30 to 60 seconds per paper server-side, so a 50-paper store is a long run.
+
+If the export skips papers for having no abstract, report which ones. They are papers the scientist curated that will NOT reach the Theorizer. It refuses to silently downgrade them to identifiers because one identifier-only entry forces PaperFinder back on and quietly reopens the whole corpus.
+
+Keep the `used=` line: those Paper ids go into `--used` at ingest so the run records what it was seeded with.
+
 ## Run the generation
 
 Run the CLI, capturing the artifact to a temp file. This requires an Asta login. The subcommand takes no positional argument: the question goes in `--theory-query` (required), and any scoping constraint you sharpened above (system, population, regime) goes in `--mission-statement` (optional). There is no output flag, so redirect stdout to the artifact path:
 
 ```
 asta generate-theories literature-theory-generation --theory-query "$QUESTION" --mission-statement "$SCOPE" > /tmp/asta-theorizer.json
+```
+
+When seeding, add the store and the matching PaperFinder flag that `export-paper-store` printed:
+
+```
+asta generate-theories literature-theory-generation --theory-query "$QUESTION" --mission-statement "$SCOPE" \
+  --paper-store @/tmp/asta-paper-store.json --no-search-additional-papers > /tmp/asta-theorizer.json
 ```
 
 Drop `--mission-statement` when there is no scoping constraint. Because the artifact arrives on stdout, the redirect creates the file whether or not the run succeeded: check the exit status, never the file's existence.
@@ -52,10 +78,10 @@ The ingest applies the same gate even when an artifact IS returned: a Theorizer 
 Marshal the artifact into the graph with the single integrate verb:
 
 ```
-wheeler integrate ingest theorizer /tmp/asta-theorizer.json --link-to <Q- or PL- id> --used <Q- or PL- id>,<F-... seeded Finding ids>
+wheeler integrate ingest theorizer /tmp/asta-theorizer.json --link-to <Q- or PL- id> --used <Q- or PL- id>,<F-... seeded Finding ids>,<P-... seeded Paper ids>
 ```
 
-Omit `--link-to` if there is no target. Pass `--used` with the graph node ids the request was built from: the link target (the `Q-`/`PL-` that motivated the run) AND every Finding id you seeded into the Theorizer extraction payload (the existing results that shaped the theory generation), comma-separated. This records `Execution -[USED]-> each input` (input-side provenance), so every generated theory traces back to the exact graph context it was built from, not just the literature support. Omit `--used` if there were no graph inputs. The verb is idempotent: re-running the same artifact creates no duplicate theories, law hypotheses, papers, edges, or USED edges. Each theory becomes a parent Finding (`artifact_type=theory`); each law becomes a Hypothesis the parent `CONTAINS`; supporting papers link `SUPPORTS` and contradicting papers link `CONTRADICTS` each law Hypothesis. The novelty verdict (established, derivable, new) is parked as `custom_novelty` on each Hypothesis, never in its `status`.
+Omit `--link-to` if there is no target. Pass `--used` with the graph node ids the request was built from: the link target (the `Q-`/`PL-` that motivated the run), every Finding id you seeded into the Theorizer extraction payload (the existing results that shaped the theory generation), AND, when you seeded a paper store, every Paper id from the `used=` line that `export-paper-store` printed (the literature the run was actually built on), comma-separated. This records `Execution -[USED]-> each input` (input-side provenance), so every generated theory traces back to the exact graph context it was built from, not just the literature support. Omit `--used` if there were no graph inputs. The verb is idempotent: re-running the same artifact creates no duplicate theories, law hypotheses, papers, edges, or USED edges. Each theory becomes a parent Finding (`artifact_type=theory`); each law becomes a Hypothesis the parent `CONTAINS`; supporting papers link `SUPPORTS` and contradicting papers link `CONTRADICTS` each law Hypothesis. The novelty verdict (established, derivable, new) is parked as `custom_novelty` on each Hypothesis, never in its `status`.
 
 ## Wire semantics to the existing graph
 

--- a/tests/integrations/asta/test_paper_store.py
+++ b/tests/integrations/asta/test_paper_store.py
@@ -1,0 +1,402 @@
+"""Tests for the paper-store marshal-in helper (Wheeler issue #85).
+
+The load-bearing property is the CLOSED-CORPUS guarantee. From the asta CLI help:
+identifier-only entries are hydrated during the PaperFinder step, so they require
+``search_additional_papers=True``, which means PaperFinder runs and can
+reintroduce papers the scientist screened out. Only a store where EVERY entry
+carries ``paper_markdown`` can be paired with ``--no-search-additional-papers``.
+
+So the invariant under test is: ``result.closed`` is True only when the store is
+genuinely usable with PaperFinder off, and a paper with no abstract is dropped
+rather than silently downgraded to an identifier (which would reopen the corpus).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from wheeler.config import WheelerConfig
+from wheeler.integrations.asta.paper_store import (
+    MODE_IDENTIFIERS,
+    MODE_MARKDOWN,
+    build_paper_store,
+    write_paper_store,
+)
+
+
+class _StubBackend:
+    """Returns canned Paper rows and records the Cypher it was asked to run."""
+
+    def __init__(self, rows):
+        self.rows = rows
+        self.queries: list[tuple[str, dict]] = []
+
+    async def run_cypher(self, query, params):
+        self.queries.append((query, params))
+        return self.rows
+
+
+def _row(pid, *, abstract="", corpus_id="", title="T", **kw):
+    base = {
+        "id": pid,
+        "corpus_id": corpus_id,
+        "title": title,
+        "authors": "A. Author",
+        "year": 2020,
+        "doi": "",
+        "abstract": abstract,
+        "venue": "",
+        "url": "",
+    }
+    base.update(kw)
+    return base
+
+
+def _build(rows, **kw):
+    backend = _StubBackend(rows)
+    import wheeler.graph.backend as backend_mod
+
+    original = backend_mod.get_backend
+    backend_mod.get_backend = lambda config: backend
+    try:
+        result = asyncio.run(
+            build_paper_store(WheelerConfig(), link_to="Q-1", **kw)
+        )
+    finally:
+        backend_mod.get_backend = original
+    return result, backend
+
+
+class TestClosedCorpusGuarantee:
+    def test_all_abstracts_yields_closed_corpus(self):
+        result, _ = _build(
+            [
+                _row("P-1", abstract="First abstract.", corpus_id="11"),
+                _row("P-2", abstract="Second abstract.", corpus_id="22"),
+            ]
+        )
+        assert result.closed is True
+        assert len(result.entries) == 2
+        assert all("paper_markdown" in e for e in result.entries)
+        assert result.paper_ids == ["P-1", "P-2"]
+
+    def test_paper_without_abstract_is_skipped_not_downgraded(self):
+        """The core invariant: no silent identifier-only entry in markdown mode.
+
+        Downgrading would force search_additional_papers=True and quietly reopen
+        the corpus, which is the exact failure this feature exists to prevent.
+        """
+        result, _ = _build(
+            [
+                _row("P-1", abstract="Has one.", corpus_id="11"),
+                _row("P-2", abstract="", corpus_id="22", title="No abstract"),
+            ]
+        )
+        assert len(result.entries) == 1
+        assert result.skipped == [{"id": "P-2", "title": "No abstract"}]
+        assert result.closed is True, (
+            "dropping the abstract-less paper must preserve the closed-corpus "
+            "guarantee for the papers that remain"
+        )
+        for entry in result.entries:
+            assert entry.get("paper_markdown"), (
+                "an entry without paper_markdown would force PaperFinder on"
+            )
+
+    def test_identifiers_mode_is_never_closed(self):
+        result, _ = _build(
+            [
+                _row("P-1", abstract="Has one.", corpus_id="11"),
+                _row("P-2", abstract="Also has one.", corpus_id="22"),
+            ],
+            mode=MODE_IDENTIFIERS,
+        )
+        assert result.closed is False, (
+            "identifier-only entries are hydrated during the PaperFinder step, "
+            "so this store can never be paired with --no-search-additional-papers"
+        )
+        assert all("paper_markdown" not in e for e in result.entries)
+        assert all("corpus_id" in e for e in result.entries)
+
+    def test_empty_selection_is_not_closed(self):
+        result, _ = _build([])
+        assert result.entries == []
+        assert result.closed is False, (
+            "an empty store must not report closed=yes; there is nothing to run"
+        )
+
+
+class TestSelection:
+    def test_link_to_selects_via_relevant_to(self):
+        _, backend = _build([_row("P-1", abstract="a")])
+        query, params = backend.queries[0]
+        assert "RELEVANT_TO" in query
+        assert params["link_to"] == "Q-1"
+        assert "ORDER BY p.id" in query, "export must be deterministic"
+
+    def test_explicit_paper_ids_bypass_the_link(self):
+        backend = _StubBackend([_row("P-9", abstract="a")])
+        import wheeler.graph.backend as backend_mod
+
+        original = backend_mod.get_backend
+        backend_mod.get_backend = lambda config: backend
+        try:
+            asyncio.run(
+                build_paper_store(WheelerConfig(), paper_ids=["P-9"])
+            )
+        finally:
+            backend_mod.get_backend = original
+        query, params = backend.queries[0]
+        assert "RELEVANT_TO" not in query
+        assert params["ids"] == ["P-9"]
+
+    def test_requires_a_selector(self):
+        with pytest.raises(ValueError, match="link_to or paper_ids"):
+            asyncio.run(build_paper_store(WheelerConfig()))
+
+    def test_rejects_unknown_mode(self):
+        with pytest.raises(ValueError, match="mode must be one of"):
+            asyncio.run(
+                build_paper_store(WheelerConfig(), link_to="Q-1", mode="nope")
+            )
+
+
+class TestMarkdownRendering:
+    def test_markdown_carries_title_metadata_and_abstract(self):
+        result, _ = _build(
+            [
+                _row(
+                    "P-1",
+                    abstract="The abstract body.",
+                    corpus_id="123",
+                    title="A Paper Title",
+                    venue="Nature",
+                    year=1999,
+                    doi="10.1/x",
+                )
+            ]
+        )
+        md = result.entries[0]["paper_markdown"]
+        assert md.startswith("# A Paper Title")
+        assert "**Authors:** A. Author" in md
+        assert "**Year:** 1999" in md
+        assert "**Venue:** Nature" in md
+        assert "**DOI:** 10.1/x" in md
+        assert "## Abstract" in md
+        assert "The abstract body." in md
+
+    def test_corpus_id_rides_along_for_server_side_dedupe(self):
+        result, _ = _build([_row("P-1", abstract="a", corpus_id="777")])
+        assert result.entries[0]["corpus_id"] == "777"
+
+
+class TestWrite:
+    def test_writes_a_json_list(self, tmp_path):
+        result, _ = _build([_row("P-1", abstract="a", corpus_id="1")])
+        out = tmp_path / "nested" / "store.json"
+        path = write_paper_store(result, out)
+
+        assert path.exists()
+        payload = json.loads(path.read_text())
+        assert isinstance(payload, list), (
+            "the store is emitted as a JSON list of entries; see the module "
+            "docstring on the inferred top-level shape"
+        )
+        assert payload[0]["corpus_id"] == "1"
+        assert not list(tmp_path.rglob("*.tmp")), "atomic write left a temp file"
+
+    def test_mode_is_reported(self):
+        result, _ = _build([_row("P-1", abstract="a")], mode=MODE_MARKDOWN)
+        assert result.to_dict()["mode"] == MODE_MARKDOWN
+        assert result.to_dict()["closed"] is True
+
+
+# ---------------------------------------------------------------------------
+# live-Neo4j e2e
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def e2e_config():
+    """Live config, with the Neo4j block taken from the project's own config.
+
+    Deliberately NOT a hardcoded password. A stale literal here is invisible
+    until the credential drifts, and then every graph test fails for a reason
+    that has nothing to do with the code under test.
+    """
+    from wheeler.config import ProjectMeta, load_config
+
+    config = load_config()
+    config.project = ProjectMeta(name="PaperStore-E2E-Test")
+    return config
+
+
+@pytest.fixture(scope="module")
+def neo4j_available(e2e_config) -> bool:
+    """Authenticated probe, not a port check: auth failure means unavailable."""
+    from neo4j import AsyncGraphDatabase, NotificationMinimumSeverity
+
+    async def _check():
+        driver = AsyncGraphDatabase.driver(
+            e2e_config.neo4j.uri,
+            auth=(e2e_config.neo4j.username, e2e_config.neo4j.password),
+            notifications_min_severity=NotificationMinimumSeverity.OFF,
+        )
+        try:
+            async with driver.session(database=e2e_config.neo4j.database) as s:
+                await s.run("RETURN 1")
+            return True
+        except Exception:
+            return False
+        finally:
+            await driver.close()
+
+    return asyncio.run(_check())
+
+
+@pytest.fixture(autouse=True)
+def _reset_driver_singleton():
+    """Each asyncio.run gets a fresh loop; a cached driver would be bound to a dead one."""
+    import wheeler.graph.driver as drv
+
+    drv._async_driver = None
+    drv._async_driver_uri = None
+    yield
+    drv._async_driver = None
+    drv._async_driver_uri = None
+
+
+def _cleanup(e2e_config, e2e_tag):
+    """Delete ONLY nodes carrying this run's unique tag. Never unscoped."""
+    from neo4j import AsyncGraphDatabase, NotificationMinimumSeverity
+
+    async def _run():
+        driver = AsyncGraphDatabase.driver(
+            e2e_config.neo4j.uri,
+            auth=(e2e_config.neo4j.username, e2e_config.neo4j.password),
+            notifications_min_severity=NotificationMinimumSeverity.OFF,
+        )
+        try:
+            async with driver.session(database=e2e_config.neo4j.database) as s:
+                await s.run(
+                    "MATCH (n) WHERE n.e2e_tag = $tag DETACH DELETE n", tag=e2e_tag
+                )
+        finally:
+            await driver.close()
+
+    try:
+        asyncio.run(_run())
+    except Exception:
+        # Best-effort teardown: a transient blip must not turn a pass into an
+        # ERROR. Orphans carry the per-run uuid tag.
+        pass
+
+
+class TestPaperStoreE2E:
+    """Real graph read: the stub cannot catch a wrong property name.
+
+    The abstract lives at ``custom_abstract`` because the backend flattens the
+    custom bag on write. A unit test with canned rows would pass even if the
+    Cypher asked for ``p.abstract``, so this reads a Paper that was written the
+    way production writes one.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _skip_and_cleanup(self, neo4j_available, e2e_config):
+        if not neo4j_available:
+            pytest.skip("Neo4j not available -- skipping paper-store e2e")
+        import uuid
+
+        self._tag = f"paperstore_e2e_{uuid.uuid4().hex}"
+        _cleanup(e2e_config, self._tag)
+        yield
+        _cleanup(e2e_config, self._tag)
+
+    def _seed(self, e2e_config):
+        """Create one Question and three Papers, two with abstracts."""
+        from neo4j import AsyncGraphDatabase, NotificationMinimumSeverity
+
+        async def _run():
+            driver = AsyncGraphDatabase.driver(
+                e2e_config.neo4j.uri,
+                auth=(e2e_config.neo4j.username, e2e_config.neo4j.password),
+                notifications_min_severity=NotificationMinimumSeverity.OFF,
+            )
+            try:
+                async with driver.session(database=e2e_config.neo4j.database) as s:
+                    await s.run(
+                        "CREATE (q:OpenQuestion {id:$qid, question:'seed', e2e_tag:$tag})",
+                        qid=f"Q-{self._tag}",
+                        tag=self._tag,
+                    )
+                    papers = [
+                        (f"P-{self._tag}-a", "Alpha", "Abstract alpha.", "111"),
+                        (f"P-{self._tag}-b", "Beta", "Abstract beta.", "222"),
+                        (f"P-{self._tag}-c", "Gamma", "", "333"),
+                    ]
+                    for pid, title, abstract, cid in papers:
+                        await s.run(
+                            "MATCH (q:OpenQuestion {id:$qid}) "
+                            "CREATE (p:Paper {id:$pid, title:$title, authors:'X. Y', "
+                            "year:2021, corpus_id:$cid, custom_abstract:$abs, "
+                            "e2e_tag:$tag})-[:RELEVANT_TO]->(q)",
+                            qid=f"Q-{self._tag}",
+                            pid=pid,
+                            title=title,
+                            cid=cid,
+                            abs=abstract,
+                            tag=self._tag,
+                        )
+            finally:
+                await driver.close()
+
+        asyncio.run(_run())
+
+    def test_round_trip_selects_curated_set_and_reads_the_real_abstract(
+        self, e2e_config, tmp_path
+    ):
+        self._seed(e2e_config)
+
+        result = asyncio.run(
+            build_paper_store(e2e_config, link_to=f"Q-{self._tag}")
+        )
+
+        # The abstract-less Paper is dropped, not downgraded.
+        assert len(result.entries) == 2, (
+            f"expected the 2 papers with abstracts, got {result.to_dict()}"
+        )
+        assert len(result.skipped) == 1
+        assert result.skipped[0]["title"] == "Gamma"
+        assert result.closed is True
+
+        # The real property name is read correctly (custom_abstract, flattened).
+        joined = "\n".join(e["paper_markdown"] for e in result.entries)
+        assert "Abstract alpha." in joined
+        assert "Abstract beta." in joined
+        assert "Gamma" not in joined
+
+        # Paper ids come back for --used provenance, deterministically ordered.
+        assert result.paper_ids == sorted(result.paper_ids)
+        assert all(pid.startswith(f"P-{self._tag}") for pid in result.paper_ids)
+
+        payload = json.loads(
+            write_paper_store(result, tmp_path / "store.json").read_text()
+        )
+        assert isinstance(payload, list) and len(payload) == 2
+
+    def test_explicit_ids_read_from_the_live_graph(self, e2e_config):
+        self._seed(e2e_config)
+        result = asyncio.run(
+            build_paper_store(
+                e2e_config,
+                paper_ids=[f"P-{self._tag}-a", f"P-{self._tag}-c"],
+                mode=MODE_IDENTIFIERS,
+            )
+        )
+        # identifiers mode keeps the abstract-less paper: it needs only an id.
+        assert len(result.entries) == 2
+        assert result.closed is False
+        assert {e["corpus_id"] for e in result.entries} == {"111", "333"}

--- a/wheeler/_data/commands/asta-theorize.md
+++ b/wheeler/_data/commands/asta-theorize.md
@@ -27,12 +27,38 @@ You are Wheeler, running an Asta Theorizer pass over a research question and mar
 - Sharpen it from the graph context: name the intervention or mechanism, the outcome, and the scope (system, population, regime). A crisp question yields crisper theories.
 - Pick at most one link target: the Question (`Q-...`) or Plan (`PL-...`) this generation supports. Each theory's parent node will be linked `AROSE_FROM` that node. If there is no clear target, run without one.
 
+## Decide whether to seed from the curated graph (ASK)
+
+By default the Theorizer runs its own PaperFinder and reads whatever it discovers. If the scientist has already curated a paper set in the graph (a `/wh:asta-lit` pass they then screened), offer to seed from it. Ask; do not assume. Seeding matters when the discovered literature keeps drifting off-target (the wrong species, preparation, or regime).
+
+Build the store from the GRAPH, never from a raw `/tmp/asta-paper-finder.json`: the artifact still contains the papers the scientist screened out, while the graph holds only the survivors.
+
+```
+wheeler integrate export-paper-store --link-to <Q- or PL- id> -o /tmp/asta-paper-store.json
+```
+
+The command prints `closed=yes|no`, a `used=P-...,P-...` line, and the exact `asta` command to run next. Read `closed` before going further, because it decides the flag pairing and the flag pairing decides whether curation survives:
+
+- **`closed=yes` (markdown mode, the default).** Every entry carries `paper_markdown`, so the Theorizer reads these papers directly. Run it with `--no-search-additional-papers`. PaperFinder never runs, nothing outside the set is pulled in, and the curation holds. The content is abstract-level, which is thinner than the server's own full-text hydration: that is the trade, corpus control for per-paper depth.
+- **`closed=no` (identifiers mode, or any entry lacking `paper_markdown`).** Identifier-only entries are hydrated during the PaperFinder step, so PaperFinder MUST stay on and can reintroduce exactly the papers that were screened out. Say this plainly rather than implying the run is curated. Hydration also costs roughly 30 to 60 seconds per paper server-side, so a 50-paper store is a long run.
+
+If the export skips papers for having no abstract, report which ones. They are papers the scientist curated that will NOT reach the Theorizer. It refuses to silently downgrade them to identifiers because one identifier-only entry forces PaperFinder back on and quietly reopens the whole corpus.
+
+Keep the `used=` line: those Paper ids go into `--used` at ingest so the run records what it was seeded with.
+
 ## Run the generation
 
 Run the CLI, capturing the artifact to a temp file. This requires an Asta login. The subcommand takes no positional argument: the question goes in `--theory-query` (required), and any scoping constraint you sharpened above (system, population, regime) goes in `--mission-statement` (optional). There is no output flag, so redirect stdout to the artifact path:
 
 ```
 asta generate-theories literature-theory-generation --theory-query "$QUESTION" --mission-statement "$SCOPE" > /tmp/asta-theorizer.json
+```
+
+When seeding, add the store and the matching PaperFinder flag that `export-paper-store` printed:
+
+```
+asta generate-theories literature-theory-generation --theory-query "$QUESTION" --mission-statement "$SCOPE" \
+  --paper-store @/tmp/asta-paper-store.json --no-search-additional-papers > /tmp/asta-theorizer.json
 ```
 
 Drop `--mission-statement` when there is no scoping constraint. Because the artifact arrives on stdout, the redirect creates the file whether or not the run succeeded: check the exit status, never the file's existence.
@@ -52,10 +78,10 @@ The ingest applies the same gate even when an artifact IS returned: a Theorizer 
 Marshal the artifact into the graph with the single integrate verb:
 
 ```
-wheeler integrate ingest theorizer /tmp/asta-theorizer.json --link-to <Q- or PL- id> --used <Q- or PL- id>,<F-... seeded Finding ids>
+wheeler integrate ingest theorizer /tmp/asta-theorizer.json --link-to <Q- or PL- id> --used <Q- or PL- id>,<F-... seeded Finding ids>,<P-... seeded Paper ids>
 ```
 
-Omit `--link-to` if there is no target. Pass `--used` with the graph node ids the request was built from: the link target (the `Q-`/`PL-` that motivated the run) AND every Finding id you seeded into the Theorizer extraction payload (the existing results that shaped the theory generation), comma-separated. This records `Execution -[USED]-> each input` (input-side provenance), so every generated theory traces back to the exact graph context it was built from, not just the literature support. Omit `--used` if there were no graph inputs. The verb is idempotent: re-running the same artifact creates no duplicate theories, law hypotheses, papers, edges, or USED edges. Each theory becomes a parent Finding (`artifact_type=theory`); each law becomes a Hypothesis the parent `CONTAINS`; supporting papers link `SUPPORTS` and contradicting papers link `CONTRADICTS` each law Hypothesis. The novelty verdict (established, derivable, new) is parked as `custom_novelty` on each Hypothesis, never in its `status`.
+Omit `--link-to` if there is no target. Pass `--used` with the graph node ids the request was built from: the link target (the `Q-`/`PL-` that motivated the run), every Finding id you seeded into the Theorizer extraction payload (the existing results that shaped the theory generation), AND, when you seeded a paper store, every Paper id from the `used=` line that `export-paper-store` printed (the literature the run was actually built on), comma-separated. This records `Execution -[USED]-> each input` (input-side provenance), so every generated theory traces back to the exact graph context it was built from, not just the literature support. Omit `--used` if there were no graph inputs. The verb is idempotent: re-running the same artifact creates no duplicate theories, law hypotheses, papers, edges, or USED edges. Each theory becomes a parent Finding (`artifact_type=theory`); each law becomes a Hypothesis the parent `CONTAINS`; supporting papers link `SUPPORTS` and contradicting papers link `CONTRADICTS` each law Hypothesis. The novelty verdict (established, derivable, new) is parked as `custom_novelty` on each Hypothesis, never in its `status`.
 
 ## Wire semantics to the existing graph
 

--- a/wheeler/integrations/asta/cli.py
+++ b/wheeler/integrations/asta/cli.py
@@ -340,3 +340,128 @@ def ingest(
         )
 
     _echo_report(report)
+
+
+@integrate_app.command("export-paper-store")
+def export_paper_store(
+    out: Path = typer.Option(
+        Path("/tmp/asta-paper-store.json"),
+        "--out",
+        "-o",
+        help="Where to write the paper store JSON.",
+    ),
+    link_to: Optional[str] = typer.Option(
+        None,
+        "--link-to",
+        help=(
+            "Select every Paper linked RELEVANT_TO this node (the Q-/PL- the "
+            "literature pass was run against). The curated set, post-screening."
+        ),
+    ),
+    papers: Optional[str] = typer.Option(
+        None,
+        "--papers",
+        help="Comma-separated Paper ids (P-...), instead of --link-to.",
+    ),
+    mode: str = typer.Option(
+        "markdown",
+        "--mode",
+        help=(
+            "markdown: emit paper_markdown per entry (abstract-level) for a "
+            "CLOSED corpus with --no-search-additional-papers. "
+            "identifiers: emit corpus_id/title only, which REQUIRES "
+            "--search-additional-papers and so cannot exclude off-target papers."
+        ),
+    ),
+) -> None:
+    """Build an Asta --paper-store payload from curated graph Papers.
+
+    Marshal-IN: reads the graph, writes a file, creates no nodes or edges.
+    """
+    from wheeler.config import load_config
+    from wheeler.integrations.asta.paper_store import (
+        MODES,
+        build_paper_store,
+        write_paper_store,
+    )
+
+    mode_key = mode.strip().lower()
+    if mode_key not in MODES:
+        typer.echo(f"Unknown mode '{mode}'. Supported: {', '.join(MODES)}.", err=True)
+        raise typer.Exit(code=2)
+
+    paper_ids = [i.strip() for i in papers.split(",") if i.strip()] if papers else []
+    if not link_to and not paper_ids:
+        typer.echo("Pass --link-to <Q-/PL- id> or --papers <P-id,...>.", err=True)
+        raise typer.Exit(code=2)
+
+    config = load_config()
+    result = asyncio.run(
+        build_paper_store(
+            config,
+            link_to=link_to,
+            paper_ids=paper_ids or None,
+            mode=mode_key,
+        )
+    )
+
+    if not result.entries:
+        typer.echo(
+            f"No papers exported (selected={result.selected}, "
+            f"skipped={len(result.skipped)}). Nothing written.",
+            err=True,
+        )
+        if result.skipped:
+            typer.echo(
+                "Every selected Paper lacked an abstract. Add abstracts, or use "
+                "--mode identifiers (which cannot give a closed corpus).",
+                err=True,
+            )
+        raise typer.Exit(code=1)
+
+    path = write_paper_store(result, out)
+
+    typer.echo(
+        f"mode={result.mode} selected={result.selected} "
+        f"exported={len(result.entries)} skipped={len(result.skipped)} "
+        f"closed={'yes' if result.closed else 'no'} store={path}"
+    )
+    if result.paper_ids:
+        typer.echo(f"used={','.join(result.paper_ids)}")
+
+    # Skipped papers are not a footnote: each one is a paper the scientist
+    # curated that will NOT reach the theorizer. Name them.
+    for item in result.skipped:
+        typer.echo(
+            f"  skipped (no abstract): {item['id']} {item['title'][:70]}", err=True
+        )
+    if result.skipped:
+        typer.echo(
+            "Those papers carry no abstract, so they cannot become "
+            "paper_markdown. Including them as identifiers would force "
+            "PaperFinder on and reopen the corpus, so they were dropped "
+            "instead. Add an abstract to include them.",
+            err=True,
+        )
+
+    # The flag pairing is the whole point and is easy to forget, so print the
+    # exact next command rather than describing it.
+    if result.closed:
+        typer.echo(
+            "\nClosed corpus. Run the theorizer with PaperFinder OFF so nothing "
+            "outside this set is pulled in:\n"
+            f"  asta generate-theories literature-theory-generation \\\n"
+            f'    --theory-query "<question>" \\\n'
+            f"    --paper-store @{path} \\\n"
+            f"    --no-search-additional-papers > /tmp/asta-theorizer.json"
+        )
+    else:
+        typer.echo(
+            "\nNOT a closed corpus: identifier-only entries are hydrated during "
+            "the PaperFinder step, so PaperFinder must stay ON and may "
+            "reintroduce off-target papers.\n"
+            f"  asta generate-theories literature-theory-generation \\\n"
+            f'    --theory-query "<question>" \\\n'
+            f"    --paper-store @{path} \\\n"
+            f"    --search-additional-papers > /tmp/asta-theorizer.json"
+        )

--- a/wheeler/integrations/asta/paper_store.py
+++ b/wheeler/integrations/asta/paper_store.py
@@ -1,0 +1,248 @@
+"""Build an Asta ``--paper-store`` payload from curated graph Papers.
+
+A marshal-IN module, and the first deterministic one. Every other helper in this
+package is marshal-OUT (a tool ran, write the result to the graph). This one runs
+the other way: it turns curated graph state into a tool payload, so the input side
+of a service call stops being prose a model hand-assembles and starts being a
+function. The failure that motivated it (Wheeler issue #85) was exactly a
+hand-built store that the server rejected with no detail.
+
+It reads the graph and writes a file. It creates NO graph nodes and NO edges, so
+unlike the ingest modules it never imports ``execute_tool``.
+
+WHY THE GRAPH AND NOT THE RAW ARTIFACT
+--------------------------------------
+The obvious source is the ``asta literature find -o`` artifact, but that is the
+wrong one: it holds every paper the search returned, including the ones the
+scientist screened out. The curated set lives in the graph, where off-target
+nodes were deleted and the survivors were linked to a Question. Reading from the
+graph is what makes the seed reflect a human judgment rather than a raw search.
+It also yields the Paper ids, so the run can record ``USED`` against the exact
+nodes that seeded it.
+
+THE CLOSED-CORPUS PROBLEM (the whole reason for ``markdown`` mode)
+-----------------------------------------------------------------
+From ``asta generate-theories literature-theory-generation --help``:
+
+    Entries with `paper_markdown` are used directly. Entries without
+    `paper_markdown` but with at least one of `corpus_id`, `s2_id`, or `title`
+    are hydrated server-side ... Hydration is performed during the PaperFinder
+    step, so it requires `search_additional_papers=True`; with PaperFinder
+    disabled, identifier-only entries are dropped.
+
+So an identifier-only store CANNOT give a curated corpus: hydrating it forces
+PaperFinder to run, and PaperFinder reintroduces the very papers that were
+screened out. Only ``paper_markdown`` entries are usable with
+``--no-search-additional-papers``, which is the one combination that yields a
+closed corpus. That is why ``markdown`` is the default mode and why it refuses to
+silently downgrade a paper that has no abstract: one identifier-only entry in an
+otherwise-markdown store forces PaperFinder back on and quietly destroys the
+guarantee the mode exists to provide.
+
+TOP-LEVEL SHAPE
+---------------
+The per-entry contract above is documented; the container shape is not. A JSON
+list is emitted, which matches the help's "entries" language and is the shape a
+"store" of records naturally takes. If a future asta version wants an object,
+this is the single place to change it. A rejected store now reports a reason
+(Wheeler issue #86), so verifying costs one run.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from wheeler.config import WheelerConfig
+
+logger = logging.getLogger(__name__)
+
+MODE_MARKDOWN = "markdown"
+MODE_IDENTIFIERS = "identifiers"
+MODES = (MODE_MARKDOWN, MODE_IDENTIFIERS)
+
+
+@dataclass
+class PaperStoreResult:
+    """The outcome of one export.
+
+    ``closed`` is the load-bearing field: True only when every emitted entry
+    carries ``paper_markdown``, which is the sole condition under which
+    ``--no-search-additional-papers`` yields a corpus limited to these papers.
+    """
+
+    mode: str = MODE_MARKDOWN
+    entries: list[dict[str, Any]] = field(default_factory=list)
+    paper_ids: list[str] = field(default_factory=list)
+    skipped: list[dict[str, str]] = field(default_factory=list)
+    selected: int = 0
+
+    @property
+    def closed(self) -> bool:
+        return bool(self.entries) and all(
+            e.get("paper_markdown") for e in self.entries
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "mode": self.mode,
+            "selected": self.selected,
+            "exported": len(self.entries),
+            "skipped": len(self.skipped),
+            "closed": self.closed,
+            "paper_ids": list(self.paper_ids),
+        }
+
+
+def _render_markdown(row: dict[str, Any]) -> str:
+    """Render one Paper node as the markdown the theorizer consumes directly.
+
+    Abstract-level, not full text: the graph stores what Paper Finder returned.
+    Thinner than the server's own S2 + OCR hydration, and that is the trade the
+    mode makes, buying corpus control at the cost of per-paper depth.
+    """
+    title = (row.get("title") or "").strip()
+    lines = [f"# {title}" if title else "# (untitled)", ""]
+
+    meta: list[str] = []
+    if row.get("authors"):
+        meta.append(f"**Authors:** {row['authors']}")
+    year = row.get("year") or 0
+    if year:
+        meta.append(f"**Year:** {year}")
+    if row.get("venue"):
+        meta.append(f"**Venue:** {row['venue']}")
+    if row.get("doi"):
+        meta.append(f"**DOI:** {row['doi']}")
+    if row.get("url"):
+        meta.append(f"**URL:** {row['url']}")
+    if row.get("corpus_id"):
+        meta.append(f"**Corpus ID:** {row['corpus_id']}")
+    if meta:
+        lines.extend(meta)
+        lines.append("")
+
+    lines.append("## Abstract")
+    lines.append("")
+    lines.append((row.get("abstract") or "").strip())
+    return "\n".join(lines).rstrip() + "\n"
+
+
+async def _select_papers(
+    backend,
+    config: WheelerConfig,
+    *,
+    link_to: str | None,
+    paper_ids: list[str] | None,
+) -> list[dict[str, Any]]:
+    """Read the curated Paper set from the graph, deterministically ordered.
+
+    Project-aware, mirroring the read scoping used by the other helpers here.
+    The abstract lives in the flattened custom bag (``custom_abstract``) because
+    ``PaperModel`` has no abstract field; ``parse_paper_finder`` promotes it
+    there via ``_CUSTOM_SCALAR_KEYS``.
+    """
+    params: dict[str, Any] = {}
+    clauses: list[str] = []
+
+    if paper_ids:
+        match = "MATCH (p:Paper)"
+        clauses.append("p.id IN $ids")
+        params["ids"] = list(paper_ids)
+    else:
+        match = "MATCH (p:Paper)-[:RELEVANT_TO]->(t)"
+        clauses.append("t.id = $link_to")
+        params["link_to"] = link_to
+
+    ptag = getattr(config.neo4j, "project_tag", "") or ""
+    if ptag:
+        clauses.append("p._wheeler_project = $ptag")
+        params["ptag"] = ptag
+
+    query = (
+        f"{match} WHERE " + " AND ".join(clauses) + " "
+        "RETURN p.id AS id, p.corpus_id AS corpus_id, p.title AS title, "
+        "p.authors AS authors, p.year AS year, p.doi AS doi, "
+        "p.custom_abstract AS abstract, p.custom_venue AS venue, "
+        "p.custom_url AS url "
+        "ORDER BY p.id"
+    )
+    rows = await backend.run_cypher(query, params)
+    return list(rows or [])
+
+
+async def build_paper_store(
+    config: WheelerConfig,
+    *,
+    link_to: str | None = None,
+    paper_ids: list[str] | None = None,
+    mode: str = MODE_MARKDOWN,
+) -> PaperStoreResult:
+    """Build a paper store from graph Papers selected by link target or id.
+
+    In ``markdown`` mode a Paper with no abstract is SKIPPED, not downgraded to
+    an identifier: mixing one identifier-only entry into the store would force
+    ``search_additional_papers=True`` and silently reopen the corpus. Callers
+    should surface the skipped list so the scientist can add the abstract or
+    choose ``identifiers`` mode deliberately.
+    """
+    if mode not in MODES:
+        raise ValueError(f"mode must be one of {MODES}, got {mode!r}")
+    if not link_to and not paper_ids:
+        raise ValueError("pass link_to or paper_ids to select the papers")
+
+    from wheeler.graph.backend import get_backend
+
+    backend = get_backend(config)
+    rows = await _select_papers(
+        backend, config, link_to=link_to, paper_ids=paper_ids
+    )
+
+    result = PaperStoreResult(mode=mode, selected=len(rows))
+    for row in rows:
+        pid = row.get("id") or ""
+        corpus_id = str(row.get("corpus_id") or "")
+        title = (row.get("title") or "").strip()
+
+        if mode == MODE_MARKDOWN:
+            abstract = (row.get("abstract") or "").strip()
+            if not abstract:
+                # Refuse to downgrade: see the module docstring. A silent
+                # identifier-only entry here would reopen the corpus.
+                result.skipped.append({"id": pid, "title": title})
+                continue
+            entry: dict[str, Any] = {"paper_markdown": _render_markdown(row)}
+            # corpus_id rides along so the server's dedupe-by-corpus_id still
+            # works if PaperFinder is enabled anyway.
+            if corpus_id:
+                entry["corpus_id"] = corpus_id
+            if title:
+                entry["title"] = title
+        else:
+            if not corpus_id and not title:
+                result.skipped.append({"id": pid, "title": title})
+                continue
+            entry = {}
+            if corpus_id:
+                entry["corpus_id"] = corpus_id
+            if title:
+                entry["title"] = title
+
+        result.entries.append(entry)
+        if pid:
+            result.paper_ids.append(pid)
+
+    return result
+
+
+def write_paper_store(result: PaperStoreResult, out_path: str | Path) -> Path:
+    """Write the store JSON atomically (tmp then rename), returning the path."""
+    path = Path(out_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(result.entries, indent=2, ensure_ascii=False) + "\n")
+    tmp.replace(path)
+    return path


### PR DESCRIPTION
Adds `wheeler integrate export-paper-store`, which builds an Asta `--paper-store` payload from Paper nodes in the graph.

## Why this is not what the issue asked for

The issue asked to document the `--paper-store` schema. Reading the CLI, **the schema is already public** in `--help`, and documenting it would not have solved the problem that was actually wanted. Two premises were wrong:

1. **The per-entry contract is documented.** Only the top-level container shape is not. A `{corpus_id, title}` store like the one in the report *should* have been valid, since `--search-additional-papers` defaults on, so the original failure may have been unrelated and merely opaque (which was #86, now shipped).

2. **Identifier-only seeding cannot give a curated corpus.** This is the real finding. Hydration happens *during the PaperFinder step*, so identifier entries require `search_additional_papers=True`. PaperFinder therefore runs alongside your seed and reintroduces the papers you screened out. That is exactly the off-target mouse paper in the report. Only a store where **every** entry carries `paper_markdown` can be paired with `--no-search-additional-papers`.

## What makes the fix possible

Wheeler can supply `paper_markdown`. `parse_paper_finder` already promotes the abstract into the custom bag, so it lands as `custom_abstract` on the Paper node (confirmed on a live graph). Synthesizing title, authors, year, venue, and abstract into markdown yields a **closed, abstract-level corpus**. That is thinner than the server's full-text hydration, and that is the trade the mode makes: corpus control for per-paper depth.

## Why it reads the graph, not the artifact

The issue framed this as converting `/tmp/asta-paper-finder.json`. That is the wrong source: the artifact still holds the papers you screened out, while the graph holds only the survivors. Reading the graph is also what yields the Paper ids, so the run records `USED` against the exact nodes that seeded it, closing input-side provenance that was previously missing for literature.

## Design decisions worth reviewing

- **`markdown` mode SKIPS a paper with no abstract** rather than downgrading it to an identifier. One identifier-only entry forces PaperFinder back on and silently reopens the corpus, so a quiet downgrade would destroy the guarantee the mode exists to provide. Skipped papers are named on stderr, since each is a paper you curated that will not reach the Theorizer.
- **The command prints `closed=yes|no` and the exact next `asta` command** with the matching PaperFinder flag. The pairing is the whole point and is easy to forget.
- **First marshal-IN module in the package.** It reads the graph and writes a file, creating no nodes or edges, so unlike the ingest modules it never imports `execute_tool`. Every other helper here runs the other direction.
- **No new CLI verb was added lightly.** I argued against one earlier on the grounds that a file-to-file transform does not belong next to the graph-writing verbs. What changed my mind is that this reads curated graph state and feeds provenance, which makes it the input half of the integration sandwich rather than a `jq` convenience.
- **Top-level shape** is emitted as a JSON list (matching the help's "entries" language) and isolated in one place. #86 now makes a rejected store report its reason, so verifying costs one run.

## Usage

```
$ wheeler integrate export-paper-store --link-to Q-281c2372
mode=markdown selected=5 exported=5 skipped=0 closed=yes store=/tmp/asta-paper-store.json
used=P-0c52642f,P-710a8878,P-9e414333,P-f2039d6b,P-fb22e9d6

Closed corpus. Run the theorizer with PaperFinder OFF so nothing outside this set is pulled in:
  asta generate-theories literature-theory-generation \
    --theory-query "<question>" \
    --paper-store @/tmp/asta-paper-store.json \
    --no-search-additional-papers > /tmp/asta-theorizer.json
```

## Tests

- 12 unit tests on the closed-corpus invariant, including that an abstract-less paper is skipped rather than downgraded, and that `identifiers` mode never reports `closed`.
- 2 live-Neo4j round-trips that read a real `custom_abstract`. A stubbed row would pass even if the Cypher asked for the wrong property name, since the backend flattens the custom bag on write.
- The e2e fixture derives credentials from the project config rather than hardcoding a password. A stale literal in the sibling test is exactly what cost this session an hour this morning.
- Teardown deletes only by a per-run uuid tag; verified zero leftover nodes in the live graph.
- Exercised end to end against the real graph in all modes, including the skip path and the empty-selection path (exit 1, no file written).

Full suite 2078 passed, 2 skipped. ruff and mypy clean.

Closes #85