### PR TITLE
fix(health): name the config and credential layer behind an auth failure (closes #103)

### DIFF
--- a/tests/regression/test_issue_102.py
+++ b/tests/regression/test_issue_102.py
@@ -1,0 +1,198 @@
+"""Regression test for issue #102: config resolution from subdirectories.
+
+Config loader should find wheeler.yaml by walking up parent directories,
+not just looking at cwd.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from wheeler.config import load_config, find_config_file, find_project_root
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_config_layers(monkeypatch):
+    """Make wheeler.yaml the winning layer for the duration of these tests.
+
+    load_config resolves in the order env > keychain > yaml > defaults. These
+    tests assert that the file layer is found from a subdirectory, so a stray
+    NEO4J_* var or a real `wheeler login` keychain entry on the dev machine
+    would override the value under test and fail the assertion for a reason
+    unrelated to config discovery.
+    """
+    for var in ("NEO4J_URI", "NEO4J_USERNAME", "NEO4J_PASSWORD", "NEO4J_DATABASE"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.delenv("WHEELER_PROJECT_ROOT", raising=False)
+    monkeypatch.setattr(
+        "wheeler.config._apply_keychain_overrides",
+        lambda config, raw_neo4j=None: config,
+    )
+
+
+@pytest.fixture
+def project_with_config():
+    """Create a temporary project directory with wheeler.yaml and a subdirectory."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        project_root = Path(tmpdir)
+        config_file = project_root / "wheeler.yaml"
+
+        config_data = {
+            "neo4j": {
+                "uri": "bolt://custom.example.com:7687",
+                "username": "custom_user",
+                "password": "custom_test_password",
+                "database": "custom_db",
+            }
+        }
+        with open(config_file, "w") as f:
+            yaml.safe_dump(config_data, f)
+
+        subdir = project_root / ".wheeler" / "asta-assistant" / "test-mission"
+        subdir.mkdir(parents=True, exist_ok=True)
+
+        yield project_root, subdir
+
+
+def test_find_project_root_from_subdirectory(project_with_config):
+    """find_project_root should walk up from a subdirectory to find the root."""
+    project_root, subdir = project_with_config
+
+    original_cwd = os.getcwd()
+    try:
+        os.chdir(subdir)
+        found_root = find_project_root()
+        assert found_root.resolve() == project_root.resolve()
+    finally:
+        os.chdir(original_cwd)
+
+
+def test_find_config_file_from_subdirectory(project_with_config):
+    """find_config_file should locate wheeler.yaml by walking up from a subdirectory."""
+    project_root, subdir = project_with_config
+    config_file = project_root / "wheeler.yaml"
+
+    original_cwd = os.getcwd()
+    try:
+        os.chdir(subdir)
+        found_config = find_config_file()
+        assert found_config is not None
+        assert found_config.resolve() == config_file.resolve()
+        assert found_config.exists()
+    finally:
+        os.chdir(original_cwd)
+
+
+def test_load_config_from_subdirectory_reads_parent_config(project_with_config):
+    """load_config should read the parent directory's wheeler.yaml when called from a subdirectory."""
+    project_root, subdir = project_with_config
+    config_file = project_root / "wheeler.yaml"
+
+    original_cwd = os.getcwd()
+    try:
+        os.chdir(subdir)
+        config = load_config()
+
+        assert config.neo4j.uri == "bolt://custom.example.com:7687"
+        assert config.neo4j.username == "custom_user"
+        assert config.neo4j.password == "custom_test_password"
+        assert config.neo4j.database == "custom_db"
+    finally:
+        os.chdir(original_cwd)
+
+
+def test_load_config_subprocess_from_subdirectory(project_with_config):
+    """Simulate MCP server: verify subprocess inheriting cwd loads parent config correctly."""
+    import subprocess
+    import sys
+    import json
+
+    project_root, subdir = project_with_config
+
+    # The keychain outranks wheeler.yaml, and this runs in a fresh interpreter
+    # where the parent's fixture patch does not apply, so neutralize it here as
+    # well. Otherwise a real `wheeler login` entry on the dev machine decides
+    # the assertion instead of the config file under test.
+    script = """
+import json
+import wheeler.config as wc
+wc._apply_keychain_overrides = lambda config, raw_neo4j=None: config
+c = wc.load_config()
+print(json.dumps({
+    'uri': c.neo4j.uri,
+    'username': c.neo4j.username,
+    'password': c.neo4j.password,
+    'database': c.neo4j.database,
+}))
+"""
+
+    # PYTHONPATH is mandatory, not defensive. The shared venv installs wheeler
+    # editable against the MAIN checkout, and cwd here is a temp dir, so cwd
+    # precedence cannot help: without this the subprocess would import the main
+    # checkout's wheeler and this test would report on the wrong tree.
+    env = {
+        **os.environ,
+        "PYTHONPATH": str(REPO_ROOT),
+        "WHEELER_SUBPROCESS_PROBE": "1",
+    }
+    for var in ("NEO4J_URI", "NEO4J_USERNAME", "NEO4J_PASSWORD", "NEO4J_DATABASE"):
+        env.pop(var, None)
+
+    original_cwd = os.getcwd()
+    try:
+        os.chdir(subdir)
+        origin = subprocess.run(
+            [sys.executable, "-c", "import wheeler, os; print(os.path.dirname(wheeler.__file__))"],
+            capture_output=True,
+            text=True,
+            cwd=str(subdir),
+            env=env,
+        )
+        assert origin.returncode == 0, f"Import probe failed: {origin.stderr}"
+        assert Path(origin.stdout.strip()) == REPO_ROOT / "wheeler", (
+            "Subprocess imported the wrong wheeler package, so its result would "
+            f"describe another tree. Expected {REPO_ROOT / 'wheeler'}, got {origin.stdout.strip()}"
+        )
+
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            cwd=str(subdir),
+            env=env,
+        )
+        assert result.returncode == 0, f"Script failed: {result.stderr}"
+        data = json.loads(result.stdout.strip())
+
+        assert data["uri"] == "bolt://custom.example.com:7687"
+        assert data["username"] == "custom_user"
+        assert data["password"] == "custom_test_password"
+        assert data["database"] == "custom_db"
+    finally:
+        os.chdir(original_cwd)
+
+
+def test_load_config_deep_subdirectory(project_with_config):
+    """Test loading config from multiple levels deep in subdirectory tree."""
+    project_root, _ = project_with_config
+
+    deep_subdir = project_root / ".wheeler" / "level1" / "level2" / "level3"
+    deep_subdir.mkdir(parents=True, exist_ok=True)
+
+    original_cwd = os.getcwd()
+    try:
+        os.chdir(deep_subdir)
+        config = load_config()
+
+        assert config.neo4j.password == "custom_test_password"
+        assert config.neo4j.database == "custom_db"
+    finally:
+        os.chdir(original_cwd)

--- a/tests/regression/test_issue_103.py
+++ b/tests/regression/test_issue_103.py
@@ -1,0 +1,121 @@
+"""Regression test for issue 103: graph_health incorrectly diagnoses auth failures.
+
+Issue: graph_health reports a password mismatch in wheeler.yaml even when no
+wheeler.yaml was found and defaults are in use. It also never reports which
+config file was loaded or explicitly states that defaults are in use.
+
+This test verifies that the diagnosis distinguishes between:
+1. No config file found (using built-in defaults)
+2. Config file found but authentication rejected
+3. Server unreachable vs. credentials rejected
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+class TestGraphHealthDiagnosis:
+    """Test graph_health's diagnosis logic for various failure modes."""
+
+    @pytest.mark.asyncio
+    async def test_graph_health_auth_error_with_no_config_file(self):
+        """When no config file is found, diagnosis should indicate defaults are in use.
+
+        This is the core bug reported in issue 103: when the MCP server runs from
+        a subdirectory where no wheeler.yaml exists, it uses built-in defaults.
+        If those defaults don't match the running Neo4j, the diagnosis should NOT
+        blame "the password in wheeler.yaml" (which was correct) but instead say
+        that no config file was found and defaults are in use.
+        """
+        from wheeler.config import find_config_file
+
+        repo_root = Path(__file__).resolve().parents[2]
+        with patch("wheeler.config.find_config_file", return_value=None):
+            from wheeler.mcp_core import graph_health
+
+            mock_error = "The client is unauthorized due to authentication failure."
+            mock_counts = {"_status": "offline", "_error": mock_error}
+            with patch("wheeler.mcp_core.schema.get_status", new_callable=AsyncMock, return_value=mock_counts):
+                result = await graph_health()
+
+        assert result["status"] == "offline"
+        assert result["blocking"] is True
+
+        assert "diagnosis" in result
+        assert "cause" in result
+        assert "remediation" in result
+
+        cause = result["cause"].lower()
+
+        assert "wheeler.yaml" not in cause or "no " in cause or "not found" in cause or "default" in cause, (
+            f"When no config file is found, diagnosis should not blame 'the password in wheeler.yaml'. "
+            f"Got: {result['cause']}"
+        )
+
+        assert "default" in cause.lower() or "no config" in cause.lower() or "not found" in cause.lower(), (
+            f"When no config file is found, diagnosis should mention defaults or absence of config. "
+            f"Got: {result['cause']}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_graph_health_auth_error_distinguishes_server_vs_credentials(self):
+        """Authentication errors should be reported differently from connection errors.
+
+        Server-unreachable (connection error) is a different problem from
+        credentials-rejected (authentication error), even though both result in
+        an offline status.
+        """
+        from wheeler.mcp_core import graph_health
+
+        auth_error = "The client is unauthorized due to authentication failure."
+        conn_error = "Connection refused"
+
+        auth_result = {"_status": "offline", "_error": auth_error}
+        with patch("wheeler.mcp_core.schema.get_status", new_callable=AsyncMock, return_value=auth_result):
+            auth_health = await graph_health()
+
+        conn_result = {"_status": "offline", "_error": conn_error}
+        with patch("wheeler.mcp_core.schema.get_status", new_callable=AsyncMock, return_value=conn_result):
+            conn_health = await graph_health()
+
+        auth_diag = auth_health.get("diagnosis", "").lower()
+        conn_diag = conn_health.get("diagnosis", "").lower()
+
+        assert auth_diag != conn_diag, (
+            "Authentication and connection errors should have different diagnoses. "
+            f"Auth: {auth_health.get('diagnosis')}, Conn: {conn_health.get('diagnosis')}"
+        )
+
+        assert "authentication" in auth_diag, f"Auth diagnosis should mention authentication: {auth_diag}"
+        assert "authentication" not in conn_diag, f"Connection diagnosis should not mention authentication: {conn_diag}"
+
+    @pytest.mark.asyncio
+    async def test_graph_health_auth_error_no_destructive_remediation(self):
+        """No remediation step should suggest destructive actions without evidence.
+
+        The original issue showed a suggested fix: 'delete the DBMS in Neo4j
+        Desktop'. This is destructive and should never be suggested unless the
+        diagnosis can actually show the credential is unrecoverable.
+        """
+        from wheeler.mcp_core import graph_health
+
+        mock_error = "The client is unauthorized due to authentication failure."
+        mock_counts = {"_status": "offline", "_error": mock_error}
+        with patch("wheeler.mcp_core.schema.get_status", new_callable=AsyncMock, return_value=mock_counts):
+            result = await graph_health()
+
+        fix_list = result.get("fix", [])
+        if isinstance(fix_list, list):
+            fix_text = " ".join(fix_list).lower()
+        else:
+            fix_text = result.get("remediation", "").lower()
+
+        assert "delete" not in fix_text or "database" not in fix_text, (
+            "Remediation should never suggest deleting the database without evidence "
+            f"that the credential is unrecoverable. Got: {fix_text}"
+        )

--- a/wheeler/mcp_core.py
+++ b/wheeler/mcp_core.py
@@ -7,10 +7,12 @@ Run: python -m wheeler.mcp_core
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 from fastmcp import FastMCP
 
 from wheeler import acts as acts_corpus
+from wheeler import config as wheeler_config
 from wheeler.config import project_knowledge_dir
 from wheeler.graph import context, schema
 from wheeler.graph.cypher_guard import WRITE_KEYWORDS, is_read_only_cypher
@@ -30,7 +32,114 @@ mcp = FastMCP(
 )
 
 
-def _diagnose_health_error(error_msg: str) -> dict:
+_PASSWORD_PRECEDENCE = (
+    "Wheeler resolves the Neo4j password in precedence order: NEO4J_PASSWORD, then the "
+    "OS keychain (wheeler login), then neo4j.password in wheeler.yaml, then the built-in "
+    "default 'research-graph'."
+)
+
+
+def _neo4j_field_sources(config_path: Path | None) -> dict[str, dict[str, str]]:
+    """Which layer supplied each Neo4j connection field.
+
+    Reports the layer and its origin, never the values: a health report gets
+    pasted into bug reports.
+    """
+    try:
+        rows = wheeler_config.neo4j_sources(config_path)
+    except Exception:
+        return {}
+    return {row.field: {"source": row.source, "origin": row.origin} for row in rows}
+
+
+def _config_evidence(with_sources: bool = False) -> dict:
+    """Report which config file is in effect, resolved the way load_config resolves it.
+
+    Without this, an auth failure can only guess at which layer supplied the
+    credential the database rejected.
+    """
+    config_path = wheeler_config.find_config_file()
+    evidence: dict = {
+        "config_file": str(config_path) if config_path else None,
+        "config_source": (
+            f"wheeler.yaml at {config_path}"
+            if config_path
+            else (
+                "no wheeler.yaml found: settings come from NEO4J_* env vars, "
+                "the OS keychain, or built-in defaults"
+            )
+        ),
+    }
+    if with_sources:
+        evidence["neo4j_sources"] = _neo4j_field_sources(config_path)
+    return evidence
+
+
+def _diagnose_auth_failure(evidence: dict) -> dict:
+    """Diagnose a rejected credential, naming the layer that actually supplied it."""
+    config_file = evidence.get("config_file")
+    sources = evidence.get("neo4j_sources") or _neo4j_field_sources(
+        Path(config_file) if config_file else None
+    )
+    password = sources.get("password", {})
+    layer = password.get("source", "")
+    origin = password.get("origin", "")
+
+    if layer == "env":
+        supplied = f"the {origin} environment variable"
+        action = (
+            f"Check the password exported in {origin}, or unset it so the keychain "
+            "and wheeler.yaml take effect."
+        )
+    elif layer == "keychain":
+        supplied = f"the OS keychain ({origin})"
+        action = (
+            f"Re-store the credential for {origin} with `wheeler login`, or set "
+            "neo4j.profile to the slot this project should connect through."
+        )
+    elif layer == "yaml":
+        supplied = f"neo4j.password in {origin}"
+        action = (
+            f"Check the neo4j.password field in {origin} against the password the "
+            "Neo4j database was created with."
+        )
+    elif layer == "default":
+        supplied = "Wheeler's built-in default"
+        if config_file:
+            action = (
+                f"{config_file} does not set neo4j.password, so the built-in default "
+                "was used. Set it there, run `wheeler login`, or export NEO4J_PASSWORD."
+            )
+        else:
+            action = (
+                "Supply the real password: run `wheeler login`, export NEO4J_PASSWORD, "
+                "or start from the project root whose wheeler.yaml sets neo4j.password."
+            )
+    else:
+        supplied = "a layer that could not be determined (source reporting failed)"
+        action = (
+            "Check NEO4J_PASSWORD, then the credential stored by `wheeler login`, "
+            "then neo4j.password in wheeler.yaml."
+        )
+
+    if config_file:
+        where = f"Resolved config file: {config_file}."
+    else:
+        where = "No config file was found, so wheeler.yaml supplied nothing on this run."
+
+    cause = f"The Neo4j server answered and rejected the credential. The password came from {supplied}."
+    if layer != "yaml":
+        cause = f"{cause} {where}"
+
+    return {
+        "diagnosis": "Neo4j authentication failed",
+        "cause": cause,
+        "remediation": f"{action} {_PASSWORD_PRECEDENCE}",
+        "fix": [action, _PASSWORD_PRECEDENCE],
+    }
+
+
+def _diagnose_health_error(error_msg: str, evidence: dict | None = None) -> dict:
     """Return structured diagnosis for common Neo4j connection errors.
 
     Always includes 'remediation' as a string (backward-compatible).
@@ -38,21 +147,9 @@ def _diagnose_health_error(error_msg: str) -> dict:
     """
     msg = error_msg.lower()
     if "unauthorized" in msg or "authentication" in msg:
-        return {
-            "diagnosis": "Neo4j authentication failed",
-            "cause": "The password in wheeler.yaml does not match the Neo4j database password.",
-            "remediation": (
-                "Open wheeler.yaml and check the neo4j.password field matches "
-                "what you set in Neo4j Desktop. Wheeler's default password is "
-                "'research-graph'. If you forgot the password, delete the DBMS "
-                "in Neo4j Desktop and create a new one."
-            ),
-            "fix": [
-                "Open wheeler.yaml and check the neo4j.password field matches what you set in Neo4j Desktop.",
-                "Wheeler's default password is 'research-graph'.",
-                "If you forgot the password: delete the DBMS in Neo4j Desktop and create a new one.",
-            ],
-        }
+        return _diagnose_auth_failure(
+            evidence if evidence is not None else _config_evidence(with_sources=True)
+        )
     if "refused" in msg or "unavailable" in msg or "connection" in msg or "failed to establish" in msg:
         return {
             "diagnosis": "Cannot connect to Neo4j",
@@ -96,13 +193,16 @@ async def graph_health() -> dict:
         "node_count": 0,
         "error": None,
     }
+    result.update(_config_evidence())
     try:
         counts = await schema.get_status(_config)
         if counts.get("_status") == "offline":
             result["status"] = "offline"
             result["error"] = counts.get("_error", "Unknown error")
             result["blocking"] = True
-            result.update(_diagnose_health_error(str(counts.get("_error", ""))))
+            evidence = _config_evidence(with_sources=True)
+            result.update(evidence)
+            result.update(_diagnose_health_error(str(counts.get("_error", "")), evidence))
         else:
             node_counts: dict[str, int] = {
                 k: v for k, v in counts.items() if not k.startswith("_")
@@ -115,7 +215,9 @@ async def graph_health() -> dict:
         result["status"] = "offline"
         result["error"] = str(exc)
         result["blocking"] = True
-        result.update(_diagnose_health_error(str(exc)))
+        evidence = _config_evidence(with_sources=True)
+        result.update(evidence)
+        result.update(_diagnose_health_error(str(exc), evidence))
 
     # Check knowledge/ directory
     knowledge_path = project_knowledge_dir(_config)


### PR DESCRIPTION
## Summary

`graph_health` now reports which config file is in effect and which layer actually supplied the rejected Neo4j password, instead of always blaming a mismatch in `wheeler.yaml`. The destructive "delete the DBMS" remediation step is removed.

The fix goes slightly beyond the issue's framing in one useful way: "no config file was found" does not imply the built-in default was used, because `NEO4J_PASSWORD` and the OS keychain both outrank `wheeler.yaml`. So rather than assuming, it reads the real per-field source via `config.neo4j_sources()` and names that layer (env var, keychain profile, yaml path, or built-in).

## Acceptance criteria (independently verified)

- [x] Output includes the resolved config file path, or an explicit no-config indicator: `result.update(_config_evidence())` runs unconditionally, so `config_file` and `config_source` appear on healthy and failing calls alike. On main both keys are absent.
- [x] No config file found says so rather than blaming a password mismatch: cause reads "The password came from Wheeler's built-in default. No config file was found, so wheeler.yaml supplied nothing on this run."
- [x] Config file found and rejected names that file by path: verified by string equality against the full absolute path, not a `wheeler.yaml` substring. `neo4j_sources` origin for the yaml layer carries the absolute path (`config.py:662`).
- [x] Unreachable and credentials-rejected produce different diagnoses: "Cannot connect to Neo4j" versus "Neo4j authentication failed", with the word authentication absent from the unreachable case. Checked against a confirmed-closed port.
- [x] No remediation suggests deleting the DBMS: the step is deleted outright, not conditionally gated. All seven branches of the auth path swept.
- [x] Existing tests still pass: the pre-existing `test_mcp_core.py` contract requiring `wheeler.yaml` and `research-graph` in the remediation string still holds and was not weakened.

## Test results

- Regression test: `tests/regression/test_issue_103.py` passes (1 failed / 2 passed on main before the fix).
- Full suite: 3049 passed, 44 skipped, 0 failures, 0 regressions vs main.
- E2E (mcp_server): pass. Real `graph_health` invoked in four conditions with no mock on the diagnosis path, 25 assertions green. Every subprocess carried `PYTHONPATH` and hard-asserted its import tree resolved under the worktree before its result was trusted, and a main-baseline run asserted the opposite tree to rule out a false pass.
- `ruff check wheeler/` and `mypy wheeler/` both clean.
- No output field can carry the password value: only `{source, origin}` are projected off each `FieldSource`, discarding `.value`. A sentinel password was searched for across all captured payloads and appears nowhere.

## Also included

`tests/regression/test_issue_102.py`, a 5-test regression guard for #102. That issue is already fixed on main by `3d10498`, so this is a guard only, not a fix. It rides here because both concern `wheeler/config.py`. Config resolution semantics are untouched: `git diff main -- wheeler/config.py` is empty, which is the scope boundary #103 sets against #102.

## Verified by

wheeler-issue-cycle, independent Verifier on 2026-08-11.

Closes #103
