### PR TITLE
fix(update_node): treat an empty string as an explicit field clear (closes #101)

### DIFF
--- a/tests/regression/test_issue_101.py
+++ b/tests/regression/test_issue_101.py
@@ -1,0 +1,221 @@
+"""Regression test for issue #101: cannot clear a string field.
+
+https://github.com/maxwellsdm/wheeler/issues/101
+
+The bug: update_node treats empty string as "field not supplied", so
+passing path="" returns "No fields to update" instead of clearing the field.
+
+This test verifies that:
+1. A string field can be cleared via update_node by passing an empty string
+2. The response reports the change (not "No fields to update")
+3. The change is recorded in the node's change_log
+4. Omitting a parameter still means "leave unchanged"
+"""
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from wheeler.config import load_config
+from wheeler.graph.backend import get_backend
+from wheeler.graph.schema import generate_node_id, PREFIX_TO_LABEL
+from wheeler.tools.graph_tools import mutations
+
+
+@pytest.fixture
+async def backend_and_config():
+    """Set up backend for test."""
+    config = load_config()
+    backend = get_backend(config)
+    yield backend, config
+    # No cleanup needed: tests manage their own node cleanup
+
+
+class TestUpdateNodeClearString:
+    """Test clearing string fields via update_node."""
+
+    @pytest.mark.asyncio
+    async def test_clear_path_field(self, backend_and_config):
+        """Test that path field can be cleared with empty string."""
+        backend, config = backend_and_config
+
+        # Create a Plan node with a path
+        node_id = generate_node_id("PL")
+        original_path = "/tmp/test_plan_issue101.md"
+
+        await backend.create_node("Plan", {
+            "id": node_id,
+            "title": "Test Plan for Issue 101",
+            "path": original_path,
+            "status": "draft",
+            "date": "2024-07-28T00:00:00Z",
+            "tier": "generated",
+            "stability": 0.5,
+            "session_id": "test_issue_101",
+            "display_name": "Test Plan",
+            "e2e_tag": f"test-101-{node_id}",  # Marker for cleanup
+        })
+
+        try:
+            # Verify node was created with the path
+            node = await backend.get_node("Plan", node_id)
+            assert node is not None, f"Node {node_id} not found after creation"
+            assert node.get("path") == original_path, "Path not set on creation"
+
+            # Attempt to clear the path field
+            update_args = {
+                "node_id": node_id,
+                "path": "",  # Explicit empty string to clear
+                "session_id": "test_issue_101"
+            }
+
+            result_json = await mutations.update_node(backend, update_args)
+            result = json.loads(result_json)
+
+            # Check: should NOT return "No fields to update"
+            assert result.get("error") != "No fields to update", (
+                f"update_node returned 'No fields to update' when clearing path. "
+                f"Full response: {result}"
+            )
+
+            # Check: should return success status
+            assert result.get("status") == "updated", (
+                f"Expected status='updated' but got {result.get('status')}. "
+                f"Response: {result}"
+            )
+
+            # Check: should report path as updated field
+            assert "path" in result.get("updated_fields", []), (
+                f"Expected path in updated_fields but got {result.get('updated_fields')}. "
+                f"Response: {result}"
+            )
+
+            # Check: should show the change
+            changes = result.get("changes", {})
+            assert "path" in changes, (
+                f"Expected path in changes but got {list(changes.keys())}. "
+                f"Response: {result}"
+            )
+            assert changes["path"]["old"] == original_path, (
+                f"Expected old value to be {original_path} but got {changes['path']['old']}"
+            )
+            assert changes["path"]["new"] == "", (
+                f"Expected new value to be empty string but got {repr(changes['path']['new'])}"
+            )
+
+            # Verify the field was actually cleared in the graph
+            updated_node = await backend.get_node("Plan", node_id)
+            assert updated_node is not None
+            assert updated_node.get("path") == "", (
+                f"Path was not cleared in graph. Got {repr(updated_node.get('path'))}"
+            )
+
+        finally:
+            # Clean up the test node
+            try:
+                await backend.delete_node("Plan", node_id)
+            except Exception:
+                pass
+
+    @pytest.mark.asyncio
+    async def test_omit_field_means_no_change(self, backend_and_config):
+        """Test that omitting a parameter leaves the field unchanged."""
+        backend, config = backend_and_config
+
+        # Create a Finding node with a description
+        node_id = generate_node_id("F")
+        original_description = "Original description"
+
+        await backend.create_node("Finding", {
+            "id": node_id,
+            "description": original_description,
+            "confidence": 0.7,
+            "date": "2024-07-28T00:00:00Z",
+            "tier": "generated",
+            "stability": 0.7,
+            "session_id": "test_issue_101",
+            "display_name": "Test Finding",
+            "e2e_tag": f"test-101-{node_id}",
+        })
+
+        try:
+            # Update only confidence, omit description
+            update_args = {
+                "node_id": node_id,
+                "confidence": 0.9,
+                # description is NOT included, should remain unchanged
+                "session_id": "test_issue_101"
+            }
+
+            result_json = await mutations.update_node(backend, update_args)
+            result = json.loads(result_json)
+
+            assert result.get("status") == "updated"
+            assert "confidence" in result.get("updated_fields", [])
+            assert "description" not in result.get("updated_fields", [])
+
+            # Verify description was not changed
+            updated_node = await backend.get_node("Finding", node_id)
+            assert updated_node is not None
+            assert updated_node.get("description") == original_description
+
+        finally:
+            try:
+                await backend.delete_node("Finding", node_id)
+            except Exception:
+                pass
+
+    @pytest.mark.asyncio
+    async def test_clear_title_field(self, backend_and_config):
+        """Test clearing title field on a Hypothesis node."""
+        backend, config = backend_and_config
+
+        # Create a Hypothesis with a statement
+        node_id = generate_node_id("H")
+        original_statement = "Original hypothesis"
+
+        await backend.create_node("Hypothesis", {
+            "id": node_id,
+            "statement": original_statement,
+            "date": "2024-07-28T00:00:00Z",
+            "tier": "generated",
+            "stability": 0.5,
+            "session_id": "test_issue_101",
+            "display_name": "Test Hyp",
+            "e2e_tag": f"test-101-{node_id}",
+        })
+
+        try:
+            # Try to clear the statement (primary content field)
+            update_args = {
+                "node_id": node_id,
+                "statement": "",  # Clear the statement
+                "session_id": "test_issue_101"
+            }
+
+            result_json = await mutations.update_node(backend, update_args)
+            result = json.loads(result_json)
+
+            # Should succeed (not return "No fields to update")
+            assert result.get("status") == "updated", (
+                f"Failed to clear statement. Response: {result}"
+            )
+
+            # Verify the statement was cleared
+            updated_node = await backend.get_node("Hypothesis", node_id)
+            assert updated_node is not None
+            assert updated_node.get("statement") == "", (
+                f"Statement was not cleared. Got {repr(updated_node.get('statement'))}"
+            )
+
+        finally:
+            try:
+                await backend.delete_node("Hypothesis", node_id)
+            except Exception:
+                pass
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/regression/test_issue_101.py
+++ b/tests/regression/test_issue_101.py
@@ -10,18 +10,33 @@ This test verifies that:
 2. The response reports the change (not "No fields to update")
 3. The change is recorded in the node's change_log
 4. Omitting a parameter still means "leave unchanged"
+5. The clear propagates through execute_tool to all three triple-write
+   layers (Neo4j, knowledge/{id}.json, synthesis/{id}.md)
 """
 
-import asyncio
 import json
+import re
+import uuid
 from pathlib import Path
 
 import pytest
 
 from wheeler.config import load_config
 from wheeler.graph.backend import get_backend
-from wheeler.graph.schema import generate_node_id, PREFIX_TO_LABEL
-from wheeler.tools.graph_tools import mutations
+from wheeler.graph.schema import generate_node_id
+from wheeler.tools.graph_tools import execute_tool, mutations
+
+# render.py emits "**Path**: <value>" only when the model's path is truthy,
+# and joins it with the other metadata using " | ". Matching the live entry
+# specifically matters: a cleared path can still appear elsewhere in the
+# file as audit history, so scanning for the raw string would be wrong.
+_LIVE_PATH_RE = re.compile(r"\*\*Path\*\*:\s*([^|\n]*)")
+
+
+def _live_path(markdown: str) -> str | None:
+    """Return the live Path value rendered in synthesis markdown, or None."""
+    match = _LIVE_PATH_RE.search(markdown)
+    return match.group(1).strip() if match else None
 
 
 @pytest.fixture
@@ -215,6 +230,118 @@ class TestUpdateNodeClearString:
                 await backend.delete_node("Hypothesis", node_id)
             except Exception:
                 pass
+
+
+class TestClearPropagatesThroughTripleWrite:
+    """Clearing a field must reach all three triple-write layers.
+
+    The tests above call the mutation handler directly, which skips both
+    validate_and_normalize and the triple-write in execute_tool. That
+    leaves JSON and synthesis propagation unguarded, so this routes
+    through execute_tool and reads every layer back off disk.
+    """
+
+    @pytest.mark.asyncio
+    async def test_clear_path_reaches_graph_json_and_synthesis(
+        self, backend_and_config, tmp_path,
+    ):
+        backend, config = backend_and_config
+
+        marker = f"issue101-triplewrite-{uuid.uuid4().hex[:8]}"
+        artifact = tmp_path / "issue101_artifact.md"
+        artifact.write_text("placeholder artifact\n")
+        # execute_tool normalizes path to absolute, so compare against the
+        # resolved form (on macOS tmp_path is a symlink into /private).
+        resolved = str(artifact.resolve())
+
+        created = json.loads(await execute_tool(
+            "add_document",
+            {
+                "title": "Issue 101 triple-write guard",
+                "path": str(artifact),
+                "status": "draft",
+                "session_id": marker,
+            },
+            config,
+        ))
+        node_id = created.get("node_id")
+        assert node_id, f"add_document did not create a node: {created}"
+
+        knowledge_file = Path(config.knowledge_path) / f"{node_id}.json"
+        synthesis_file = Path(config.synthesis_path) / f"{node_id}.md"
+
+        try:
+            # All three layers carry the path before the clear.
+            graph_before = await backend.get_node("Document", node_id)
+            assert graph_before is not None
+            assert graph_before.get("path") == resolved
+
+            assert knowledge_file.exists(), f"no knowledge file at {knowledge_file}"
+            json_before = json.loads(knowledge_file.read_text())
+            assert json_before.get("path") == resolved
+
+            assert synthesis_file.exists(), f"no synthesis file at {synthesis_file}"
+            assert _live_path(synthesis_file.read_text()) == resolved
+
+            # Clear it through the dispatch path, not the handler.
+            result = json.loads(await execute_tool(
+                "update_node",
+                {"node_id": node_id, "path": "", "session_id": marker},
+                config,
+            ))
+            assert result.get("status") == "updated", (
+                f"clearing path through execute_tool failed: {result}"
+            )
+            assert result.get("changes", {}).get("path") == {
+                "old": resolved, "new": "",
+            }, f"unexpected changes payload: {result.get('changes')}"
+
+            # Layer 1: Neo4j.
+            graph_after = await backend.get_node("Document", node_id)
+            assert graph_after is not None
+            assert graph_after.get("path") == "", (
+                f"graph path not cleared: {repr(graph_after.get('path'))}"
+            )
+
+            # Layer 2: knowledge JSON, re-read off disk.
+            json_after = json.loads(knowledge_file.read_text())
+            assert json_after.get("path") == "", (
+                f"knowledge JSON path not cleared (layer drift): "
+                f"{repr(json_after.get('path'))}"
+            )
+
+            # The clear is recorded in change_log as old -> new.
+            path_entries = [
+                entry for entry in json_after.get("change_log", [])
+                if "path" in entry.get("changes", {})
+            ]
+            assert path_entries, (
+                f"no change_log entry for the cleared path: "
+                f"{json_after.get('change_log')}"
+            )
+            assert path_entries[-1]["changes"]["path"] == [resolved, ""]
+
+            # Layer 3: synthesis no longer renders a live Path entry. The old
+            # value may survive as audit history, which is by design, so this
+            # asserts on the live entry rather than on the raw string.
+            assert _live_path(synthesis_file.read_text()) is None, (
+                "synthesis still renders a live Path entry after the clear"
+            )
+
+            # _field_specs._check_path short-circuits on the empty string. If
+            # that guard regresses, the path is resolved against the process
+            # cwd instead of staying cleared.
+            for layer, value in (
+                ("graph", graph_after.get("path")),
+                ("knowledge JSON", json_after.get("path")),
+            ):
+                assert value != str(Path.cwd()), (
+                    f"{layer} path was resolved to the cwd instead of cleared"
+                )
+        finally:
+            await execute_tool(
+                "delete_node", {"node_id": node_id, "session_id": marker}, config,
+            )
 
 
 if __name__ == "__main__":

--- a/wheeler/mcp_mutations.py
+++ b/wheeler/mcp_mutations.py
@@ -636,21 +636,27 @@ async def set_tier(node_id: str, tier: str) -> dict:
 @_logged
 async def update_node(
     node_id: str,
-    description: str = "",
+    description: str | None = None,
     confidence: float | None = None,
-    statement: str = "",
-    status: str = "",
-    title: str = "",
-    content: str = "",
-    question: str = "",
+    statement: str | None = None,
+    status: str | None = None,
+    title: str | None = None,
+    content: str | None = None,
+    question: str | None = None,
     priority: int | None = None,
-    path: str = "",
-    tier: str = "",
-    started_at: str = "",
-    ended_at: str = "",
+    path: str | None = None,
+    tier: str | None = None,
+    started_at: str | None = None,
+    ended_at: str | None = None,
     allow_provenance: bool = False,
 ) -> dict:
-    """Update fields on an existing Wheeler knowledge graph node. Only non-empty fields are applied.
+    """Update fields on an existing Wheeler knowledge graph node. Omitted fields are left unchanged.
+
+    Omitting an argument (or passing null) means "leave this field alone".
+    Passing an empty string is a real value that CLEARS the field, which is
+    how a node whose file was deleted or moved gets its dangling path reset
+    (path=""). The clear is reported in changes and recorded in change_log
+    like any other update.
 
     Fields are validated against the node type's schema: a field that does
     not exist on the node type is rejected with an error naming it, never
@@ -679,7 +685,7 @@ async def update_node(
         ("path", path), ("tier", tier),
         ("started_at", started_at), ("ended_at", ended_at),
     ]:
-        if val is not None and val != "":
+        if val is not None:
             update_args[field] = val
     if allow_provenance:
         update_args["allow_provenance"] = True

--- a/wheeler/tools/graph_tools/__init__.py
+++ b/wheeler/tools/graph_tools/__init__.py
@@ -298,23 +298,25 @@ TOOL_DEFINITIONS = [
     {
         "name": "update_node",
         "description": (
-            "Update fields on an existing knowledge graph node. Only non-empty "
-            "fields are applied. The 'updated' timestamp is set automatically. "
-            "Use for correcting descriptions, changing status, adjusting "
-            "confidence, or updating any node field after creation."
+            "Update fields on an existing knowledge graph node. Omitted (null) "
+            "fields are left unchanged; an empty string is a real value that "
+            "clears the field (e.g. path='' resets a dangling path). The "
+            "'updated' timestamp is set automatically. Use for correcting "
+            "descriptions, changing status, adjusting confidence, or updating "
+            "any node field after creation."
         ),
         "parameters": {
             "node_id": {"type": "string", "description": "The node ID to update (e.g., F-3a2b)"},
-            "description": {"type": "string", "description": "Updated description (Finding, Dataset)", "default": ""},
-            "statement": {"type": "string", "description": "Updated statement (Hypothesis)", "default": ""},
-            "question": {"type": "string", "description": "Updated question (OpenQuestion)", "default": ""},
-            "title": {"type": "string", "description": "Updated title (Paper, Document, ResearchNote)", "default": ""},
-            "content": {"type": "string", "description": "Updated content (ResearchNote)", "default": ""},
+            "description": {"type": "string", "description": "Updated description (Finding, Dataset)", "default": None},
+            "statement": {"type": "string", "description": "Updated statement (Hypothesis)", "default": None},
+            "question": {"type": "string", "description": "Updated question (OpenQuestion)", "default": None},
+            "title": {"type": "string", "description": "Updated title (Paper, Document, ResearchNote)", "default": None},
+            "content": {"type": "string", "description": "Updated content (ResearchNote)", "default": None},
             "confidence": {"type": "number", "description": "Confidence 0.0-1.0 (Finding)", "default": None},
             "priority": {"type": "integer", "description": "Priority 1-10 (OpenQuestion)", "default": None},
-            "status": {"type": "string", "description": "Status (Hypothesis, Document, Execution)", "default": ""},
-            "tier": {"type": "string", "description": "reference or generated", "default": ""},
-            "path": {"type": "string", "description": "File path (Dataset, Script, Document)", "default": ""},
+            "status": {"type": "string", "description": "Status (Hypothesis, Document, Execution)", "default": None},
+            "tier": {"type": "string", "description": "reference or generated", "default": None},
+            "path": {"type": "string", "description": "File path (Dataset, Script, Document)", "default": None},
         },
         "required": ["node_id"],
     },

--- a/wheeler/tools/graph_tools/mutations.py
+++ b/wheeler/tools/graph_tools/mutations.py
@@ -999,9 +999,12 @@ async def update_node(backend, args: dict) -> str:
     allow_provenance=true is passed, which permits explicit repair of a
     broken Execution record.
 
-    Only non-empty, non-None fields are applied. The 'updated' timestamp
-    is set automatically. Returns the node_id, label, list of updated
-    fields, and a changes dict showing old vs new values.
+    ``None`` is the "not provided" sentinel: a field whose value is None
+    (or absent from args) is left unchanged. An empty string is a real
+    value, so passing ``path=""`` clears the field, which is how a node
+    with a dangling path is repaired. The 'updated' timestamp is set
+    automatically. Returns the node_id, label, list of updated fields,
+    and a changes dict showing old vs new values.
     """
     node_id = args["node_id"]
 
@@ -1025,7 +1028,7 @@ async def update_node(backend, args: dict) -> str:
     for k, v in args.items():
         if k in exclude_keys:
             continue
-        if v is None or v == "":
+        if v is None:
             continue
         if k not in allowed_fields:
             if k in _UPDATE_PROVENANCE_FIELDS:


### PR DESCRIPTION
## Summary

`update_node` treated an empty string as "argument not supplied", so a string field could never be cleared and a dangling path was unrepairable through the tool. An empty string is now a real value that clears the field; omission still means leave unchanged.

The root cause was at three layers, all of which had to change together or the clear would silently no-op: the tool schema defaults (`tools/graph_tools/__init__.py`), the MCP wrapper (`mcp_mutations.py:688`), and the mutation handler (`tools/graph_tools/mutations.py:1031`).

## Acceptance criteria (verified)

- [x] **A string field can be cleared through update_node.** Both sentinel layers genuinely fixed, confirmed by reading the diff rather than trusting the report.
- [x] **The response reports the change, not "No fields to update":** `{"node_id":"PL-47dca37d","updated_fields":["path"],"changes":{"path":{"old":"/private/tmp/.../ood_mean_axis_equation_update.md","new":""}},"status":"updated"}`
- [x] **Omitting an argument still means leave unchanged.** This was the data-destroying regression risk of the `""` to `None` sentinel change, so it was tested adversarially through both entry points: `update_node(node_id=..., status='in-progress')` with all else omitted touched `status` only, with title and path unchanged in both Neo4j and JSON. Extra guard found: `tier=''` is rejected by the enum validator, so the sentinel change cannot corrupt tier.
- [x] **The clear is recorded in change_log,** read off disk from `knowledge/PL-47dca37d.json`: `{"action":"fields_updated","changes":{"path":["/private/tmp/.../ood_mean_axis_equation_update.md",""]},"actor":"system"}`

## Test results

- Regression test: `tests/regression/test_issue_101.py` passes. Confirmed failing on main first (2 failed, 1 passed).
- Full suite: 2003 passed, 2 skipped, 0 failures. Baseline 1999/2, so +4 new and 0 regressions.
- E2E (graph_mutation): pass, 44/44 assertions against live Neo4j. Full CRUD round-trip with all three triple-write layers read independently (JSON off disk, never inferred from the tool return): CREATE, CLEAR, UPDATE by omission, second CLEAR, DELETE, each re-reading graph plus `knowledge/{id}.json` plus `synthesis/{id}.md`.
- ruff clean, mypy clean (91 source files).
- Data safety: every node tagged `verify101-<uuid>`, teardown removed only that tag, 0 leftover, graph intact at 2150 nodes, no pre-existing node touched.

## Reviewer notes

**A third layer nobody briefed.** `_field_specs.py:115-116` `_check_path` short-circuits on empty string. That pre-existing guard is the only reason `path=""` survives `execute_tool`'s in-place path normalization; without it the clear would have silently written the current working directory instead of an empty value. Nothing committed protected it, which is what the second commit on this branch addresses: a test routed through `execute_tool` that reads all three layers back and asserts the cleared value stays exactly `""` rather than resolving against cwd.

**One semantic ripple outside update_node, accepted.** `restore.py:1174-1180` forwards all archived props wholesale into `update_node` under `--conflict replace`. Archived nodes routinely carry empty-string fields, which were previously skipped and now apply, so `replace` genuinely replaces rather than leaving stale values. Direction is toward correctness. `tests/test_restore.py` 37/37 pass. All 12 internal `update_node` call sites were audited: this is the only wholesale forwarder, the other 11 pass small guarded dicts. `ensure_artifact` passes only node_id/hash/session_id, so the issue's scope boundary is honored.

**One resisted false alarm worth recording.** The old path does remain in `synthesis/{id}.md`, but only inside the Change Log audit entry. `render.py:215` emits the live `**Path**` line only `if m.path`, so the live pointer is gone. That is criterion 4 working, not layer drift.

## Verified by

wheeler-issue-cycle, independent Verifier, 2026-07-28. Gates re-run at branch HEAD after the follow-up test commit.

Closes #101
