### PR TITLE
feat(llmsr): refit constants per group so the search scores the FORM (slice 1 of #107)

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -10,6 +10,7 @@
 - `prov-agent-research.md` -- Research notes from W3C PROV-DM schema design (v0.5.0).
 - `asta-integration.md` -- 850-line analysis of AllenAI Asta agent-baselines and integration plan (not yet implemented).
 - `field-data-contracts.md` -- Design doc for field-level validation in mutation tools (shipped in v0.6.0).
+- `llmsr-objective-formulation.md` -- Design doc generalizing the LLM-SR metric contract into an Objective: per-group refit (one form, one theta per cell/trial/subject), score vectors through the vendored buffer's existing `scores_per_test` API, and a declarable optimizer. Slice 1 (`--group-by`) shipped; slices 2 and 3 tracked in issue #107.
 
 ## Conventions
 

--- a/docs/llmsr-objective-formulation.md
+++ b/docs/llmsr-objective-formulation.md
@@ -1,0 +1,141 @@
+# LLM-SR: the general Objective formulation
+
+Status: design, partially implemented (slice 1).
+Supersedes the metric contract shipped in #96, #97, #98 by generalizing it. Nothing here breaks
+those; each is the degenerate case of what follows.
+
+## The problem
+
+Symbolic regression looks for a FUNCTIONAL FORM. The constants are usually a nuisance. Today the
+fit path conflates the two:
+
+```
+score = m( f(X; θ*), y )          θ* = argmin_θ  l( f(X;θ), y )
+```
+
+One pooled dataset, one θ, one scalar. If the same law governs 40 cells with 40 different constant
+sets, this scores the form against a single compromise θ and charges the FORM for a mismatch that
+belongs to the PARAMETERS. A correct law loses to a wrong-but-flexible one.
+
+What is actually wanted:
+
+```
+score = ⟨ m( f(X_i; θ*_i), y_i ) ⟩_i      θ*_i = argmin_θ  l( f(X_i;θ), y_i )
+```
+
+Each group i (cell, trial, subject, condition) refits its OWN constants under the SAME form. The
+form is then judged on the vector of per-group results. This is profile likelihood: the per-group
+constants are nuisance parameters profiled out, and what remains measures only the form.
+
+## What shipped in #96 to #98, and what it does not do
+
+Shipped: an arbitrary callable `(y_pred, y_true) -> float` registered from the scientist's own
+module, `data_shape` dispatch so a candidate may be a simulator with variable-length output, and
+`guard` for hard accept/reject separate from the scalar.
+
+Not shipped, and not expressible: per-group refit, a score vector, any scorer that needs to refit
+or rescale as part of computing the error, per-point weights, or parameter-dependent penalties.
+The scorer signature sees neither `X` nor `θ` (though `Constraint.check` does see `θ`, an
+asymmetry with no justification), so χ² with per-point σᵢ cannot be written. The only workaround
+is closing over module-level data, which welds a metric to one dataset.
+
+## The formulation
+
+Five facets, each a plug-in point, defaults reproducing current behavior exactly:
+
+```
+partition:  Data              -> [Group]     # who gets their own θ   (default: one group)
+bind:       (equation, Group) -> CallPlan    # how to call the candidate (today: a closed enum)
+score:      (form, group, fit)-> float       # per-group score, MAY refit or rescale internally
+constrain:  (pred, ctx)       -> bool        # hard gates, per group
+optimize:   (loss_fn, ctx)    -> θ           # today: hardcoded BFGS
+```
+
+### The control inversion
+
+The load-bearing change. Today the pipeline fits, then hands the metric a finished prediction, so
+a metric can never refit and therefore can never profile out a nuisance parameter. Instead the
+scorer receives the FORM and the GROUP plus a refit primitive it may call:
+
+```python
+def shape_error(form, group, fit):
+    """Score this cell on FORM only: its own constants and its own gain are nuisances."""
+    θ = fit(form, group, loss=lambda yp, yt: np.mean((yp - yt) ** 2))
+    yp = form(*group.cols, θ)
+    A = np.vstack([yp, np.ones_like(yp)]).T          # nuisance gain + offset,
+    (a, b), *_ = np.linalg.lstsq(A, group.y, rcond=None)   # profiled out, not fitted
+    return float(np.mean((a * yp + b - group.y) ** 2) / np.var(group.y))
+
+register_objective(Objective(
+    key="shape_per_cell",
+    group_by="cell_id",
+    score=shape_error,
+    lower_is_better=True,
+))
+```
+
+Every slot accepts a callable or a bare constant, with a constant promoted to `lambda *_: c`, so
+thresholds and fixed weights read naturally.
+
+### The score vector, and why no vendor fork is needed
+
+The vendored FunSearch buffer is already vector-native:
+
+```python
+register_program(program, island_id, scores_per_test: ScoresPerTest)   # a DICT
+_reduce_score(spt)  = mean over tests                       # island ranking signal
+_get_signature(spt) = tuple(spt[k] for k in sorted(spt))    # CLUSTER KEY within an island
+```
+
+Wheeler calls it with `{"data": result.score}`, a single key, which is where the vector is
+destroyed. Passing `{group_id: score_i}` instead recovers upstream's design at no cost:
+`_reduce_score` supplies the island ranking for free, and `_get_signature` clusters forms by their
+per-group profile. `vendor/` stays unforked, which matters given `d0b05b7` frames it as a plug-in
+for LLM-SR rather than our code.
+
+The distinction to keep straight: the island model needs SOME ordering to build prompts. That is a
+property of FunSearch's algorithm, not of the science. The buffer is a search heuristic; the
+winner is selected by Wheeler in `best` from `submissions.jsonl`, which stores the raw vector. So
+the buffer may be fed a coarse signal without costing final-selection precision.
+
+### Known caveat: signature degeneracy
+
+`Signature` is a dict key. Raw per-group floats are all distinct, so every program lands in its own
+cluster and the diversity mechanism does nothing. Note this is ALREADY true today: `{"data": score}`
+gives `(score,)`, unique per program. Passing the raw vector is therefore no worse, but it does not
+fix it either.
+
+The fix is a declared `cluster_by` quantizer, deliberately deferred to slice 2 because the
+scientifically right quantization is a per-group pass/fail at a threshold, which makes the
+signature read "the set of groups this form explains" and preserves exactly the diversity axis
+worth preserving. That threshold is the scientist's call, not a default worth inventing.
+
+## Two consequences
+
+**The optimizer becomes load-bearing.** `fit.py` hardcodes multi-start BFGS (`_N_RESTARTS = 6`).
+BFGS uses a numerical gradient, identically zero on a piecewise-constant objective, so it
+terminates at `x0`. Measured on a representative event-count objective:
+
+```
+BFGS starts that MOVED off x0: 0/13
+best value found: 1.0        (0.0 is a perfect fit)
+Nelder-Mead, same starts:    0.0     exact
+```
+
+Spike-distance and event-count losses are piecewise constant in θ, so the `spike_train` shape
+opened by #97 is currently fitted by an optimizer that cannot fit it: it degrades to best-of-7
+random search. Per-group refit multiplies this by the group count, and a scorer that refits
+internally multiplies it again. `optimize` must become declarable with a gradient-free default for
+non-smooth objectives.
+
+**Failed groups need a policy.** A form that nails 38 of 40 and fails 2, versus one mediocre on all
+40: the NaN policy picks the winner. That is a scientific call, not a default. It is also where the
+#98 hard constraints land, since a guard may now fail on a subset of groups.
+
+## Slices
+
+1. **`--group-by` with per-group θ and the raw vector into `scores_per_test`.** No vendor change.
+   Backward compatible: no `--group-by` means one group, byte-identical to today.
+2. **The `score(form, group, fit)` inversion** with the refit primitive, plus `cluster_by`.
+3. **Declarable `optimize`**, gradient-free default for non-smooth objectives, groups fanned out in
+   parallel to recover the cost.

--- a/tests/integrations/llmsr/test_grouped_fit.py
+++ b/tests/integrations/llmsr/test_grouped_fit.py
@@ -1,0 +1,204 @@
+"""Per-group refit: one FORM, one theta per group (issue #107, slice 1).
+
+The scientific claim under test: when the same law governs several individuals
+with DIFFERENT constants, a single pooled fit charges the FORM for variation that
+belongs to the PARAMETERS, and rejects a correct law. Refitting per group does
+not.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from wheeler.integrations.llmsr import fit as fit_mod
+from wheeler.integrations.llmsr import metrics as metrics_mod
+
+LINEAR = (
+    "import numpy as np\n"
+    "def equation(x1, params):\n"
+    "    return params[0] * x1 + params[1]\n"
+)
+
+# The same law y = a*x + b, three cells, three different (a, b).
+CELLS = {"c01": (2.5, -1.0), "c02": (-4.0, 8.0), "c03": (0.5, 3.0)}
+
+
+def _dataset(n_per_cell: int = 40):
+    rng = np.random.default_rng(3)
+    xs, ys, labels = [], [], []
+    for name, (a, b) in CELLS.items():
+        x = rng.uniform(-3.0, 3.0, n_per_cell)
+        xs.append(x)
+        ys.append(a * x + b)
+        labels += [name] * n_per_cell
+    return np.concatenate(xs).reshape(-1, 1), np.concatenate(ys), labels
+
+
+def _groups(X, y, labels):
+    out = []
+    for name in sorted(CELLS):
+        mask = np.array([label == name for label in labels])
+        out.append((name, X[mask], y[mask]))
+    return out
+
+
+class TestPerGroupRefit:
+    def test_pooled_fit_rejects_the_correct_form(self):
+        """The baseline that motivates the feature: one theta cannot serve three cells."""
+        X, y, _labels = _dataset()
+        pooled = fit_mod.evaluate_body(LINEAR, "equation", X, y, metrics_mod.MSE)
+        assert pooled.valid
+        # The form is EXACTLY right, yet pooling makes it look badly wrong.
+        assert pooled.value > 1.0
+
+    def test_per_group_refit_recovers_every_cell(self):
+        X, y, labels = _dataset()
+        result = fit_mod.evaluate_body_grouped(
+            LINEAR, "equation", _groups(X, y, labels), metrics_mod.MSE
+        )
+        assert result.valid
+        assert result.value < 1e-12  # mean over groups, versus >1.0 pooled
+
+        # Each cell recovered ITS OWN constants, not a compromise.
+        for name, (a, b) in CELLS.items():
+            got = result.params_per_group[name]
+            assert got[0] == pytest.approx(a, abs=1e-6)
+            assert got[1] == pytest.approx(b, abs=1e-6)
+
+    def test_score_vector_is_keyed_by_group(self):
+        X, y, labels = _dataset()
+        result = fit_mod.evaluate_body_grouped(
+            LINEAR, "equation", _groups(X, y, labels), metrics_mod.MSE
+        )
+        assert sorted(result.per_group) == ["c01", "c02", "c03"]
+        assert sorted(result.per_group_value) == ["c01", "c02", "c03"]
+        # The scalar is the mean over the vector, which is what the vendored
+        # buffer's own _reduce_score computes.
+        assert result.score == pytest.approx(
+            sum(result.per_group.values()) / len(result.per_group)
+        )
+
+    def test_group_order_is_deterministic_so_signatures_compare(self):
+        """The buffer keys clusters on the score signature; order must be stable."""
+        X, y, labels = _dataset()
+        shuffled = list(reversed(_groups(X, y, labels)))
+        a = fit_mod.evaluate_body_grouped(
+            LINEAR, "equation", _groups(X, y, labels), metrics_mod.MSE
+        )
+        b = fit_mod.evaluate_body_grouped(LINEAR, "equation", shuffled, metrics_mod.MSE)
+        assert sorted(a.per_group.items()) == sorted(b.per_group.items())
+
+
+class TestStrictValidity:
+    def test_one_failing_group_invalidates_and_names_it(self):
+        """Strict by design: the signature is only comparable over the same groups."""
+        X, y, labels = _dataset()
+        groups = _groups(X, y, labels)
+        # Give c02 a target that no real-valued a*x+b can reach finitely.
+        label, gX, _gy = groups[1]
+        groups[1] = (label, gX, np.full(gX.shape[0], np.inf))
+        result = fit_mod.evaluate_body_grouped(
+            LINEAR, "equation", groups, metrics_mod.MSE
+        )
+        assert not result.valid
+        assert "c02" in result.error
+
+    def test_ungrouped_failure_message_is_unprefixed(self):
+        """An ungrouped run has no group to blame, so the old message is preserved."""
+        X, y, _labels = _dataset()
+        bad = (
+            "import numpy as np\n"
+            "def equation(x1, params):\n"
+            "    return np.log(x1) * params[0]\n"
+        )
+        result = fit_mod.evaluate_body(bad, "equation", X, y, metrics_mod.MSE)
+        assert not result.valid
+        assert "group" not in result.error
+
+
+class TestUngroupedIsUnchanged:
+    def test_single_group_publishes_flat_params(self):
+        """Every existing caller reads .params; one group means one theta."""
+        X, y, _labels = _dataset()
+        result = fit_mod.evaluate_body(LINEAR, "equation", X, y, metrics_mod.MSE)
+        assert result.valid
+        assert result.params  # not empty
+        assert result.params_per_group[fit_mod.UNGROUPED] == result.params
+        assert result.value == result.per_group_value[fit_mod.UNGROUPED]
+
+
+class TestGroupedCli:
+    """The CLI path: --group-by threads through init and lands in submissions."""
+
+    def _write_csv(self, path: Path) -> None:
+        X, y, labels = _dataset(n_per_cell=25)
+        lines = ["cell_id,x1,y"]
+        for label, xi, yi in zip(labels, X[:, 0], y):
+            # float(), not repr(): numpy 2.x reprs a scalar as "np.float64(1.5)",
+            # which is not a parseable CSV cell.
+            lines.append(f"{label},{float(xi):.17g},{float(yi):.17g}")
+        path.write_text("\n".join(lines) + "\n")
+
+    def _spec(self, path: Path) -> None:
+        path.write_text(
+            "import numpy as np\n\n"
+            "MAX_NPARAMS = 4\n\n"
+            "@evaluate.run\n"
+            "def evaluate(data):\n"
+            "    return 0.0\n\n"
+            "@equation.evolve\n"
+            "def equation(x1, params):\n"
+            "    return params[0] * x1 + params[1]\n"
+        )
+
+    def test_group_by_produces_a_per_group_vector(self, tmp_path):
+        self._write_csv(tmp_path / "train.csv")
+        self._spec(tmp_path / "spec.txt")
+        wt = str(Path(__file__).resolve().parents[3])
+        out = subprocess.run(
+            [
+                sys.executable, "-m", "wheeler.tools.cli", "llmsr", "init",
+                "--spec", "spec.txt", "--data", "train.csv",
+                "--metric", "mse", "--group-by", "cell_id",
+            ],
+            cwd=tmp_path, capture_output=True, text=True,
+            env={"PATH": "/usr/bin:/bin", "PYTHONPATH": wt, "HOME": str(tmp_path)},
+        )
+        assert out.returncode == 0, out.stderr
+        run_dir = Path(json.loads(out.stdout)["run_dir"])
+        if not run_dir.is_absolute():
+            run_dir = tmp_path / run_dir
+
+        meta = json.loads((run_dir / "meta.json").read_text())
+        assert meta["group_by"] == "cell_id"
+
+        sub = json.loads((run_dir / "submissions.jsonl").read_text().splitlines()[0])
+        assert sub["valid"] is True
+        # The seed body IS the true form, so every cell fits once refitted.
+        assert sorted(sub["per_group"]) == ["c01", "c02", "c03"]
+        assert sorted(sub["params_per_group"]) == ["c01", "c02", "c03"]
+        for name, (a, b) in CELLS.items():
+            assert sub["params_per_group"][name][0] == pytest.approx(a, abs=1e-6)
+            assert sub["params_per_group"][name][1] == pytest.approx(b, abs=1e-6)
+
+    def test_group_by_rejects_an_unknown_column(self, tmp_path):
+        self._write_csv(tmp_path / "train.csv")
+        self._spec(tmp_path / "spec.txt")
+        wt = str(Path(__file__).resolve().parents[3])
+        out = subprocess.run(
+            [
+                sys.executable, "-m", "wheeler.tools.cli", "llmsr", "init",
+                "--spec", "spec.txt", "--data", "train.csv",
+                "--metric", "mse", "--group-by", "nope",
+            ],
+            cwd=tmp_path, capture_output=True, text=True,
+            env={"PATH": "/usr/bin:/bin", "PYTHONPATH": wt, "HOME": str(tmp_path)},
+        )
+        assert out.returncode != 0
+        assert "nope" in (out.stderr + out.stdout)

--- a/tests/integrations/llmsr/test_shapes.py
+++ b/tests/integrations/llmsr/test_shapes.py
@@ -91,12 +91,12 @@ class TestSpikeTrainLoading:
     def test_event_column_is_read_as_padded(self):
         metrics_mod.load_user_metrics()
         metric = metrics_mod.get_metric("spike_count")
-        X, y = _load_data("train.csv", metric)
+        X, y, _ = _load_data("train.csv", metric)
         assert X.shape == (5, 1)
         assert y == [0.2, 0.35]  # shorter than the stimulus, and a plain sequence
 
     def test_regression_loading_is_untouched(self):
-        X, y = _load_data("train.csv", metrics_mod.MSE)
+        X, y, _ = _load_data("train.csv", metrics_mod.MSE)
         assert X.shape == (5, 1)
         assert isinstance(y, np.ndarray) and len(y) == 5
 

--- a/wheeler/integrations/llmsr/cli.py
+++ b/wheeler/integrations/llmsr/cli.py
@@ -87,12 +87,43 @@ def _read_meta(run_dir: Path) -> dict:
     return json.loads((run_dir / "meta.json").read_text())
 
 
-def _load_xy(data_path: str) -> tuple[np.ndarray, np.ndarray]:
+def _header(data_path: str) -> list[str]:
+    with open(data_path) as fh:
+        return [c.strip() for c in fh.readline().strip().split(",")]
+
+
+def _load_xy(data_path: str, group_by: str = "") -> tuple[np.ndarray, np.ndarray, object]:
+    """Load (X, y, labels). ``labels`` is None unless ``group_by`` names a column.
+
+    The group column is EXCLUDED from X: it identifies who the row belongs to, it
+    is not an input to the equation. It is read separately as text, because a
+    label like ``c01`` is not a float and would otherwise come back as NaN.
+    """
     data = np.genfromtxt(data_path, delimiter=",", skip_header=1)
-    return data[:, :-1], data[:, -1].reshape(-1)
+    if data.ndim == 1:
+        data = data.reshape(1, -1)
+    if not group_by:
+        return data[:, :-1], data[:, -1].reshape(-1), None
+
+    header = _header(data_path)
+    if group_by not in header:
+        raise typer.BadParameter(
+            f"--group-by {group_by!r} is not a column in {data_path}; columns: {header}"
+        )
+    gi = header.index(group_by)
+    if gi == len(header) - 1:
+        raise typer.BadParameter(
+            f"--group-by {group_by!r} is the target column (the last one); "
+            "group by an identifier column instead"
+        )
+    labels = np.atleast_1d(
+        np.genfromtxt(data_path, delimiter=",", skip_header=1, usecols=[gi], dtype=str)
+    )
+    keep = [i for i in range(data.shape[1] - 1) if i != gi]
+    return data[:, keep], data[:, -1].reshape(-1), labels
 
 
-def _load_data(data_path: str, metric: metrics_mod.Metric):
+def _load_data(data_path: str, metric: metrics_mod.Metric, group_by: str = ""):
     """Load a run's data in the shape its metric declares.
 
     ``regression``: the tabular convention, last column is the target, one value
@@ -101,11 +132,48 @@ def _load_data(data_path: str, metric: metrics_mod.Metric):
     stimulus samples, so that column is read as padded (blank cells dropped)
     rather than as one value per sample.
     """
-    X, y = _load_xy(data_path)
+    X, y, labels = _load_xy(data_path, group_by)
     if metric.data_shape == metrics_mod.REGRESSION:
-        return X, y
+        return X, y, labels
+    if group_by:
+        # Event times do not line up with stimulus rows, so a row mask cannot
+        # partition them. Refusing beats silently grouping the wrong axis.
+        raise typer.BadParameter(
+            f"--group-by is not supported for data_shape {metric.data_shape!r}: "
+            "recorded events do not correspond row-for-row with stimulus samples, "
+            "so a per-row group column cannot partition them. Use one run per group."
+        )
     events = np.asarray(y, dtype=float)
-    return X, [float(v) for v in events[~np.isnan(events)]]
+    return X, [float(v) for v in events[~np.isnan(events)]], None
+
+
+def _as_groups(X, y, labels) -> list[tuple[str, np.ndarray, object]]:
+    """Partition into (label, X_i, y_i). Ungrouped is the single-group case.
+
+    Sorted by label so the group ORDER is deterministic across candidates. The
+    vendored buffer keys its clusters on the score signature, so two candidates
+    must present their groups identically or the signatures are incomparable.
+    """
+    if labels is None:
+        return [(fit_mod.UNGROUPED, X, y)]
+    y_arr = np.asarray(y)
+    out = []
+    for label in sorted({str(v) for v in labels.tolist()}):
+        mask = np.asarray([str(v) == label for v in labels.tolist()])
+        out.append((label, X[mask], y_arr[mask]))
+    return out
+
+
+def _scores_per_test(sub: dict) -> dict[str, float]:
+    """The score vector a submission contributes to the vendored buffer.
+
+    Submissions written before per-group scoring carry only a scalar `score`, so
+    they replay under the single ``UNGROUPED`` key exactly as they always did.
+    """
+    per_group = sub.get("per_group")
+    if per_group:
+        return {str(k): float(v) for k, v in per_group.items()}
+    return {fit_mod.UNGROUPED: sub["score"]}
 
 
 def _read_submissions(run_dir: Path) -> list[dict]:
@@ -195,7 +263,9 @@ def _rebuild_buffer(run_dir: Path, meta: dict):
         fn, _program = evaluator._sample_to_program(
             sub["body"], sub.get("version_generated"), template, fte
         )
-        db.register_program(fn, sub.get("island_id"), {"data": sub["score"]})
+        db.register_program(
+            fn, sub.get("island_id"), _scores_per_test(sub)
+        )
     return template, db, fte
 
 
@@ -204,8 +274,7 @@ def _score_body(
     version_generated: Optional[int],
     template,
     fte: str,
-    X: np.ndarray,
-    y: np.ndarray,
+    groups: list[tuple[str, np.ndarray, object]],
     metric,
     max_nparams: int,
     timeout: int,
@@ -222,8 +291,13 @@ def _score_body(
             program,
             fn,
         )
-    result = fit_mod.evaluate_body(
-        program, fte, X, y, metric, max_nparams=max_nparams, timeout_seconds=timeout
+    result = fit_mod.evaluate_body_grouped(
+        program,
+        fte,
+        groups,
+        metric,
+        max_nparams=max_nparams,
+        timeout_seconds=timeout,
     )
     return result, program, fn
 
@@ -263,6 +337,15 @@ def init(
     run_id: Optional[str] = typer.Option(None, help="explicit run id (default: random)"),
     max_nparams: Optional[int] = typer.Option(None, help="free-constant budget (default: spec MAX_NPARAMS or 10)"),
     timeout: int = typer.Option(30, help="per-fit timeout seconds"),
+    group_by: str = typer.Option(
+        "",
+        help=(
+            "column naming who each row belongs to (cell, trial, subject). Each "
+            "group refits its OWN constants under the same form, so a law whose "
+            "constants vary across individuals is not charged for that variation. "
+            "Default: ungrouped, one shared parameter set."
+        ),
+    ),
 ) -> None:
     """Create a run: bind spec + data + metric + generator, seed the buffer."""
     metric_obj = _metric_for(metric)
@@ -292,17 +375,21 @@ def init(
         "function_to_run": ftr,
         "max_nparams": max_nparams,
         "timeout": timeout,
+        "group_by": group_by.strip(),
         "created": _now(),
         "created_epoch": time.time(),
     }
     (run_dir / "meta.json").write_text(json.dumps(meta, indent=2))
 
     # seed the buffer with the spec's initial equation body (submission 0, all islands)
-    X, y = _load_data(str(meta["data_path"]), metric_obj)
+    X, y, labels = _load_data(
+        str(meta["data_path"]), metric_obj, str(meta.get("group_by", ""))
+    )
     seed_body = template.get_function(fte).body
     _t0 = time.time()
     result, program, _fn = _score_body(
-        seed_body, None, template, fte, X, y, metric_obj, max_nparams, timeout
+        seed_body, None, template, fte,
+        _as_groups(X, y, labels), metric_obj, max_nparams, timeout,
     )
     _append_submission(run_dir, {
         "sample_order": 0,
@@ -312,6 +399,9 @@ def init(
         "score": result.score,
         "value": result.value,
         "params": result.params,
+        "per_group": result.per_group,
+        "per_group_value": result.per_group_value,
+        "params_per_group": result.params_per_group,
         "island_id": None,
         "version_generated": None,
         "seed": True,
@@ -388,17 +478,23 @@ def submit(
     meta = _read_meta(run_dir)
     metric_obj = _metric_for(meta["metric"])
     template, db, fte = _rebuild_buffer(run_dir, meta)
-    X, y = _load_data(str(meta["data_path"]), metric_obj)
+    X, y, labels = _load_data(
+        str(meta["data_path"]), metric_obj, str(meta.get("group_by", ""))
+    )
 
     body = body_file.read_text()
     _t0 = time.time()
     result, program, fn = _score_body(
-        body, version_generated, template, fte, X, y,
+        body, version_generated, template, fte, _as_groups(X, y, labels),
         metric_obj, meta["max_nparams"], meta["timeout"],
     )
     fit_seconds = time.time() - _t0
     if result.valid:
-        db.register_program(fn, island_id, {"data": result.score})
+        # result.valid, so score is not None.
+        assert result.score is not None
+        db.register_program(
+            fn, island_id, result.per_group or {fit_mod.UNGROUPED: result.score}
+        )
 
     sample_order = len(_read_submissions(run_dir))
     _append_submission(run_dir, {
@@ -409,6 +505,9 @@ def submit(
         "score": result.score,
         "value": result.value,
         "params": result.params,
+        "per_group": result.per_group,
+        "per_group_value": result.per_group_value,
+        "params_per_group": result.params_per_group,
         "island_id": island_id,
         "version_generated": version_generated,
         "seed": False,
@@ -502,6 +601,19 @@ def best(
         "generator": meta["generator"],
         "equation": winner["body"].strip("\n"),
         "params": winner["params"],
+        # Grouped runs only. `params` above is empty for them, because there IS no
+        # single parameter vector: the whole point is that each group keeps its
+        # own. Absent (not empty) on an ungrouped run, so existing readers are
+        # untouched.
+        **(
+            {
+                "group_by": meta.get("group_by", ""),
+                "params_per_group": winner.get("params_per_group") or {},
+                "value_per_group": winner.get("per_group_value") or {},
+            }
+            if meta.get("group_by")
+            else {}
+        ),
         "program": program,
         "metrics": metrics_out,
         "selection": {
@@ -615,7 +727,7 @@ def _candidate_ood(meta: dict, cand: dict) -> float | None:
         else metric
     )
     try:
-        X, y = _load_data(str(sibling), metric)
+        X, y, _ = _load_data(str(sibling), metric)
     except OSError:
         return None
     return fit_mod.evaluate_fixed(
@@ -660,6 +772,13 @@ def _split_metrics(meta: dict, winner: dict) -> dict[str, float]:
     the training file. Applies the fitted constants without re-fitting.
     """
     out: dict[str, float] = {}
+    if meta.get("group_by"):
+        # Held-out scoring applies FIXED constants, and a grouped run has no single
+        # constant vector to apply: each group kept its own. Scoring held-out data
+        # per group needs a policy for groups absent from the held-out file, which
+        # is deferred with the rest of the Objective work (see issue #107). Returning
+        # empty is honest; applying an arbitrary group's constants would not be.
+        return out
     fte = meta["function_to_evolve"]
     program = winner["program"]
     params = winner["params"]
@@ -675,7 +794,7 @@ def _split_metrics(meta: dict, winner: dict) -> dict[str, float]:
             splits[name] = str(sibling)
     for split, path in splits.items():
         try:
-            X, y = _load_data(path, metric)
+            X, y, _ = _load_data(path, metric)
         except OSError:
             continue
         for mkey in report_keys:

--- a/wheeler/integrations/llmsr/fit.py
+++ b/wheeler/integrations/llmsr/fit.py
@@ -12,6 +12,17 @@ trailing ``params``), so no per-spec coupling is needed.
 handed (see ``_bind_inputs``). The optimizer is the same either way: what changes
 is whether the prediction has to line up row-for-row with the data.
 
+Fitting is PER GROUP (``evaluate_body_grouped``). A run may declare a column
+naming who each row belongs to (a cell, a trial, a subject), and then every group
+refits its OWN constants under the SAME form. This matters because symbolic
+regression is looking for the functional FORM: if one law governs 40 cells with
+40 different constant sets, a single pooled fit charges the FORM for variation
+that belongs to the PARAMETERS and rejects a correct law. The result carries the
+per-group score VECTOR, which is what reaches the vendored buffer, where
+``_reduce_score`` supplies island ranking and ``_get_signature`` clusters forms by
+their per-group profile. An ungrouped run is the one-group case and is bit-for-bit
+unchanged. See docs/llmsr-objective-formulation.md.
+
 Execution runs in a forked, timeout-bounded child process (reusing the vendored
 sandbox's fork context) because the equation body is model-generated code: a
 pathological body cannot hang or crash the parent.
@@ -38,6 +49,10 @@ _DEFAULT_MAX_NPARAMS = 10
 _DEFAULT_TIMEOUT = 30
 _N_RESTARTS = 6  # extra BFGS starts beyond all-ones, to escape flat/local regions
 
+# The group label for an ungrouped run. Matches the key Wheeler has always passed
+# to the vendored buffer, so submissions written before grouping replay unchanged.
+UNGROUPED = "data"
+
 
 @dataclass
 class FitResult:
@@ -50,6 +65,15 @@ class FitResult:
     # no, whatever it scored) or "numeric" (no finite metric value was produced).
     # Empty on a valid fit. Conflating the two hides a truncated frontier.
     rejection_reason: str = ""
+    # Per-group results, keyed by group label. `score`/`value` above are the mean
+    # over these. The VECTOR is the primary object: it is what reaches the
+    # vendored buffer as `scores_per_test`, where `_reduce_score` supplies island
+    # ranking and `_get_signature` clusters forms by their per-group profile.
+    # Each group refits its OWN constants, so params_per_group has one entry per
+    # group and the flat `params` is meaningful only for an ungrouped run.
+    per_group: dict[str, float] = field(default_factory=dict)
+    per_group_value: dict[str, float] = field(default_factory=dict)
+    params_per_group: dict[str, list[float]] = field(default_factory=dict)
 
 
 def _first_violation(metric: Metric, y_pred, y_true, params) -> str:
@@ -94,7 +118,80 @@ def _bind_inputs(metric: Metric, equation, X, y) -> tuple[list, object, str]:
     return [np.asarray(X[:, i], dtype=float) for i in range(n_cols)], y, ""
 
 
-def _worker(program_str, function_to_evolve, X, y, metric: Metric, max_nparams, q):
+def _fit_one_group(opt, equation, metric: Metric, X, y, max_nparams) -> dict:
+    """Fit this group's OWN constants and score it. One group, one theta.
+
+    Pulled out of ``_worker`` unchanged so that the single-group case stays
+    numerically identical: the restart RNG is seeded per group, so group 1 of a
+    grouped run draws exactly the inits an ungrouped run drew.
+    """
+    cols, y_true, bind_error = _bind_inputs(metric, equation, X, y)
+    if bind_error:
+        return {"valid": False, "error": bind_error, "rejection_reason": "numeric"}
+
+    with np.errstate(all="ignore"):
+        def loss(p):
+            y_pred = equation(*cols, np.asarray(p, dtype=float))
+            return metric.loss(y_pred, y_true)
+
+        # Multi-start BFGS: a single all-ones init leaves forms whose constants
+        # live far from 1 (a temperature optimum, a saturation constant) stuck in
+        # a flat region and mis-scored, so the search would reject a CORRECT form.
+        # Deterministic restarts (fixed seed) keep the fit reproducible.
+        restart_rng = np.random.default_rng(0)
+        inits = [np.ones(max_nparams)]
+        inits += [
+            restart_rng.uniform(-12.0, 12.0, max_nparams) for _ in range(_N_RESTARTS)
+        ]
+        best = None
+        for x0 in inits:
+            try:
+                res = opt.minimize(loss, x0, method="BFGS")
+            except Exception:
+                continue
+            if np.isfinite(res.fun) and (best is None or res.fun < best.fun):
+                best = res
+        if best is None:
+            return {
+                "valid": False,
+                "error": "no successful fit from any start",
+                "rejection_reason": "numeric",
+            }
+        params = np.asarray(best.x, dtype=float)
+        y_pred = equation(*cols, params)
+        value = float(metric.report(y_pred, y_true))
+        violated = _first_violation(metric, y_pred, y_true, params) if np.isfinite(value) else ""
+
+    if not np.isfinite(value):
+        return {
+            "valid": False,
+            "error": "non-finite metric value",
+            "rejection_reason": "numeric",
+        }
+    if violated:
+        # Keep the value and the constants: a candidate the guard rejected
+        # often scored WELL, and hiding that hides why it was thrown out.
+        return {
+            "valid": False,
+            "rejection_reason": "constraint",
+            "error": f"rejected by hard constraint {violated!r}",
+            "value": value,
+            "params": params.tolist(),
+        }
+    return {
+        "valid": True,
+        "value": value,
+        "score": metric.score_from_value(value),
+        "params": params.tolist(),
+    }
+
+
+def _worker(program_str, function_to_evolve, groups, metric: Metric, max_nparams, q):
+    """Fit one candidate FORM against every group, each with its own constants.
+
+    ``groups`` is a list of ``(label, X, y)``. The form is shared; theta is not.
+    Compiling the program is done once, then each group refits independently.
+    """
     try:
         import scipy.optimize as opt  # local: only needed in the child
 
@@ -105,66 +202,17 @@ def _worker(program_str, function_to_evolve, X, y, metric: Metric, max_nparams, 
         exec(program_str, namespace)  # noqa: S102 - sandboxed, model-generated body
         equation = namespace.get(function_to_evolve)
         if not callable(equation):
-            q.put({"valid": False, "error": f"no callable {function_to_evolve!r}"})
+            q.put({"error": f"no callable {function_to_evolve!r}"})
             return
 
-        cols, y_true, bind_error = _bind_inputs(metric, equation, X, y)
-        if bind_error:
-            q.put({"valid": False, "error": bind_error})
-            return
-
-        with np.errstate(all="ignore"):
-            def loss(p):
-                y_pred = equation(*cols, np.asarray(p, dtype=float))
-                return metric.loss(y_pred, y_true)
-
-            # Multi-start BFGS: a single all-ones init leaves forms whose constants
-            # live far from 1 (a temperature optimum, a saturation constant) stuck in
-            # a flat region and mis-scored, so the search would reject a CORRECT form.
-            # Deterministic restarts (fixed seed) keep the fit reproducible.
-            restart_rng = np.random.default_rng(0)
-            inits = [np.ones(max_nparams)]
-            inits += [
-                restart_rng.uniform(-12.0, 12.0, max_nparams) for _ in range(_N_RESTARTS)
-            ]
-            best = None
-            for x0 in inits:
-                try:
-                    res = opt.minimize(loss, x0, method="BFGS")
-                except Exception:
-                    continue
-                if np.isfinite(res.fun) and (best is None or res.fun < best.fun):
-                    best = res
-            if best is None:
-                q.put({"valid": False, "error": "no successful fit from any start"})
-                return
-            params = np.asarray(best.x, dtype=float)
-            y_pred = equation(*cols, params)
-            value = float(metric.report(y_pred, y_true))
-            violated = _first_violation(metric, y_pred, y_true, params) if np.isfinite(value) else ""
-
-        if not np.isfinite(value):
-            q.put({"valid": False, "error": "non-finite metric value"})
-            return
-        if violated:
-            # Keep the value and the constants: a candidate the guard rejected
-            # often scored WELL, and hiding that hides why it was thrown out.
-            q.put({
-                "valid": False,
-                "rejection_reason": "constraint",
-                "error": f"rejected by hard constraint {violated!r}",
-                "value": value,
-                "params": params.tolist(),
-            })
-            return
         q.put({
-            "valid": True,
-            "value": value,
-            "score": metric.score_from_value(value),
-            "params": params.tolist(),
+            "groups": {
+                label: _fit_one_group(opt, equation, metric, gX, gy, max_nparams)
+                for label, gX, gy in groups
+            }
         })
     except Exception as exc:  # any failure in untrusted body -> invalid, never raise
-        q.put({"valid": False, "error": f"{type(exc).__name__}: {exc}"})
+        q.put({"error": f"{type(exc).__name__}: {exc}"})
 
 
 def evaluate_fixed(
@@ -214,19 +262,61 @@ def evaluate_body(
     non-finite result, or timeout (``rejection_reason`` ``numeric``), and also
     when a hard constraint rejected the fitted candidate (``constraint``).
     """
+    result = evaluate_body_grouped(
+        program_str,
+        function_to_evolve,
+        [(UNGROUPED, X, y)],
+        metric,
+        max_nparams=max_nparams,
+        timeout_seconds=timeout_seconds,
+    )
+    # One group, so the aggregate IS that group and `params` is already flat.
+    # sum([v]) / 1 is exact in IEEE, so this stays bit-for-bit identical to the
+    # pre-grouping implementation.
+    return result
+
+
+def evaluate_body_grouped(
+    program_str: str,
+    function_to_evolve: str,
+    groups: list[tuple[str, np.ndarray, object]],
+    metric: Metric,
+    *,
+    max_nparams: int = _DEFAULT_MAX_NPARAMS,
+    timeout_seconds: int = _DEFAULT_TIMEOUT,
+) -> FitResult:
+    """Fit one FORM against every group, each refitting its own constants.
+
+    This is the per-group protocol: the equation body is shared across groups,
+    theta is not. A form that governs 40 cells with 40 different constant sets
+    scores well here, where a single pooled fit would charge the FORM for a
+    mismatch that belongs to the PARAMETERS.
+
+    Validity is STRICT: a candidate is valid only if EVERY group fitted and
+    passed its constraints. Two reasons, one practical and one structural. The
+    practical one is that this reproduces the ungrouped semantics exactly. The
+    structural one is that the vendored island model keys its clusters on the
+    score signature, so every candidate must be scored on the SAME group set or
+    the signatures are not comparable. A per-group failure policy (accept a form
+    that fails k of n groups) is a scientific call and is deferred; see
+    docs/llmsr-objective-formulation.md.
+
+    The timeout scales with the group count: it bounds one fit, and there are
+    now ``len(groups)`` of them behind one fork.
+    """
     queue = _MP_CONTEXT.Queue()
     proc = _MP_CONTEXT.Process(
         target=_worker,
-        args=(program_str, function_to_evolve, X, y, metric, max_nparams, queue),
+        args=(program_str, function_to_evolve, groups, metric, max_nparams, queue),
     )
     proc.start()
-    proc.join(timeout=timeout_seconds)
+    proc.join(timeout=timeout_seconds * max(1, len(groups)))
     if proc.is_alive():
         proc.terminate()
         proc.join()
         return FitResult(
             valid=False,
-            error=f"timeout after {timeout_seconds}s",
+            error=f"timeout after {timeout_seconds * max(1, len(groups))}s",
             rejection_reason="numeric",
         )
 
@@ -235,17 +325,52 @@ def evaluate_body(
             valid=False, error="worker produced no result", rejection_reason="numeric"
         )
     out = queue.get_nowait()
-    if not out.get("valid"):
+    if "groups" not in out:  # compile error or no such callable: applies to every group
         return FitResult(
             valid=False,
             error=out.get("error", "invalid"),
-            rejection_reason=out.get("rejection_reason", "numeric"),
-            value=out.get("value"),
-            params=out.get("params", []),
+            rejection_reason="numeric",
         )
+
+    per = out["groups"]
+    failed = [(label, r) for label, r in per.items() if not r.get("valid")]
+    if failed:
+        label, first = sorted(failed, key=lambda kv: kv[0])[0]
+        detail = first.get("error", "invalid")
+        # Name the group only when there IS one. An ungrouped run has no group to
+        # blame, and prefixing its sole pseudo-group would change every existing
+        # error message for no gain.
+        if not (len(per) == 1 and label == UNGROUPED):
+            detail = f"group {label!r}: {detail}"
+            if len(failed) > 1:
+                detail += f" ({len(failed)} of {len(per)} groups failed)"
+        return FitResult(
+            valid=False,
+            error=detail,
+            rejection_reason=first.get("rejection_reason", "numeric"),
+            value=first.get("value"),
+            params=first.get("params", []),
+            per_group_value={
+                label: r["value"] for label, r in per.items() if r.get("value") is not None
+            },
+        )
+
+    per_group = {label: r["score"] for label, r in per.items()}
+    per_group_value = {label: r["value"] for label, r in per.items()}
+    params_per_group = {label: r["params"] for label, r in per.items()}
+    # With a single group there IS one parameter vector, so publish it flat: every
+    # existing caller (best.json, OOD scoring via evaluate_fixed) reads `params`,
+    # and an ungrouped run must keep behaving exactly as it did.
+    flat_params = next(iter(params_per_group.values())) if len(params_per_group) == 1 else []
     return FitResult(
         valid=True,
-        score=out["score"],
-        value=out["value"],
-        params=out["params"],
+        # The scalar is the mean over groups, matching the vendored
+        # `_reduce_score`, and is what selection and reporting use. The VECTOR is
+        # the primary object and is what reaches the buffer.
+        score=sum(per_group.values()) / len(per_group),
+        value=sum(per_group_value.values()) / len(per_group_value),
+        params=flat_params,
+        per_group=per_group,
+        per_group_value=per_group_value,
+        params_per_group=params_per_group,
     )


### PR DESCRIPTION
Slice 1 of #107. Design doc lands with it at `docs/llmsr-objective-formulation.md`.

## The problem

Symbolic regression is looking for a functional FORM. The constants are usually a nuisance. The fit path conflated the two: one pooled dataset, one theta, one scalar.

When the same law governs several individuals with different constants, a single pooled fit charges the FORM for variation that belongs to the PARAMETERS. A correct law then loses to a wrong-but-flexible one.

## What this adds

`wheeler llmsr init --group-by <column>` names who each row belongs to (a cell, a trial, a subject). Every group refits its OWN constants under the SAME candidate form, and the candidate is scored on the resulting vector. This is profile likelihood: the per-group constants are nuisance parameters profiled out, so what remains measures the form.

Measured on three cells sharing `y = a*x + b` with different `(a, b)` per cell, where the candidate is the exactly-correct form:

```
POOLED  (one shared theta): mse 32.4795
GROUPED (theta per cell)  : mean mse 5.94629e-16
  per-cell mse : {'c01': 0.0, 'c02': 0.0, 'c03': 0.0}
  c01: recovered a=+2.500000 b=-1.000000   true a=+2.5 b=-1.0
  c02: recovered a=-4.000000 b=+8.000000   true a=-4.0 b=+8.0
  c03: recovered a=+0.500000 b=+3.000000   true a=+0.5 b=+3.0
```

Confirmed through the real CLI too, `init` to `best.json`, not just the library:

```json
"group_by": "cell_id",
"params_per_group": {"c01": [2.5, -1.0], "c02": [-4.0, 8.0], "c03": [0.5, 3.0]},
"value_per_group": {"c01": 1e-15, "c02": 0.0, "c03": 0.0}
```

## No vendor fork was needed

The vendored FunSearch buffer is already vector-native:

```python
register_program(program, island_id, scores_per_test: ScoresPerTest)   # a DICT
_reduce_score(spt)  = mean over tests                       # island ranking
_get_signature(spt) = tuple(spt[k] for k in sorted(spt))    # cluster key
```

Wheeler was calling it with `{"data": score}`, a single key, which is where the vector was being destroyed. Passing `{group_id: score_i}` recovers upstream's own design: `_reduce_score` supplies the island ranking for free, and `_get_signature` starts clustering forms by their per-group profile. `vendor/` is untouched, which matters given d0b05b7 frames it as a plug-in for LLM-SR rather than our code.

## Backward compatibility

Ungrouped runs are **bit-for-bit unchanged**, verified against `origin/main` via hex float literals with no tolerance. 6 of 6 cases identical (3 candidate bodies x mse/nmse, including a failing case), comparing value, every parameter, the error string, and the rejection reason:

```
linear   mse   identical=True  value=0x1.452cfe29a1922p-14
linear   nmse  identical=True  value=0x1.a6275373e33cep-19
nonlin   mse   identical=True  value=0x1.157de434e7962p+3
nonlin   nmse  identical=True  value=0x1.683fa87d8c5f6p-2
bad      mse   identical=True  value=None
bad      nmse  identical=True  value=None
identical: 6   differing: 0
```

The first pass of that check caught a real regression: I was prefixing `group 'data':` onto ungrouped error messages. Fixed, and there is now a test pinning it.

Submissions written before this change carry only a scalar `score` and replay under the single `UNGROUPED` key exactly as they always did (`_scores_per_test`).

## Three deliberate limits, explicit rather than silent

1. **Validity is STRICT**: every group must fit or the candidate is invalid, naming the first failing group. The buffer keys clusters on the score signature, so candidates must be scored on the same group set or the signatures are incomparable. A per-group failure policy ("accept a form that fails k of n") is a scientific call, deferred and called out in #107.
2. **`--group-by` is refused for `spike_train`**, with a message explaining why: recorded events do not correspond row-for-row with stimulus samples, so a per-row group column cannot partition them.
3. **Held-out ID/OOD scoring returns empty for grouped runs.** It applies FIXED params and a grouped run has no single vector. Returning empty is honest; applying an arbitrary group's constants would not be.

## Test results

- 9 new tests in `tests/integrations/llmsr/test_grouped_fit.py`, including two that drive the real CLI as a subprocess (with the `PYTHONPATH` guard proved, since the shared venv's editable install points at the main checkout).
- Full suite: 2054 passed, 2 skipped, 0 failures. Measured baseline on this branch's merge-base: 2045 passed, 2 skipped. So +9 new and 0 regressions.
- ruff clean, mypy clean (91 source files). Pre-commit hook passed independently.
- No em dashes. Author `arthurh`.

## Not in this PR

Slices 2 and 3 from #107, which are the parts that matter most for complicated error functions:

- **The `score(form, group, fit)` control inversion.** Today the pipeline fits and then hands the metric a finished prediction, so a metric can never refit and therefore cannot profile out a nuisance parameter (a per-cell gain and offset regressed out before measuring shape error). That is the change that makes an arbitrary error function genuinely arbitrary.
- **Declarable optimizer.** `fit.py` hardcodes multi-start BFGS, which uses a numerical gradient that is identically zero on a piecewise-constant objective. Measured: 0 of 13 starts moved off `x0`, best value 1.0, while Nelder-Mead from the same starts reached 0.0 exactly. Per-group refit multiplies the cost of that by the group count.
